### PR TITLE
Add support for RADIO_BROWSER source

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A comprehensive solution for controlling and preserving Bose SoundTouch devices,
 - ⚡ **Real-time Events**: WebSocket connection for live device state monitoring
 - 🔍 **Device Discovery**: Automatic discovery via UPnP/SSDP and mDNS
 - 📻 **Content Navigation**: Browse and search TuneIn, Pandora, Spotify, local music
+- 📻 **RadioBrowser**: Access thousands of internet radio stations via [radio-browser.info](docs/reference/radio-browser.md)
 - 🎙️ **Station Management**: Add and play radio stations without presets
 - 🖥️ **CLI Tool**: Comprehensive command-line interface
 - 🌐 **SoundTouch Service**: Emulate Bose cloud services for offline device operation

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -33,6 +33,7 @@
 * [Preset Management](reference/PRESET-MANAGEMENT.md)
 * [Source Selection](reference/SOURCE-SELECTION.md)
 * [Volume Controls](reference/VOLUME-CONTROLS.md)
+* [RadioBrowser](reference/radio-browser.md)
 * [Bass Controls](reference/BASS-CONTROLS.md)
 * [Key Controls](reference/KEY-CONTROLS.md)
 * [Feature Mapping](reference/FEATURE-MAPPING.md)

--- a/docs/reference/SOURCE-SELECTION.md
+++ b/docs/reference/SOURCE-SELECTION.md
@@ -38,6 +38,7 @@ The Bose SoundTouch Go client provides comprehensive source selection functional
 - `IHEARTRADIO` - iHeartRadio streaming
 - `STORED_MUSIC` - Local/network stored music
 - `AIRPLAY` - Apple AirPlay (device dependent)
+- `RADIO_BROWSER` - [RadioBrowser](radio-browser.md) internet radio directory
 
 ## Client Library Usage
 

--- a/docs/reference/radio-browser.md
+++ b/docs/reference/radio-browser.md
@@ -1,0 +1,34 @@
+## radio-browser.info
+
+- https://www.radio-browser.info is a community driven radio station database.
+- It provides an API to access the data and allows users to submit new stations or update existing ones.
+
+### Search for stations
+
+- Go to https://www.radio-browser.info and find a station you like.
+- Click on the station and copy the UUID from the URL.
+- e.g. `https://www.radio-browser.info/history/d28420a4-eccf-47a2-ace1-088c7e7cb7e0`
+
+### RADIO_BROWSER
+
+- This project supports source type RADIO_BROWSER to play radio stations.
+- Set the `location` attribute to `/stations/byuuid/{UUID}`.
+
+```xml
+<ContentItem
+  source="RADIO_BROWSER"
+  type="stationurl"
+  isPresetable="true"
+  location="/stations/byuuid/9610c454-0601-11e8-ae97-52543be04c81">
+  <itemName>RADIO_BROWSER</itemName>
+  <containerArt></containerArt>
+</ContentItem>
+```
+
+### Playing the station
+
+To start the radio stream replace `<uuid>` and `<soundtouch>` and run curl like this:
+
+```bash
+curl -d '<ContentItem source="RADIO_BROWSER" type="stationurl" location="/stations/byuuid/<uuid>"/>' <soundtouch>:8090/select
+```

--- a/pkg/service/constants/constants.go
+++ b/pkg/service/constants/constants.go
@@ -41,6 +41,7 @@ var Providers = []string{
 	"RADIO.COM",
 	"RADIO_COM",
 	"SIRIUSXM_EVEREST",
+	"RADIO_BROWSER",
 }
 
 // Common file and path constants used by the datastore and setup logic.

--- a/pkg/service/handlers/static/bmx_services.json
+++ b/pkg/service/handlers/static/bmx_services.json
@@ -170,6 +170,46 @@
         "liveRadio",
         "onDemand"
       ]
+    },
+    {
+      "_links": {
+        "bmx_navigate": {
+          "href": "/v1/navigate"
+        },
+        "bmx_token": {
+          "href": "/v1/token"
+        },
+        "self": {
+          "href": "/"
+        }
+      },
+      "askAdapter": false,
+      "assets": {
+        "color": "#000000",
+        "description": "RadioBrowser is an open source internet radio directory. It provides access to thousands of internet radio stations worldwide. RadioBrowser is community driven and relies on user contributions to keep the station database up to date.",
+        "icons": {
+          "largeSvg": "{MEDIA_SERVER}/orion-monochrome.svg",
+          "monochromePng": "{MEDIA_SERVER}/orion-monochrome_v2.png",
+          "monochromeSvg": "{MEDIA_SERVER}/orion-monochrome.svg",
+          "smallSvg": "{MEDIA_SERVER}/orion-monochrome.svg"
+        },
+        "name": "RadioBrowser"
+      },
+      "authenticationModel": {
+        "anonymousAccount": {
+          "autoCreate": true,
+          "enabled": true
+        }
+      },
+      "baseUrl": "https://all.api.radio-browser.info/soundtouch",
+      "id": {
+        "name": "RADIO_BROWSER",
+        "value": 39
+      },
+      "streamTypes": [
+        "liveRadio",
+        "onDemand"
+      ]
     }
   ]
 }


### PR DESCRIPTION
This implementation follows the reference from soundcork pull request #158. It adds RADIO_BROWSER to the known providers and includes the service configuration in bmx_services.json. Documentation has also been added to explain how to use the RadioBrowser feature. Credits to @gmuth (https://github.com/gmuth) for the original idea and implementation in soundcork. References:

- https://github.com/deborahgu/soundcork/pull/158
- https://gitlab.com/radiobrowser/radiobrowser-api-rust/-/issues/248