### PR TITLE
Restrict the GITHUB_TOKEN permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -139,6 +139,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [vulnerability-scan, static-analysis, codeql-analysis]
     if: always()
+    permissions:
+      contents: read
 
     steps:
       - name: Security scan summary


### PR DESCRIPTION
Potential fix for [https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/8](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/8)

To fix the problem, explicitly declare a minimal `permissions` block for the `security-summary` job so it does not inherit broader repository defaults. This job only needs to read job results (from the `needs` context) and write to the job summary, which does not require any repository write scopes, so a safe baseline is `contents: read`. It does not upload SARIF or interact with security alerts, so it does not need `security-events: write`.

Concretely, in `.github/workflows/security.yml`, under the `security-summary` job (around lines 137–142), add a `permissions` section with `contents: read`. This keeps existing behavior unchanged while constraining the GITHUB_TOKEN. No new imports or dependencies are needed; only the YAML for the job definition is updated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
