### PR TITLE
The RADIOPLAYER source is deprecated

### DIFF
--- a/pkg/service/constants/constants.go
+++ b/pkg/service/constants/constants.go
@@ -82,6 +82,7 @@ const (
 	// ProviderAlexa is the identifier for Amazon Alexa.
 	ProviderAlexa = "ALEXA"
 	// ProviderRadioplayer is the identifier for Radioplayer.
+	// RADIOPLAYER is deprecated: https://www.radioplayer.de/apps/bose.html
 	ProviderRadioplayer = "RADIOPLAYER"
 	// ProviderRadioDotCom is the identifier for Radio.com.
 	ProviderRadioDotCom = "RADIO.COM"


### PR DESCRIPTION
See https://www.radioplayer.de/apps/bose.html

> Der Radioplayer in BOSE Lautsprechersystemen (ARCHIV)
>
> Bose Soundbar und Bose Soundtouch
>
> ACHTUNG: BOSE steht seit jeher für glasklaren Sound. Im Jahr 2018 wurden daher auch sämtliche Sender des Radioplayers in den SoundBar und SoundTouch Geräten des Audio-Herstellers aus Massachussets verfügbar gemacht. Trotz des großen Erfolges der Geräte, besondern auch in Deutschland, hat sich BOSE jedoch dazu entschieden die Linie der SoundTouch-Geräte nicht mehr fortzuführen. Die letzte Aktualisierung der BOSE SoundTouch-App (in der der Radioplayer integriert war, siehe unten) erfolgte in den App-Stores in 2021. Seither sind einige (neuere) Sender nicht mehr wie gewohnt verfügbar. BOSE hat zudem verkündet, den Support der SoundTouch-Geräte zum 18. Februar 2026 komplett einzustellen, was den Zugriff auf Musikdienste wie den Radioplayer vollends beendet.
