### PR TITLE
Fix checksums job to only download binary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
 
           # Build CLI
           build_binary "soundtouch-cli" "./cmd/soundtouch-cli"
-          
+
           # Build Service
           build_binary "soundtouch-service" "./cmd/soundtouch-service"
         id: build
@@ -203,9 +203,10 @@ jobs:
     needs: [validate, build]
 
     steps:
-      - name: Download all artifacts
+      - name: Download binary artifacts
         uses: actions/download-artifact@v7
         with:
+          pattern: binaries-*
           path: ./binaries
 
       - name: Generate checksums


### PR DESCRIPTION
The checksums job was downloading all artifacts including Docker build artifacts, but it was only designed to process binary artifacts. This caused failures when the Docker job created artifacts that didn't match the expected soundtouch-* binary file patterns.

Changed the artifact download to use pattern: binaries-* to only download the binary artifacts that the checksums generation logic expects.
