### PR TITLE
Fix TypeError in Web UI by renaming proxy-domain to soundcork-url

### DIFF
--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -676,7 +676,7 @@ async function showSummary(ip) {
         return;
     }
     const targetUrl = document.getElementById('target-domain').value;
-    const proxyUrl = document.getElementById('proxy-domain').value;
+    const proxyUrl = document.getElementById('soundcork-url').value;
 
     const opts = {
         marge: document.getElementById('opt-marge').value,
@@ -926,7 +926,7 @@ async function migrate(ip) {
         return;
     }
     const targetUrl = document.getElementById('target-domain').value;
-    const proxyUrl = document.getElementById('proxy-domain').value;
+    const proxyUrl = document.getElementById('soundcork-url').value;
     const method = document.getElementById('migration-method').value;
 
     const opts = {


### PR DESCRIPTION
This commit fixes a JS error in showSummary and migrate functions where they were still trying to access the UI element by its old ID 'proxy-domain' instead of the new 'soundcork-url'.
