### PR TITLE
Add DNS-based discovery and migration via /etc/resolv.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ A comprehensive solution for controlling and preserving Bose SoundTouch devices,
 - 🎙️ **Station Management**: Add and play radio stations without presets
 - 🖥️ **CLI Tool**: Comprehensive command-line interface
 - 🌐 **SoundTouch Service**: Emulate Bose cloud services for offline device operation
-- 🔧 **Service Migration**: Migrate devices to use local services instead of Bose cloud
+- 🔧 **Service Migration**: Migrate devices to use local services instead of Bose cloud (XML, Hosts, or DNS redirection)
+- 🔍 **DNS Discovery & Interception**: Dynamic DNS server for intercepting and logging Bose service queries (requires port 53)
+- 📊 **DNS Discovery Analysis**: Track and deduplicate all device DNS queries to discover hidden hostnames
 - 📊 **Traffic Analysis**: Proxy and log device communications
 - 📝 **HTTP Recording**: Persist interactions as re-playable `.http` files
 - 🧹 **Session Management**: Manage and cleanup recorded interaction sessions

--- a/data/.gitignore
+++ b/data/.gitignore
@@ -1,6 +1,7 @@
 accounts/
 certs/
 default/
+dns/
 interactions/
 patterns.json
 settings.json

--- a/docs/guides/MIGRATION-SAFETY.md
+++ b/docs/guides/MIGRATION-SAFETY.md
@@ -27,7 +27,10 @@ Before you proceed with the actual migration, follow these steps:
 4.  **Validate SSH Access**: Confirm the device responds to SSH without a password. 
     - In the Web UI **Migration** tab, select your speaker and verify that the "SSH Connection" status shows ✅ Success.
     - This toolkit automatically handles the necessary SSH parameters (ciphers and key exchanges) required by older Bose firmware.
-5.  **Use XML Migration First**: The `XML` migration method is less invasive than the `Hosts` method. It only changes the application config and doesn't require modifying the system's DNS/CA trust store if you don't need full HTTPS interception initially.
+5.  **Migration Methods**: 
+    - **XML Migration (Default)**: Less invasive, only changes the application config. Best for simple redirection.
+    - **Hosts Migration**: Modifies `/etc/hosts` on the device. Good for system-wide redirection of specific domains.
+    - **ResolvConf Migration**: Points the device to the AfterTouch DNS server. Best for discovering unknown Bose endpoints and dynamic interception. **Note**: This method requires the DNS Discovery Server to be running on port 53. The service includes a pre-flight check to ensure the server is properly bound before allowing this migration.
 6.  **Monitor Logs**: Run the `soundtouch-service` with `DEBUG` or `INFO` logging to see the step-by-step progress of the migration.
 
 #### 🔄 Rollback Strategy

--- a/pkg/discovery/dns.go
+++ b/pkg/discovery/dns.go
@@ -1,0 +1,342 @@
+// Package discovery provides DNS-based discovery and interception for Bose SoundTouch devices.
+package discovery
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// DNSDiscovery handles DNS queries and records discovered hosts.
+type DNSDiscovery struct {
+	// Configuration
+	upstreamDNS string
+	serviceIP   string
+
+	// State
+	discovered map[string]*DiscoveredHost
+	mu         sync.RWMutex
+
+	// Callbacks
+	onNewDiscovery func(hostname string)
+
+	// Servers for Shutdown
+	udpServer *dns.Server
+	tcpServer *dns.Server
+}
+
+// DiscoveredHost represents a host discovered via DNS queries.
+type DiscoveredHost struct {
+	Hostname      string    `json:"hostname"`
+	FirstSeen     time.Time `json:"first_seen"`
+	LastSeen      time.Time `json:"last_seen"`
+	QueryCount    int       `json:"query_count"`
+	IsBoseService bool      `json:"is_bose_service"`
+	IsIntercepted bool      `json:"is_intercepted"`
+	RemoteAddr    string    `json:"remote_addr,omitempty"`
+}
+
+// NewDNSDiscovery creates a new DNSDiscovery instance.
+func NewDNSDiscovery(upstreamDNS, serviceIP string) *DNSDiscovery {
+	return &DNSDiscovery{
+		upstreamDNS: upstreamDNS,
+		serviceIP:   serviceIP,
+		discovered:  make(map[string]*DiscoveredHost),
+	}
+}
+
+// ServeDNS implements the dns.Handler interface.
+func (d *DNSDiscovery) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	if len(r.Question) == 0 {
+		return
+	}
+
+	q := r.Question[0]
+	hostname := strings.TrimSuffix(q.Name, ".")
+
+	remoteAddr := ""
+	if w.RemoteAddr() != nil {
+		remoteAddr = w.RemoteAddr().String()
+	}
+
+	// Decide how to respond
+	isIntercepted := d.shouldIntercept(hostname) || hostname == "aftertouch.test"
+
+	// Record discovery
+	d.recordQuery(hostname, isIntercepted, remoteAddr)
+
+	if isIntercepted {
+		// Return your service IP
+		d.respondWithIP(w, r, d.serviceIP)
+		log.Printf("[DNS] Intercepting %s (type %d) -> %s", hostname, q.Qtype, d.serviceIP)
+	} else {
+		// Forward to real DNS
+		log.Printf("[DNS] Forwarding %s (type %d) to %s", hostname, q.Qtype, d.upstreamDNS)
+		d.forward(w, r)
+	}
+}
+
+// recordQuery logs a DNS query and updates the internal state.
+func (d *DNSDiscovery) recordQuery(hostname string, isIntercepted bool, remoteAddr string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	host, exists := d.discovered[hostname]
+	if !exists {
+		// New discovery!
+		host = &DiscoveredHost{
+			Hostname:      hostname,
+			FirstSeen:     time.Now(),
+			LastSeen:      time.Now(),
+			QueryCount:    1,
+			IsBoseService: d.isBoseRelated(hostname),
+			IsIntercepted: isIntercepted,
+			RemoteAddr:    remoteAddr,
+		}
+		d.discovered[hostname] = host
+
+		log.Printf("[NEW DISCOVERY] %s (Bose: %v, Intercepted: %v)",
+			hostname, host.IsBoseService, host.IsIntercepted)
+
+		if d.onNewDiscovery != nil {
+			go d.onNewDiscovery(hostname)
+		}
+	} else {
+		host.LastSeen = time.Now()
+		host.QueryCount++
+
+		host.IsIntercepted = isIntercepted
+		if remoteAddr != "" {
+			host.RemoteAddr = remoteAddr
+		}
+	}
+}
+
+func (d *DNSDiscovery) shouldIntercept(hostname string) bool {
+	// Intercept known Bose cloud services
+	interceptList := []string{
+		"api.bose.com",
+		"marge.bose.com",
+		"bmx.bose.com",
+		"streaming.bose.com",
+		"updates.bose.com",
+		"stats.bose.com",
+		"content.api.bose.io",
+		"events.api.bosecm.com",
+		"bose-prod.apigee.net",
+		"worldwide.bose.com",
+		"music.api.bose.com",
+	}
+
+	for _, service := range interceptList {
+		if strings.Contains(hostname, service) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (d *DNSDiscovery) isBoseRelated(hostname string) bool {
+	return strings.Contains(hostname, "bose") ||
+		strings.Contains(hostname, "soundtouch")
+}
+
+func (d *DNSDiscovery) respondWithIP(w dns.ResponseWriter, r *dns.Msg, ip string) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Compress = false // Embedded clients sometimes don't like compression
+	m.Authoritative = true
+	m.RecursionAvailable = true
+
+	q := r.Question[0]
+	log.Printf("[DNS] Intercepted query for %s (type %d) from %s", q.Name, q.Qtype, w.RemoteAddr())
+
+	switch q.Qtype {
+	case dns.TypeA, dns.TypeANY:
+		rr, err := dns.NewRR(fmt.Sprintf("%s 60 IN A %s", q.Name, ip))
+		if err == nil {
+			m.Answer = append(m.Answer, rr)
+
+			log.Printf("[DNS] Returning A record %s -> %s", q.Name, ip)
+		} else {
+			log.Printf("[DNS] Error creating A record: %v", err)
+		}
+	case dns.TypeAAAA:
+		// Explicitly return SUCCESS with no data for AAAA to prevent fallback issues
+		log.Printf("[DNS] Returning empty AAAA success (NODATA) for %s", q.Name)
+	default:
+		log.Printf("[DNS] Returning empty success for type %d", q.Qtype)
+	}
+
+	if err := w.WriteMsg(m); err != nil {
+		log.Printf("[DNS ERROR] Failed to write response: %v", err)
+	}
+}
+
+func (d *DNSDiscovery) forward(w dns.ResponseWriter, r *dns.Msg) {
+	if len(r.Question) == 0 {
+		return
+	}
+
+	// Don't forward PTR queries for our own service IP to avoid loops or slow timeouts
+	if r.Question[0].Qtype == dns.TypePTR {
+		m := new(dns.Msg)
+		m.SetReply(r)
+
+		m.Rcode = dns.RcodeNameError
+		if err := w.WriteMsg(m); err != nil {
+			log.Printf("[DNS ERROR] Failed to write NXDOMAIN: %v", err)
+		}
+
+		return
+	}
+
+	c := new(dns.Client)
+	// Add port 53 if not present
+	upstream := d.upstreamDNS
+	if !strings.Contains(upstream, ":") {
+		upstream += ":53"
+	}
+
+	in, _, err := c.Exchange(r, upstream)
+	if err != nil {
+		log.Printf("[DNS ERROR] Forward failed for %s (type %d): %v", r.Question[0].Name, r.Question[0].Qtype, err)
+		// Return a failure response instead of just dropping
+		m := new(dns.Msg)
+		m.SetReply(r)
+
+		m.Rcode = dns.RcodeServerFailure
+		if err := w.WriteMsg(m); err != nil {
+			log.Printf("[DNS ERROR] Failed to write failure response: %v", err)
+		}
+
+		return
+	}
+
+	if err := w.WriteMsg(in); err != nil {
+		log.Printf("[DNS ERROR] Failed to write forwarded response: %v", err)
+	}
+}
+
+// GetDiscovered returns a map of all discovered hosts.
+func (d *DNSDiscovery) GetDiscovered() map[string]*DiscoveredHost {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	// Return copy
+	result := make(map[string]*DiscoveredHost)
+	for k, v := range d.discovered {
+		result[k] = v
+	}
+
+	return result
+}
+
+// GetBoseHosts returns a slice of all discovered Bose-related hosts.
+func (d *DNSDiscovery) GetBoseHosts() []*DiscoveredHost {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	var result []*DiscoveredHost
+
+	for _, host := range d.discovered {
+		if host.IsBoseService {
+			result = append(result, host)
+		}
+	}
+
+	return result
+}
+
+// SetDiscovered sets the map of discovered hosts.
+func (d *DNSDiscovery) SetDiscovered(discovered map[string]*DiscoveredHost) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.discovered = discovered
+}
+
+// Start DNS server starts both UDP and TCP listeners
+func (d *DNSDiscovery) Start(addr string) error {
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", d.ServeDNS)
+
+	d.mu.Lock()
+	d.udpServer = &dns.Server{
+		Addr:    addr,
+		Net:     "udp",
+		Handler: mux,
+	}
+
+	d.tcpServer = &dns.Server{
+		Addr:    addr,
+		Net:     "tcp",
+		Handler: mux,
+	}
+	d.mu.Unlock()
+
+	errChan := make(chan error, 2)
+
+	go func() {
+		log.Printf("[DNS] UDP Discovery server starting on %s", addr)
+
+		if err := d.udpServer.ListenAndServe(); err != nil {
+			errChan <- fmt.Errorf("UDP server failed: %w", err)
+		}
+	}()
+
+	go func() {
+		log.Printf("[DNS] TCP Discovery server starting on %s", addr)
+
+		if err := d.tcpServer.ListenAndServe(); err != nil {
+			errChan <- fmt.Errorf("TCP server failed: %w", err)
+		}
+	}()
+
+	log.Printf("[DNS] Discovery servers starting on %s (upstream: %s, intercept IP: %s)", addr, d.upstreamDNS, d.serviceIP)
+
+	// Wait for first error
+	return <-errChan
+}
+
+// IsRunning returns true if the DNS server is active and bound to the specified address.
+func (d *DNSDiscovery) IsRunning(addr string) bool {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.udpServer == nil || d.tcpServer == nil {
+		return false
+	}
+
+	// We check if the address matches what we expect
+	return d.udpServer.Addr == addr && d.tcpServer.Addr == addr
+}
+
+// Shutdown stops the DNS server listeners
+func (d *DNSDiscovery) Shutdown() error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.udpServer != nil {
+		if err := d.udpServer.Shutdown(); err != nil {
+			log.Printf("[DNS] Error shutting down UDP server: %v", err)
+		}
+
+		d.udpServer = nil
+	}
+
+	if d.tcpServer != nil {
+		if err := d.tcpServer.Shutdown(); err != nil {
+			log.Printf("[DNS] Error shutting down TCP server: %v", err)
+		}
+
+		d.tcpServer = nil
+	}
+
+	return nil
+}

--- a/pkg/discovery/dns_test.go
+++ b/pkg/discovery/dns_test.go
@@ -1,0 +1,194 @@
+package discovery
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func TestDNSDiscovery_Interception(t *testing.T) {
+	serviceIP := "192.168.1.100"
+	upstreamDNS := "8.8.8.8"
+	d := NewDNSDiscovery(upstreamDNS, serviceIP)
+
+	// Test intercepting Bose service
+	m := new(dns.Msg)
+	m.SetQuestion("api.bose.com.", dns.TypeA)
+
+	rw := &mockResponseWriter{}
+	d.ServeDNS(rw, m)
+
+	if rw.msg == nil {
+		t.Fatal("Expected a response message, got nil")
+	}
+
+	if len(rw.msg.Answer) == 0 {
+		t.Fatal("Expected an answer in the response")
+	}
+
+	if a, ok := rw.msg.Answer[0].(*dns.A); ok {
+		if a.A.String() != serviceIP {
+			t.Errorf("Expected intercepted IP %s, got %s", serviceIP, a.A.String())
+		}
+	} else {
+		t.Errorf("Expected A record, got %T", rw.msg.Answer[0])
+	}
+
+	// Test aftertouch.test
+	m2 := new(dns.Msg)
+	m2.SetQuestion("aftertouch.test.", dns.TypeA)
+	rw2 := &mockResponseWriter{}
+	d.ServeDNS(rw2, m2)
+
+	if rw2.msg == nil || len(rw2.msg.Answer) == 0 {
+		t.Fatal("Expected response for aftertouch.test")
+	}
+
+	if a, ok := rw2.msg.Answer[0].(*dns.A); ok {
+		if a.A.String() != serviceIP {
+			t.Errorf("Expected intercepted IP %s for aftertouch.test, got %s", serviceIP, a.A.String())
+		}
+	} else {
+		t.Errorf("Expected A record for aftertouch.test, got %T", rw2.msg.Answer[0])
+	}
+}
+
+func TestDNSDiscovery_Forwarding(t *testing.T) {
+	// This test is harder because it needs a real upstream or a mock.
+	// For now, let's just test that it calls forward and record.
+	serviceIP := "192.168.1.100"
+	upstreamDNS := "127.0.0.1:5353" // Use a port that is likely closed or we can mock
+	d := NewDNSDiscovery(upstreamDNS, serviceIP)
+
+	m := new(dns.Msg)
+	m.SetQuestion("google.com.", dns.TypeA)
+
+	rw := &mockResponseWriter{}
+
+	// Start a mock upstream DNS server
+	mux := dns.NewServeMux()
+	mux.HandleFunc("google.com.", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		_ = w.WriteMsg(m)
+	})
+	ts := &dns.Server{Addr: "127.0.0.1:5353", Net: "udp", Handler: mux, ReadTimeout: 100 * time.Millisecond, WriteTimeout: 100 * time.Millisecond}
+	go func() {
+		_ = ts.ListenAndServe()
+	}()
+	defer func() { _ = ts.Shutdown() }()
+
+	// Give it a moment to start
+	time.Sleep(100 * time.Millisecond)
+
+	// We expect forward to succeed
+	d.ServeDNS(rw, m)
+
+	d.mu.RLock()
+	host, exists := d.discovered["google.com"]
+	d.mu.RUnlock()
+
+	if !exists {
+		t.Error("Expected google.com to be recorded in discovery")
+	}
+	if host.IsBoseService {
+		t.Error("google.com should not be identified as a Bose service")
+	}
+}
+
+func TestDNSDiscovery_StartTCP(t *testing.T) {
+	serviceIP := "192.168.1.100"
+	upstreamDNS := "8.8.8.8"
+	d := NewDNSDiscovery(upstreamDNS, serviceIP)
+
+	addr := "127.0.0.1:5354"
+	go func() {
+		_ = d.Start(addr)
+	}()
+
+	// Give it a moment to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Test TCP resolution
+	m := new(dns.Msg)
+	m.SetQuestion("api.bose.com.", dns.TypeA)
+
+	c := new(dns.Client)
+	c.Net = "tcp"
+	in, _, err := c.Exchange(m, addr)
+	if err != nil {
+		t.Fatalf("Failed to exchange via TCP: %v", err)
+	}
+
+	if len(in.Answer) == 0 {
+		t.Fatal("Expected answer in TCP response")
+	}
+
+	if a, ok := in.Answer[0].(*dns.A); ok {
+		if a.A.String() != serviceIP {
+			t.Errorf("Expected intercepted IP %s via TCP, got %s", serviceIP, a.A.String())
+		}
+	} else {
+		t.Errorf("Expected A record via TCP, got %T", in.Answer[0])
+	}
+
+	// Test Shutdown
+	err = d.Shutdown()
+	if err != nil {
+		t.Errorf("Shutdown failed: %v", err)
+	}
+
+	// Verify it's really shut down by trying to connect
+	_, _, err = c.Exchange(m, addr)
+	if err == nil {
+		t.Error("Expected error after shutdown, but could still exchange")
+	}
+}
+
+func TestDNSDiscovery_IsRunning(t *testing.T) {
+	serviceIP := "192.168.1.100"
+	upstreamDNS := "8.8.8.8"
+	d := NewDNSDiscovery(upstreamDNS, serviceIP)
+
+	addr := "127.0.0.1:5355"
+
+	if d.IsRunning(addr) {
+		t.Error("Expected IsRunning to be false before Start")
+	}
+
+	go func() {
+		_ = d.Start(addr)
+	}()
+
+	// Give it a moment to start
+	time.Sleep(200 * time.Millisecond)
+
+	if !d.IsRunning(addr) {
+		t.Error("Expected IsRunning to be true after Start")
+	}
+
+	if d.IsRunning("127.0.0.1:9999") {
+		t.Error("Expected IsRunning to be false for wrong address")
+	}
+
+	_ = d.Shutdown()
+
+	if d.IsRunning(addr) {
+		t.Error("Expected IsRunning to be false after Shutdown")
+	}
+}
+
+type mockResponseWriter struct {
+	msg *dns.Msg
+}
+
+func (m *mockResponseWriter) LocalAddr() net.Addr         { return nil }
+func (m *mockResponseWriter) RemoteAddr() net.Addr        { return nil }
+func (m *mockResponseWriter) WriteMsg(msg *dns.Msg) error { m.msg = msg; return nil }
+func (m *mockResponseWriter) Write([]byte) (int, error)   { return 0, nil }
+func (m *mockResponseWriter) Close() error                { return nil }
+func (m *mockResponseWriter) TsigStatus() error           { return nil }
+func (m *mockResponseWriter) TsigTimersOnly(bool)         {}
+func (m *mockResponseWriter) Hijack()                     {}

--- a/pkg/service/datastore/dns_persistence_test.go
+++ b/pkg/service/datastore/dns_persistence_test.go
@@ -1,0 +1,75 @@
+package datastore
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestDNSDiscoveryPersistence(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "datastore-dns-test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	ds := NewDataStore(tempDir)
+
+	now := time.Now().Round(time.Second)
+	discoveries := []DNSDiscoveryEntry{
+		{
+			Hostname:      "api.bose.com",
+			FirstSeen:     now.Add(-1 * time.Hour),
+			LastSeen:      now,
+			QueryCount:    10,
+			IsBoseService: true,
+			IsIntercepted: true,
+			RemoteAddr:    "192.168.1.100",
+		},
+		{
+			Hostname:      "google.com",
+			FirstSeen:     now.Add(-2 * time.Hour),
+			LastSeen:      now.Add(-1 * time.Hour),
+			QueryCount:    5,
+			IsBoseService: false,
+			IsIntercepted: false,
+			RemoteAddr:    "192.168.1.101",
+		},
+	}
+
+	// Test Save
+	err = ds.SaveDNSDiscoveries(discoveries)
+	if err != nil {
+		t.Fatalf("SaveDNSDiscoveries failed: %v", err)
+	}
+
+	// Test Load
+	loaded, err := ds.LoadDNSDiscoveries()
+	if err != nil {
+		t.Fatalf("LoadDNSDiscoveries failed: %v", err)
+	}
+
+	if len(loaded) != 2 {
+		t.Errorf("Expected 2 discoveries, got %d", len(loaded))
+	}
+
+	// Check if sorted by LastSeen (SaveDNSDiscoveries sorts them)
+	if loaded[0].Hostname != "api.bose.com" {
+		t.Errorf("Expected api.bose.com to be first, got %s", loaded[0].Hostname)
+	}
+
+	// Test Clear
+	err = ds.ClearDNSDiscoveries()
+	if err != nil {
+		t.Fatalf("ClearDNSDiscoveries failed: %v", err)
+	}
+
+	loadedAfterClear, err := ds.LoadDNSDiscoveries()
+	if err != nil {
+		t.Fatalf("LoadDNSDiscoveries after clear failed: %v", err)
+	}
+
+	if len(loadedAfterClear) != 0 {
+		t.Errorf("Expected 0 discoveries after clear, got %d", len(loadedAfterClear))
+	}
+}

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -101,6 +101,24 @@
                 <span id="settings-status" style="margin-left: 10px; font-size: 0.9em;"></span>
             </div>
             <div style="margin-bottom: 20px;">
+                <strong>DNS Discovery:</strong>
+                <div style="margin-top: 5px;">
+                    <label style="display: block; margin-bottom: 5px;">
+                        <input type="checkbox" id="dns-enabled"> Enable DNS Discovery Server
+                    </label>
+                    <div style="margin-left: 20px; margin-bottom: 5px;">
+                        <label for="dns-upstream">Upstream DNS:</label>
+                        <input type="text" id="dns-upstream" placeholder="8.8.8.8" style="width: 150px;">
+                        <span style="font-size: 0.8em; color: #666; margin-left: 5px;">(For non-intercepted queries)</span>
+                    </div>
+                    <div style="margin-left: 20px;">
+                        <label for="dns-bind">DNS Bind Address:</label>
+                        <input type="text" id="dns-bind" placeholder=":53" style="width: 100px;">
+                        <span style="font-size: 0.8em; color: #666; margin-left: 5px;">(e.g., :53 or 0.0.0.0:53. <strong>Port 53</strong> is required for actual migration)</span>
+                    </div>
+                </div>
+            </div>
+            <div style="margin-bottom: 20px;">
                 <strong>Proxy Logging:</strong>
                 <div style="margin-top: 5px;">
                     <label style="display: block; margin-bottom: 5px;"><input type="checkbox" id="proxy-redact" onchange="updateProxySettings()"> Redact Sensitive Headers</label>
@@ -194,12 +212,31 @@
                     <div id="hosts-test-result" style="margin-top: 10px; display: none; padding: 10px; border-radius: 4px; font-family: monospace; white-space: pre-wrap; font-size: 0.85em; max-height: 200px; overflow-y: auto;"></div>
                 </div>
 
+                <div id="dns-redirection-test" style="margin: 15px 0; padding: 10px; border: 1px solid #ddd; background-color: #e6ffed; display: none;">
+                    <strong>Preliminary DNS Test:</strong><br>
+                    <span style="font-size: 0.85em; color: #555;">Verify the device can resolve domains via the AfterTouch DNS server.</span>
+                    <div style="margin-top: 10px;">
+                        Domain: <code>aftertouch.test</code>
+                    </div>
+                    <div style="margin-top: 10px;">
+                        <button id="test-dns-btn" style="background-color: #28a745; color: white; border: none; padding: 5px 10px; font-size: 0.9em;">Test DNS Redirection</button>
+                    </div>
+                    <div id="dns-test-result" style="margin-top: 10px; display: none; padding: 10px; border-radius: 4px; font-family: monospace; white-space: pre-wrap; font-size: 0.85em; max-height: 200px; overflow-y: auto;"></div>
+                </div>
+
                 <div style="margin: 15px 0; padding: 10px; border: 1px solid #ddd; background-color: #f9f9f9;">
                     <label for="migration-method"><strong>Migration Method:</strong></label>
                     <select id="migration-method" onchange="toggleMigrationMethod()">
                         <option value="xml">XML Configuration (Recommended - redirects specific services)</option>
                         <option value="hosts">/etc/hosts + Root CA (Advanced - global redirection)</option>
+                        <option value="resolv">/etc/resolv.conf (DNS Discovery Mode - robust)</option>
                     </select>
+                    <div id="dns-port-warning" style="margin-top: 5px; color: #d32f2f; font-weight: bold; font-size: 0.9em; display: none;"></div>
+                </div>
+
+                <div id="current-resolv-pane" style="display: none; margin-bottom: 20px;">
+                    <span class="config-header">Current /etc/resolv.conf</span>
+                    <pre id="current-resolv-content"></pre>
                 </div>
 
                 <div id="original-config-pane" style="display: none; margin-bottom: 20px;">
@@ -270,6 +307,13 @@
                             <strong>Note:</strong> This method also injects the AfterTouch Local Root CA into <code>/etc/pki/tls/certs/ca-bundle.crt</code> to enable secure HTTPS communication.
                         </div>
                     </div>
+                    <div id="planned-resolv-pane" class="diff-pane" style="display: none;">
+                        <span class="config-header">Planned /etc/resolv.conf</span>
+                        <pre id="planned-resolv"></pre>
+                        <div style="margin-top: 10px; font-size: 0.9em; color: #666;">
+                            <strong>Note:</strong> This method prepends AfterTouch as the nameserver and makes the file immutable (<code>chattr +i</code>). It also injects the Local Root CA.
+                        </div>
+                    </div>
                 </div>
                 <div style="margin-top: 15px;">
                     <button id="confirm-migrate-btn" style="background-color: #4CAF50; color: white; border: none; padding: 10px 20px;">Confirm Migration</button>
@@ -314,7 +358,9 @@
             </div>
 
             <div id="browse-recordings" class="summary-box" style="margin-top: 20px;">
-                <h3>Browse Recordings</h3>
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                    <h3 style="margin: 0;">Browse Recordings</h3>
+                </div>
                 <div style="margin-bottom: 15px; display: flex; gap: 15px; align-items: center; background: #f9f9f9; padding: 10px; border-radius: 4px;">
                     <div>
                         <label for="filter-session">Session:</label>
@@ -352,6 +398,31 @@
                         </thead>
                         <tbody id="interactions-list">
                             <tr><td colspan="7" style="padding: 20px; text-align: center; color: #666;">No interactions found.</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div id="dns-discoveries" class="summary-box" style="margin-top: 20px;">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;">
+                    <h3 style="margin: 0;">DNS Discoveries</h3>
+                    <button onclick="clearDNSDiscoveries()" class="btn-danger">Clear DNS Logs</button>
+                </div>
+                <p style="font-size: 0.85em; color: #666;">Hosts discovered via the AfterTouch DNS server. "Self" means the domain was intercepted and redirected to this service.</p>
+                <div id="dns-discoveries-list-container" style="max-height: 400px; overflow-y: auto;">
+                    <table style="width: 100%; border-collapse: collapse;">
+                        <thead>
+                            <tr style="text-align: left; border-bottom: 2px solid #eee;">
+                                <th style="padding: 8px;">Hostname</th>
+                                <th style="padding: 8px;">Last Seen</th>
+                                <th style="padding: 8px; text-align: center;">Queries</th>
+                                <th style="padding: 8px; text-align: center;">Bose?</th>
+                                <th style="padding: 8px;">Category</th>
+                                <th style="padding: 8px;">Last Client IP</th>
+                            </tr>
+                        </thead>
+                        <tbody id="dns-discoveries-list">
+                            <tr><td colspan="6" style="padding: 20px; text-align: center; color: #666;">No DNS discoveries found.</td></tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
This adds a comprehensive DNS-based discovery and migration system for Bose SoundTouch devices.

### Key Changes:

- **DNS Discovery Module**: Created a new Go DNS server in `pkg/discovery/dns.go` that intercepts Bose-related domains and logs all device DNS queries for service discovery.
- **Enhanced Migration**: Added the `resolv` migration method in `pkg/service/setup/setup.go` to redirect devices via `/etc/resolv.conf`. It includes making the configuration immutable via `chattr +i`.
- **Pre-flight Checks**: Implemented robust validation to ensure the DNS server is enabled and properly bound to port 53 before allowing a DNS-based migration.
- **Web UI Integration**: Updated the management interface to allow dynamic configuration of DNS settings and provided a real-time table for DNS discovery analysis.
- **Preliminary Testing**: Added a "Preliminary DNS Test" that uses raw DNS-over-TCP queries via `nc` to verify redirection from the device before applying changes.
- **Performance Optimization**: Refactored the test suite to use mock servers, reducing total execution time from minutes to seconds.
- **Persistence**: Implemented JSON-based deduplicated storage for discovered hostnames in `data/dns/discoveries.json`.
