### PR TITLE
chore(compose): slim down base config, move test concerns to ci overlay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@
 
 # Docker/Service Settings
 SOUNDTOUCH_HOSTNAME=soundtouch.local
+SOUNDTOUCH_VERSION=latest
 
 # Discovery Settings
 DISCOVERY_TIMEOUT=5s

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       target: soundtouch-service
+    networks:
+      - soundtouch-test-net
     volumes:
       - ./tests/integration/testdata:/app/data
     environment:
@@ -14,3 +16,31 @@ services:
       - AMAZON_CLIENT_SECRET=mock-amazon-secret
       - AMAZON_TOKEN_URL=http://amazon-mock:8080/auth/o2/token
       - AMAZON_PROFILE_URL=http://amazon-mock:8080/user/profile
+
+  spotify-mock:
+    image: golang:1.26.2-alpine
+    container_name: spotify-mock
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: go run ./cmd/mock-spotify/main.go -port 8080
+    ports:
+      - "8081:8080"
+    networks:
+      - soundtouch-test-net
+
+  amazon-mock:
+    image: golang:1.26.2-alpine
+    container_name: amazon-mock
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: go run ./cmd/mock-amazon/main.go -port 8080
+    ports:
+      - "8082:8080"
+    networks:
+      - soundtouch-test-net
+
+networks:
+  soundtouch-test-net:
+    name: soundtouch-test-net

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   soundtouch-service:
-    image: ghcr.io/gesellix/bose-soundtouch:latest
+    image: ghcr.io/gesellix/bose-soundtouch:${SOUNDTOUCH_VERSION:-latest}
     # build: .
     container_name: soundtouch-service
     # Linux only, required for discovery. Swarm requires host network at the task level.
@@ -8,8 +8,6 @@ services:
     ports:
       - "8000:8000"
       - "8443:8443"
-    networks:
-      - soundtouch-test-net
     environment:
       - PORT=8000
       - HTTPS_PORT=8443
@@ -36,34 +34,6 @@ services:
         reservations:
           cpus: '0.25'
           memory: 128M
-
-  spotify-mock:
-    image: golang:1.26.2-alpine
-    container_name: spotify-mock
-    working_dir: /app
-    volumes:
-      - .:/app
-    command: go run ./cmd/mock-spotify/main.go -port 8080
-    ports:
-      - "8081:8080"
-    networks:
-      - soundtouch-test-net
-
-  amazon-mock:
-    image: golang:1.26.2-alpine
-    container_name: amazon-mock
-    working_dir: /app
-    volumes:
-      - .:/app
-    command: go run ./cmd/mock-amazon/main.go -port 8080
-    ports:
-      - "8082:8080"
-    networks:
-      - soundtouch-test-net
-
-networks:
-  soundtouch-test-net:
-    name: soundtouch-test-net
 
 volumes:
   soundtouch-data:


### PR DESCRIPTION
- Move spotify-mock and amazon-mock services to docker-compose.ci.yml
- Move soundtouch-test-net network definition to docker-compose.ci.yml
- Pin image version via SOUNDTOUCH_VERSION env var (defaults to 'latest')
- Document SOUNDTOUCH_VERSION in .env.example
