### PR TITLE
Restrict the GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -55,6 +55,8 @@ jobs:
   static-analysis:
     name: Static Security Analysis
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/4](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/4)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions for the `static-analysis` job to the minimum required, rather than relying on inherited defaults. The steps in this job only need to read repository contents to run analysis and to allow actions like `semgrep/semgrep-action` and `github/codeql-action/upload-sarif` to read code and upload results; they do not need write access to the repository.

The best fix is to add a `permissions` block under `static-analysis`, similar to the other jobs, and set it to `contents: read`. This keeps functionality unchanged: `actions/checkout` and the other actions still work, but the token won’t have unnecessary write capabilities. Concretely, in `.github/workflows/security.yml`, between line 57 (`runs-on: ubuntu-latest`) and line 59 (`steps:`), insert:

```yaml
    permissions:
      contents: read
```

No imports or other definitions are required; GitHub Actions natively supports the `permissions` key in workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
