### PR TITLE
Restrict the GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -121,6 +121,8 @@ jobs:
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/7](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/7)

In general, to fix this issue you add a `permissions` block either at the workflow root or on the specific job, granting only the scopes that job actually needs (usually `contents: read` for read-only operations). This prevents the job from inheriting broader default permissions from the repository or organization.

For this workflow, the best minimal, non-breaking change is to add a `permissions` block under the `dependency-review` job. That job checks out the code and runs `actions/dependency-review-action`, which only needs to read the repository contents and dependency information. It does not create releases, push code, or modify issues/PRs in the provided snippet, so `contents: read` is sufficient. Concretely, in `.github/workflows/security.yml`, under the `dependency-review` job (lines 121–136), insert:

```yaml
    permissions:
      contents: read
```

between `runs-on: ubuntu-latest` and `if: github.event_name == 'pull_request'`. No new imports or external dependencies are needed; this is purely a YAML configuration change within the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
