### PR TITLE
docs: update soundcork parity and community tools analysis

### DIFF
--- a/.docsignore
+++ b/.docsignore
@@ -2,4 +2,4 @@
 # Paths are relative to the docs/ directory.
 # Lines starting with # and blank lines are ignored.
 
-analysis/bose-soundtouch-community-tools.md
+#analysis/bose-soundtouch-community-tools.md

--- a/.github/markdown-link-check.json
+++ b/.github/markdown-link-check.json
@@ -37,6 +37,12 @@
     },
     {
       "pattern": "https://apkpure.com/bose-soundtouch/com.bose.soundtouch"
+    },
+    {
+      "pattern": "^https://bose\\.fandom\\.com/"
+    },
+    {
+      "pattern": "^https://www\\.reddit\\.com/"
     }
   ],
   "replacementPatterns": [

--- a/docs/PARITY-SOUNDCORK.md
+++ b/docs/PARITY-SOUNDCORK.md
@@ -20,7 +20,7 @@ This document provides a comparative analysis of the current Go implementation a
 ## 3. Key Strengths of SoundCork
 - **Group Pairing Logic**: Includes logic to manage master/slave relationships for SoundTouch 10 stereo pairs.
 - **Service Extensibility**: JSON-based registry for BMX services makes it easier to mock multiple providers (SiriusXM, Spotify) without code changes.
-- **Mock Coverage**: Better coverage of "dummy" endpoints that respond with plausible XML (e.g., `customerSupport`).
+- ~~**Mock Coverage**: Better coverage of "dummy" endpoints that respond with plausible XML (e.g., `customerSupport`).~~ **Addressed**: AfterTouch's `HandleNotFound` (registered via `r.NotFound`) logs every unimplemented endpoint as `[UNHANDLED]` and forwards the request to the Bose upstream via `HandleBoseProxy`. This provides at least the same coverage as static dummy responses, while also aiding discovery of new endpoints.
 
 ## 4. Suggested Implementation Steps for Bose-SoundTouch
 
@@ -35,6 +35,7 @@ This document provides a comparative analysis of the current Go implementation a
 - Speaker can self-refresh credentials independently; no periodic re-priming needed for token expiry.
 - Automatic fallback to `tokenType=accesstoken` if `getInfo` fails (older firmware without DH support).
 - See `docs/concepts/spotify-priming-strategy.md` for full protocol details.
+- **Remaining gap**: Background watchdog to re-prime devices that lose their session (reboot / power loss). Not required for token expiry on modern firmware; only needed for the "speaker rebooted and lost state" recovery path and for older firmware on the fallback path (~45 min token expiry).
 
 ### C. Modularize BMX Registry (Medium Priority)
 - Extract the hardcoded service list in `HandleBMXRegistry` into an external `bmx-services.json` file.
@@ -47,4 +48,10 @@ This document provides a comparative analysis of the current Go implementation a
 - Develop a minimal internal status page to list active accounts and connected devices, improving usability over raw API calls.
 
 ## 5. Summary
-While our Go implementation is structurally more consistent with recent reference recordings (e.g., `buttonNumber`, detailed `components`), SoundCork provides better coverage of multi-device coordination (Groups) and service emulation (BMX) that we should adopt for a more complete offline experience.
+
+Group support and ZeroConf Spotify priming are now feature-complete in AfterTouch. The Go implementation is structurally more consistent with recent reference recordings (e.g., `buttonNumber`, detailed `components`). SoundCork's remaining functional advantages are:
+
+- **BMX service extensibility**: the `bmx_services.json` registry makes it trivial to add or mock new streaming providers without code changes (step C above).
+- **Group pairing logic**: master/slave relationship management for SoundTouch 10 stereo pairs goes beyond the CRUD AfterTouch implements.
+
+For the broader ecosystem context (feature matrix across all community projects, AfterTouch open tasks, and cross-project observations) see [docs/analysis/bose-soundtouch-community-tools.md](analysis/bose-soundtouch-community-tools.md).

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -61,6 +61,7 @@
 * [Bose Lab Runbook](analysis/BOSE-LAB-RUNBOOK.md)
 * [Missing Routes Spotify](analysis/MISSING-ROUTES-SPOTIFY.md)
 * [Bose App ADB Emulator](analysis/BOSE-APP-ADB-Emulator.md)
+* [Community Tools](analysis/bose-soundtouch-community-tools.md)
 
 ## Parity Analysis
 * [Parity Improvements](PARITY-IMPROVEMENTS.md)

--- a/docs/analysis/bose-soundtouch-community-tools.md
+++ b/docs/analysis/bose-soundtouch-community-tools.md
@@ -1,0 +1,298 @@
+# Bose SoundTouch — Community Tools for Post-EOL Preservation
+
+> **Context:** Bose announced the shutdown of SoundTouch cloud services, extended to **May 6, 2026**. On that date the official SoundTouch app will update to a local-only version. Bose has released the [SoundTouch Web API documentation](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) as open-source to enable community-driven development. This document surveys the active community projects, their feature coverage, and open development opportunities.
+
+---
+
+## What Bose Is Doing
+
+After the May 6, 2026 shutdown, the following will **continue to work**:
+
+- Streaming via Bluetooth, AirPlay, Spotify Connect, and AUX
+- Local device control and grouping via an updated SoundTouch app
+- Remote control features (play, pause, skip, volume)
+- HDMI/optical connections on soundbars
+
+The following will **stop working**:
+
+- Physical and app-based presets
+- In-app music service browsing (TuneIn, Pandora, etc.)
+- Stereo pairing for SoundTouch 10
+- Security and firmware updates
+
+---
+
+## Community Projects
+
+### 1. soundcork
+**[github.com/deborahgu/soundcork](https://github.com/deborahgu/soundcork)**
+| | |
+|---|---|
+| Language | Python |
+| License | MIT |
+| Stars | 111 |
+| Contributors | 8 |
+| Commits | 287 |
+| Status | Pre-alpha, actively developed |
+
+A reverse-engineered intercept API that replaces the Bose cloud servers locally. Works by redirecting the speaker's internal `SoundTouchSdkPrivateCfg.xml` to a self-hosted FastAPI server, emulating the `marge` server (required for basic network functionality) and the `bmx` server (required for TuneIn). Deployable as a Docker container or systemd daemon. The most community-engaged project, with a dedicated discussion thread tracking Bose cloud service status.
+
+---
+
+### 2. Überböse API
+**[github.com/julius-d/ueberboese-api](https://github.com/julius-d/ueberboese-api)**
+| | |
+|---|---|
+| Language | Java (Spring Boot) |
+| License | MIT |
+| Stars | 10 |
+| Contributors | 1 |
+| Commits | 224 |
+| Tags/Releases | 163 |
+| Documentation | [julius-d.github.io/ueberboese-api](https://julius-d.github.io/ueberboese-api/) |
+
+Reverse-engineers and rebuilds the Bose streaming HTTP API. Unique in publishing a machine-readable OpenAPI specification (`ueberboese-api.yaml`) and comprehensive request logging — making it the best research instrument for understanding what speakers actually call upstream. Implements Spotify OAuth integration and TuneIn. Companion to the Überböse App.
+
+---
+
+### 3. Überböse App
+**[github.com/julius-d/ueberboese-app](https://github.com/julius-d/ueberboese-app)**
+| | |
+|---|---|
+| Language | Flutter (Dart) |
+| License | MIT |
+| Latest version | 0.26.0 (March 2026) |
+| Distribution | [F-Droid](https://f-droid.org/en/packages/io.github.juliusd.ueberboese.app/) |
+| Platform | Android |
+
+The only native installable phone app in the ecosystem. Pairs with the Überböse API server. Features: preset view/play/reprogram, multi-room zone management, volume control, now-playing display, Spotify authentication setup. Controls speakers directly via the local SoundTouch WebServices API (no server required for basic control).
+
+---
+
+### 4. SoundTouch Hybrid 2026
+**[github.com/TJGigs/Bose-SoundTouch-Hybrid-2026](https://github.com/TJGigs/Bose-SoundTouch-Hybrid-2026)**
+(V3 variant: [github.com/TJGigs/Bose-SoundTouch-Hybrid-2026-V3](https://github.com/TJGigs/Bose-SoundTouch-Hybrid-2026-V3))
+| | |
+|---|---|
+| Language | Node.js (JavaScript) |
+| License | — |
+| Stars | 1 |
+| Commits | 3 (V1) / 12 (V3) |
+| Status | Experimental / testing |
+
+A self-hosted private cloud that emulates and replaces the Bose Cloud Service. Runs locally on a NAS or PC, intercepts the complex server handshakes needed to keep the SoundTouch infrastructure functional. Relies on **Music Assistant** for backend audio routing and provider aggregation. Features a setup wizard including USB config generation (`OverrideSdkPrivateCfg.xml`) and an on-screen Bose Cloud Emulation Setup guide. Targets users who want the broadest streaming provider support via Music Assistant's ecosystem.
+
+---
+
+### 5. OpenCloudTouch (OCT)
+**[github.com/scheilch/opencloudtouch](https://github.com/scheilch/opencloudtouch)**
+| | |
+|---|---|
+| Language | Python (FastAPI) + TypeScript (React) |
+| License | Apache 2.0 |
+| Stars | 9 |
+| Commits | 313 |
+| Latest release | v1.1.1 (April 12, 2026) |
+| Documentation | GitHub Wiki (EN/DE) |
+
+A single Docker container combining a FastAPI backend and React frontend. The most production-ready project in the ecosystem in terms of release discipline and deployment accessibility. Features: internet radio with full hardware preset support (buttons 1–6), responsive web UI, device discovery via SSDP/UPnP, multi-room zone management, BMX-compatible endpoints, TuneIn stream resolver, RadioBrowser as a built-in first-class search provider, and pre-built Raspberry Pi SD card images for Pi 3/4/5. Deployable on amd64, arm64, and arm/v7. Documented in English and German. Spotify and Music Assistant integration are on the roadmap.
+
+---
+
+### 6. AfterTouch
+**[github.com/gesellix/Bose-SoundTouch](https://github.com/gesellix/Bose-SoundTouch)** by gesellix
+| | |
+|---|---|
+| Language | Go |
+| License | MIT |
+| Stars | 16 |
+| Contributors | 2 |
+| Commits | 217 |
+| Releases | 51 (latest: v0.28.0, Feb 15, 2026) |
+| Documentation | [gesellix.github.io/Bose-SoundTouch](https://gesellix.github.io/Bose-SoundTouch/) |
+
+The most comprehensive single toolkit in the ecosystem. Comprises three components: a Go library (importable package), a CLI (`soundtouch-cli`), and a local cloud emulation service (`soundtouch-service`). Covers the widest range of dimensions of any single project. Implements the complete Bose Spotify OAuth relay including surrogate secret generation and token refresh proxy. Includes a built-in DNS server for device redirection without SSH, HTTPS/custom CA injection, HTTP session recording, traffic proxy/logging, and a web management UI. Tested on real SoundTouch 10 and 20 hardware. Has a Patreon for ongoing support.
+
+---
+
+### 7. soundcork-stockholm-app
+**[github.com/krahl/soundcork-stockholm-app](https://github.com/krahl/soundcork-stockholm-app)**
+| | |
+|---|---|
+| Language | Java |
+| License | — |
+| Stars | 2 |
+| Commits | 21 |
+| Status | Active development, bugs expected |
+
+A Java-based middleware that hosts the original Bose Stockholm frontend (extracted from the APK) in a local web browser at `http://127.0.0.1:8088/`. Bridges the Stockholm UI to local speakers via an HTTP proxy that resolves cross-origin issues, with SSDP-based device discovery and JSON state persistence. Unlike every other tool in the ecosystem, it runs the **official Bose UI** rather than a custom replacement — preserving the familiar Bose UX at the cost of requiring the Stockholm APK. Notable limitations: OAuth flows are unreliable, and WebSocket connections to speakers over HTTPS have blocking issues. Works alongside soundcork's backend for full cloud emulation.
+
+---
+
+### 8. jaas666/bose-soundtouch-web-api (Reference)
+**[github.com/jaas666/bose-soundtouch-web-api](https://github.com/jaas666/bose-soundtouch-web-api)**
+
+Community-maintained Markdown conversion of the official Bose SoundTouch Web API PDF (v1.0, January 7, 2026). Useful as a developer reference. Not a deployable tool.
+
+---
+
+## Feature Coverage Matrix
+
+Legend: ● Yes/complete · ◑ Partial/planned · ○ No
+
+| Dimension                                          | soundcork | Überböse API | Überböse App | ST Hybrid 2026 | OpenCloudTouch | AfterTouch | Stockholm App |
+|----------------------------------------------------|:---------:|:------------:|:------------:|:--------------:|:--------------:|:----------:|:-------------:|
+| **① App layer — local HTTP/WS control**            |           |              |              |                |                |            |               |
+| Playback control (play/pause/vol)                  |     ○     |      ○       |      ●       |       ●        |       ●        |     ●      |       ●       |
+| Preset view & trigger                              |     ○     |      ○       |      ●       |       ●        |       ●        |     ●      |       ●       |
+| Preset write / reprogram                           |     ○     |      ○       |      ●       |       ●        |       ◑        |     ●      |       ●       |
+| Multi-room zone management                         |     ○     |      ○       |      ●       |       ●        |       ●        |     ●      |       ●       |
+| Now playing / status display                       |     ○     |      ○       |      ●       |       ●        |       ●        |     ●      |       ●       |
+| Device discovery (SSDP/mDNS)                       |     ○     |      ○       |      ●       |       ○        |       ●        |     ●      |       ●       |
+| WebSocket real-time events                         |     ○     |      ○       |      ◑       |       ●        |       ◑        |     ●      |       ◑       |
+| **② Cloud/service layer — replaces Bose upstream** |           |              |              |                |                |            |               |
+| Marge server emulation                             |     ●     |      ●       |      ○       |       ●        |       ○        |     ●      |       ○       |
+| BMX / content registry                             |     ◑     |      ◑       |      ○       |       ●        |       ●        |     ●      |       ○       |
+| Account / OAuth token relay                        |     ○     |      ●       |      ○       |       ◑        |       ○        |     ●      |       ◑       |
+| Preset sync (cloud-side)                           |     ●     |      ●       |      ○       |       ●        |       ○        |     ●      |       ○       |
+| Recents sync                                       |     ●     |      ◑       |      ○       |       ◑        |       ○        |     ●      |       ○       |
+| Sources / device info persistence                  |     ●     |      ●       |      ○       |       ●        |       ○        |     ●      |       ○       |
+| Stereo group CRUD (ST10 pairs)                     |     ●     |      ○       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| **③ Device redirection — USB/SSH setup**           |           |              |              |                |                |            |               |
+| Setup wizard / guided redirect                     |     ◑     |      ◑       |      ○       |       ●        |       ●        |     ●      |       ○       |
+| USB image / config generation                      |     ○     |      ○       |      ○       |       ●        |       ○        |     ◑      |       ○       |
+| HTTPS / custom CA support                          |     ○     |      ○       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| **④ Streaming provider integration**               |           |              |              |                |                |            |               |
+| Internet radio (RadioBrowser)                      |     ○     |      ◑       |      ◑       |       ◑        |       ●        |     ◑      |       ○       |
+| TuneIn stream resolver                             |     ●     |      ●       |      ●       |       ●        |       ●        |     ●      |       ●       |
+| Spotify OAuth / Connect                            |     ○     |      ●       |      ●       |       ◑        |       ◑        |     ●      |       ◑       |
+| Pandora                                            |     ○     |      ○       |      ○       |       ○        |       ○        |     ●      |       ◑       |
+| Music Assistant backend                            |     ○     |      ○       |      ○       |       ●        |       ◑        |     ○      |       ○       |
+| **⑤ Mobile / native app**                          |           |              |              |                |                |            |               |
+| Android app (installable)                          |     ○     |      ○       |      ●       |       ○        |       ○        |     ○      |       ○       |
+| iOS app                                            |     ○     |      ○       |      ○       |       ○        |       ○        |     ○      |       ○       |
+| Mobile-responsive web UI                           |     ○     |      ○       |      ○       |       ●        |       ●        |     ●      |       ●       |
+| **⑥ Smart home / ecosystem integration**           |           |              |              |                |                |            |               |
+| Home Assistant integration                         |     ○     |      ○       |      ○       |       ○        |       ○        |     ◑      |       ○       |
+| Music Assistant integration                        |     ○     |      ○       |      ○       |       ●        |       ◑        |     ○      |       ○       |
+| **⑦ CLI / automation tools**                       |           |              |              |                |                |            |               |
+| CLI for scripting / automation                     |     ○     |      ○       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| Traffic proxy / API logging                        |     ◑     |      ●       |      ○       |       ○        |       ○        |     ●      |       ◑       |
+| HTTP session recording                             |     ○     |      ○       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| **⑧ Library / SDK**                                |           |              |              |                |                |            |               |
+| Importable library / package                       |     ○     |      ○       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| Published API spec / docs                          |     ○     |      ●       |      ○       |       ○        |       ○        |     ●      |       ○       |
+| Docker deployment                                  |     ●     |      ●       |      ○       |       ●        |       ●        |     ●      |       ●       |
+| Raspberry Pi SD card image                         |     ○     |      ○       |      ○       |       ○        |       ●        |     ○      |       ○       |
+
+---
+
+## Making AfterTouch the One-Stop Solution — Open Tasks
+
+AfterTouch is the strongest single project across the service and developer layers. Its remaining gaps are on the consumer-facing and ecosystem-integration sides.
+
+### Priority 1 — PWA installability
+
+The web UI is already fully responsive — it has Bootstrap grid columns, `@media (max-width: 768px)` and `@media (max-width: 576px)` breakpoints, and a proper viewport meta tag. It works on iPhone and Android browsers today. What's missing is **installability**: no `manifest.json` and no service worker, so it cannot be added to the home screen as a standalone app. Adding these would close the iOS app gap ecosystem-wide (no project has an iOS app) at minimal effort.
+
+### Priority 2 — RadioBrowser as a first-class provider
+
+AfterTouch can proxy and play any stream URL, but there is no built-in station search. OpenCloudTouch's RadioBrowser integration is the reference. Tasks:
+- Wire the [RadioBrowser API](https://www.radio-browser.info/) into the `soundtouch-web` web UI as a browsable/searchable source.
+- Make discovered stations directly presetable to hardware buttons.
+- This is the most common replacement for TuneIn for users who listened to internet radio via presets.
+
+### Priority 3 — Raspberry Pi SD card image
+
+OpenCloudTouch ships a flashable Pi image and it dramatically lowers the barrier for the most common "always-on local server" deployment. AfterTouch already has Docker and a web management UI; this is largely a CI/packaging task:
+- Build a Pi image (using e.g. `pi-gen` or `rpi-imager`-compatible tooling) that boots directly into `soundtouch-service`.
+- Auto-starts on boot, auto-discovers devices, opens the web UI on a known port.
+- Target Pi 3/4/5 with amd64/arm64/arm/v7 variants (mirroring OCT's approach).
+
+### Priority 4 — USB config generation in the web UI
+
+AfterTouch modifies `SoundTouchSdkPrivateCfg.xml` via SSH (`pkg/service/setup/setup.go`) and documents the redirect process thoroughly, but does not yet generate the USB stick content for users without SSH access. A "prepare USB stick" button in the web UI would remove the last manual step:
+- Generate `OverrideSdkPrivateCfg.xml` pre-populated with the running server's URL.
+- Optionally include the custom CA certificate for HTTPS-capable devices.
+- Surface alongside the existing guided migration wizard.
+
+### Priority 5 — Music Assistant integration
+
+SoundTouch Hybrid 2026 uses Music Assistant as its streaming backend, giving access to Apple Music, Deezer, local libraries, and many other providers. A formal Music Assistant **player provider** for AfterTouch would give power users a path to sources beyond Spotify, TuneIn, Pandora, and RadioBrowser. The Music Assistant community has an open discussion thread on this ([#4766](https://github.com/orgs/music-assistant/discussions/4766)).
+
+### Priority 6 — DNS-based migration documentation
+
+AfterTouch includes a built-in DNS server (`ENABLE_DNS_DISCOVERY`, `DNS_BIND_ADDR`, `DNS_UPSTREAM`) that intercepts `*.bose.com` queries and forwards everything else upstream — no Pi-hole, AdGuard, or any other external tool required. The ResolvConf migration path already treats DNS as a first-class option. The remaining gap is awareness: users unfamiliar with the project may not realise no external DNS infrastructure is needed. Tasks:
+- Surface the built-in DNS server more prominently in the getting-started documentation.
+- Document Pi-hole / AdGuard Home as an *alternative* for users who already run those, not a requirement.
+
+### Priority 7 — MQTT integration
+
+A design document exists (`docs/guides/MQTT-INTEGRATION-DESIGN.md`) but no code has been written. Implementing it would unlock home automation use cases without requiring the full Home Assistant stack — enabling triggers like "play preset 1 when front door opens" via any MQTT-capable automation platform.
+
+---
+
+## soundcork ↔ AfterTouch
+
+soundcork and AfterTouch share the most functional overlap of any two projects in the ecosystem. For the implementation-level parity analysis and remaining tasks see [docs/PARITY-SOUNDCORK.md](../PARITY-SOUNDCORK.md).
+
+### Architectural differences (not gaps)
+
+These exist in soundcork but are deliberate architectural choices in AfterTouch, not missing features:
+
+| Area                     | soundcork                             | AfterTouch                                                |
+|--------------------------|---------------------------------------|-----------------------------------------------------------|
+| Web UI                   | FastAPI + Jinja2 miniapp and admin UI | Separate `soundtouch-web` component (Go + plain HTML/JS)  |
+| Direct device management | SSH/SCP access into speakers          | HTTP API only; no SSH                                     |
+| Device discovery client  | Python `upnpclient` library           | mDNS + UPnP in Go, with dedicated DNS interception server |
+| Token delivery           | Push (ZeroConf priming to port 8200)  | Pull (device calls back to fetch)                         |
+| Persistence format       | Flat files                            | XML flat files + atomic writes                            |
+
+### AfterTouch capabilities soundcork lacks
+
+| Feature                                   | Notes                                                           |
+|-------------------------------------------|-----------------------------------------------------------------|
+| DNS server for device redirect            | Intercepts Bose domain queries; no Pi-hole required             |
+| HTTPS / custom CA injection               | Full TLS with certificate generation and trust workflow         |
+| HTTP interaction recording & replay       | Captures real device traffic for debugging and regression tests |
+| Device migration (serial → MAC path)      | Handles legacy device ID formats automatically                  |
+| Transparent proxy mode with upstream sync | Can mirror to real Bose cloud while running locally             |
+| CLI (`soundtouch-cli`)                    | Scriptable control of speakers                                  |
+| Importable Go library                     | `github.com/gesellix/bose-soundtouch/pkg/client`                |
+
+---
+
+
+
+### Ecosystem fragmentation vs. convergence
+
+The community is currently covering different parts of the problem in parallel rather than converging. AfterTouch explicitly credits soundcork, Überböse, and SoundTouch Plus in its README and describes its `soundtouch-service` as "heavily inspired by SoundCork". There is an opportunity — and arguably a need — for these projects to formally coordinate: shared test fixtures, a common compatibility matrix against specific firmware versions, and agreed-on API contracts would all reduce duplicated effort.
+
+### Firmware version sensitivity
+
+The SoundTouch 10 is most dependent on Marge for basic network functionality; the 20 and 30 are somewhat more tolerant. Compatibility across firmware versions is not systematically documented anywhere. A community firmware compatibility matrix (model × firmware version × which emulation features work) would be high value and is currently missing.
+
+### Security posture
+
+All projects warn that speakers should only be used on a private, firewalled network after cloud shutdown. AfterTouch is the only project to implement HTTPS/custom CA, which matters if devices are ever on a network where traffic could be inspected. soundcork's SECURITY.md explicitly warns against running on open networks.
+
+### No iOS app — a structural gap
+
+The original SoundTouch app was iOS-first. Every community replacement is Android-only (Überböse App) or browser-based. This is the largest unaddressed user segment in the ecosystem.
+
+### Bose's open-source move as a precedent
+
+Bose's decision to release API documentation rather than simply shutting down is notable — it mirrors what Pebble users did themselves with Rebble after that shutdown, but here the manufacturer initiated it. This sets a useful precedent and gives the community a solid legal and technical foundation to build on.
+
+### Related community resources
+
+- [Bose SoundTouch Plus (Home Assistant component)](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus) — comprehensive HA integration by Todd Lucas, extensive API wiki
+- [Bose SoundTouch Hook](https://github.com/CodeFinder2/bose-soundtouch-hook) — `LD_PRELOAD`-based reverse engineering framework used by AfterTouch for protocol research
+- [Bose SoundTouch Web API (community Markdown)](https://github.com/jaas666/bose-soundtouch-web-api) — official API PDF converted to Markdown
+- [Bose Wiki — SoundTouch App Alternatives](https://bose.fandom.com/wiki/SoundTouch_app_alternatives) — community-maintained living list of workarounds and projects
+- [Reddit megathread — Bose alternatives](https://www.reddit.com/r/bose) — ongoing community discussion
+- [Radio Browser](https://www.radio-browser.info/) — the free, community-maintained internet radio directory used as a TuneIn replacement
+
+---
+
+*Document compiled April 2026. Project details sourced directly from GitHub repositories and official documentation. Star counts, commit counts, and release dates reflect the state at time of writing and will change as projects evolve. soundcork-stockholm-app added April 2026.*

--- a/docs/analysis/bose-soundtouch-community-tools.md
+++ b/docs/analysis/bose-soundtouch-community-tools.md
@@ -71,7 +71,6 @@ The only native installable phone app in the ecosystem. Pairs with the Überbös
 
 ### 4. SoundTouch Hybrid 2026
 **[github.com/TJGigs/Bose-SoundTouch-Hybrid-2026](https://github.com/TJGigs/Bose-SoundTouch-Hybrid-2026)**
-(V3 variant: [github.com/TJGigs/Bose-SoundTouch-Hybrid-2026-V3](https://github.com/TJGigs/Bose-SoundTouch-Hybrid-2026-V3))
 | | |
 |---|---|
 | Language | Node.js (JavaScript) |

--- a/docs/concepts/spotify-priming-strategy.md
+++ b/docs/concepts/spotify-priming-strategy.md
@@ -38,7 +38,7 @@ AfterTouch adopts a **Server-Centric Hybrid Model** that prioritizes device clea
 AfterTouch replicates the native Bose "Add Source" experience. No Spotify priming occurs until a user explicitly links their Spotify account through the AfterTouch Management Dashboard. This ensures privacy and respects users who do not wish to use Spotify.
 
 ### 2. Device Cleanliness (Minimalist Footprint)
-We avoid invasive modifications to the speaker's filesystem. 
+We avoid invasive modifications to the speaker's filesystem.
 - **No On-Device Scripts:** We deprecate the use of internal boot-primer scripts.
 - **Native Communication:** We rely on the speaker's native ability to talk to Bose services, which are intercepted via DNS to point to the AfterTouch server.
 

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -22,6 +23,9 @@ import (
 	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/constants"
 )
+
+// ErrGroupNotFound is returned when no group is found for a given device.
+var ErrGroupNotFound = errors.New("group not found")
 
 func exists(path string) bool {
 	_, err := os.Stat(path)
@@ -1933,7 +1937,7 @@ func (ds *DataStore) GetGroupForDevice(account, deviceID string) (*models.Group,
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil, ErrGroupNotFound
 		}
 
 		return nil, err
@@ -1961,7 +1965,7 @@ func (ds *DataStore) GetGroupForDevice(account, deviceID string) (*models.Group,
 		}
 	}
 
-	return nil, nil
+	return nil, ErrGroupNotFound
 }
 
 // AddGroup saves a new group to disk and returns its generated ID.
@@ -2002,8 +2006,8 @@ func (ds *DataStore) ModifyGroup(account, groupID, newName string) (*models.Grou
 	}
 
 	var g models.Group
-	if err := xml.Unmarshal(data, &g); err != nil {
-		return nil, err
+	if xmlErr := xml.Unmarshal(data, &g); xmlErr != nil {
+		return nil, xmlErr
 	}
 
 	g.Name = newName

--- a/pkg/service/handlers/handlers_marge.go
+++ b/pkg/service/handlers/handlers_marge.go
@@ -687,7 +687,7 @@ func (s *Server) HandleMargeDeviceGroup(w http.ResponseWriter, r *http.Request) 
 	w.Header().Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
 
 	group, err := s.ds.GetGroupForDevice(account, device)
-	if err != nil || group == nil {
+	if err != nil {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(constants.XMLHeader + `<group/>`))
 
@@ -732,7 +732,7 @@ func (s *Server) HandleMargeAddGroup(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var group models.Group
-	if err := xml.Unmarshal(body, &group); err != nil {
+	if xmlErr := xml.Unmarshal(body, &group); xmlErr != nil {
 		http.Error(w, "Invalid XML", http.StatusBadRequest)
 		return
 	}
@@ -773,7 +773,7 @@ func (s *Server) HandleMargeModifyGroup(w http.ResponseWriter, r *http.Request) 
 	}
 
 	var req models.Group
-	if err := xml.Unmarshal(body, &req); err != nil {
+	if xmlErr := xml.Unmarshal(body, &req); xmlErr != nil {
 		http.Error(w, "Invalid XML", http.StatusBadRequest)
 		return
 	}

--- a/pkg/service/handlers/handlers_proxy.go
+++ b/pkg/service/handlers/handlers_proxy.go
@@ -113,6 +113,7 @@ func (s *Server) HandleNotFound(w http.ResponseWriter, r *http.Request) {
 
 		preview := body
 		truncated := ""
+
 		if len(preview) > 512 {
 			preview = preview[:512]
 			truncated = "…"

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -470,6 +470,7 @@ func (s *Server) pushSpotifyTokenToDevice(deviceIP, username, accessToken string
 	} else {
 		zcURL = fmt.Sprintf("http://%s:8200/zc", deviceIP)
 	}
+
 	return spotify.PushSpotifyCredentials(zcURL, username, accessToken)
 }
 

--- a/pkg/service/spotify/zeroconf.go
+++ b/pkg/service/spotify/zeroconf.go
@@ -51,9 +51,11 @@ func generateDHKeyPair() (privateKey *big.Int, publicKeyBytes []byte, err error)
 	if _, err = rand.Read(privBytes); err != nil {
 		return
 	}
+
 	privateKey = new(big.Int).SetBytes(privBytes)
 	pub := new(big.Int).Exp(dhGenerator, privateKey, dhPrime)
 	publicKeyBytes = padBigInt(pub, dhKeySize)
+
 	return
 }
 
@@ -61,6 +63,7 @@ func generateDHKeyPair() (privateKey *big.Int, publicKeyBytes []byte, err error)
 func computeSharedSecret(privateKey *big.Int, remotePublicKeyBytes []byte) []byte {
 	remote := new(big.Int).SetBytes(remotePublicKeyBytes)
 	shared := new(big.Int).Exp(remote, privateKey, dhPrime)
+
 	return padBigInt(shared, dhKeySize)
 }
 
@@ -76,6 +79,7 @@ func deriveKeys(sharedSecret []byte) (encKey, macKey []byte) {
 	hMac := hmac.New(sha1.New, baseKey)
 	hMac.Write([]byte("checksum"))
 	macKey = hMac.Sum(nil)
+
 	return
 }
 
@@ -125,6 +129,7 @@ func encryptBlob(encKey, macKey, plaintext []byte) ([]byte, error) {
 	out = append(out, iv...)
 	out = append(out, ciphertext...)
 	out = append(out, mac.Sum(nil)...)
+
 	return out, nil
 }
 
@@ -141,6 +146,7 @@ func decryptBlob(encKey, macKey, blob []byte) ([]byte, error) {
 
 	mac := hmac.New(sha1.New, macKey)
 	mac.Write(ciphertext)
+
 	if !hmac.Equal(mac.Sum(nil), gotMAC) {
 		return nil, fmt.Errorf("blob HMAC verification failed")
 	}
@@ -152,16 +158,19 @@ func decryptBlob(encKey, macKey, blob []byte) ([]byte, error) {
 
 	plaintext := make([]byte, len(ciphertext))
 	cipher.NewCTR(block, iv).XORKeyStream(plaintext, ciphertext)
+
 	return plaintext, nil
 }
 
 // ZeroConfGetInfo fetches the speaker's DH public key via GET ?action=getInfo.
 func ZeroConfGetInfo(zcBaseURL string) ([]byte, error) {
 	client := &http.Client{Timeout: 10 * time.Second}
+
 	resp, err := client.Get(zcBaseURL + "?action=getInfo")
 	if err != nil {
 		return nil, fmt.Errorf("getInfo: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
@@ -169,9 +178,10 @@ func ZeroConfGetInfo(zcBaseURL string) ([]byte, error) {
 	}
 
 	var info zcGetInfoResponse
-	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
-		return nil, fmt.Errorf("getInfo: decode: %w", err)
+	if decodeErr := json.NewDecoder(resp.Body).Decode(&info); decodeErr != nil {
+		return nil, fmt.Errorf("getInfo: decode: %w", decodeErr)
 	}
+
 	if info.PublicKey == "" {
 		return nil, fmt.Errorf("getInfo: empty publicKey")
 	}
@@ -184,6 +194,7 @@ func ZeroConfGetInfo(zcBaseURL string) ([]byte, error) {
 			return nil, fmt.Errorf("getInfo: invalid base64 publicKey: %w", err)
 		}
 	}
+
 	return pubKey, nil
 }
 
@@ -208,6 +219,7 @@ func PushSpotifyCredentials(zcBaseURL, username, accessToken string) error {
 	encKey, macKey := deriveKeys(sharedSecret)
 
 	plaintext := buildCredentialsBlob(username, accessToken)
+
 	encryptedBlob, err := encryptBlob(encKey, macKey, plaintext)
 	if err != nil {
 		return fmt.Errorf("pushSpotifyCredentials: encrypt: %w", err)
@@ -219,16 +231,19 @@ func PushSpotifyCredentials(zcBaseURL, username, accessToken string) error {
 	data.Set("clientKey", base64.StdEncoding.EncodeToString(ourPublicKeyBytes))
 
 	client := &http.Client{Timeout: 10 * time.Second}
+
 	resp, err := client.PostForm(zcBaseURL+"?action=addUser", data)
 	if err != nil {
 		return fmt.Errorf("pushSpotifyCredentials: addUser: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("pushSpotifyCredentials: addUser status %d: %s", resp.StatusCode, body)
 	}
+
 	return nil
 }
 
@@ -243,16 +258,19 @@ func pushSimplifiedToken(zcBaseURL, username, accessToken string) error {
 	data.Set("tokenType", "accesstoken")
 
 	client := &http.Client{Timeout: 10 * time.Second}
+
 	resp, err := client.PostForm(zcBaseURL+"?action=addUser", data)
 	if err != nil {
 		return fmt.Errorf("pushSimplifiedToken: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("pushSimplifiedToken: status %d: %s", resp.StatusCode, body)
 	}
+
 	return nil
 }
 
@@ -261,8 +279,10 @@ func padBigInt(n *big.Int, size int) []byte {
 	if len(b) >= size {
 		return b
 	}
+
 	out := make([]byte, size)
 	copy(out[size-len(b):], b)
+
 	return out
 }
 
@@ -271,5 +291,6 @@ func writeVarint(buf *bytes.Buffer, v uint64) {
 		buf.WriteByte(byte(v) | 0x80)
 		v >>= 7
 	}
+
 	buf.WriteByte(byte(v))
 }

--- a/pkg/service/spotify/zeroconf_test.go
+++ b/pkg/service/spotify/zeroconf_test.go
@@ -152,9 +152,9 @@ func TestPushSpotifyCredentials_FullRoundTrip(t *testing.T) {
 		case "getInfo":
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
-				"status":      101,
+				"status":       101,
 				"statusString": "OK",
-				"publicKey":   base64.StdEncoding.EncodeToString(speakerPublicBytes),
+				"publicKey":    base64.StdEncoding.EncodeToString(speakerPublicBytes),
 			})
 
 		case "addUser":
@@ -310,7 +310,6 @@ func parseCredentialsBlob(data []byte) (*parsedCredentials, error) {
 	}
 	return &r, nil
 }
-
 
 func readProtoVarint(data []byte) (uint64, int) {
 	var val uint64


### PR DESCRIPTION
- Mark ZeroConf Spotify priming and 404 handler as addressed in both docs
- Remove stale "Remaining gaps" and "Already adopted" tracking tables from community-tools.md; detail now lives in PARITY-SOUNDCORK.md
- Update PARITY-SOUNDCORK.md summary to reflect Groups and ZeroConf as done; add cross-reference to community-tools.md
- Rename remaining "gesellix" project references to "AfterTouch" throughout community-tools.md (URLs and author attribution unchanged)
- Add soundcork-stockholm-app (entry 7) to community projects list
- Correct DNS priority entry: built-in DNS server requires no external tools
