### PR TITLE
chore(build): add -trimpath to GitHub workflow build commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
           if [ "${{ matrix.goos }}" = "windows" ]; then
             output_name="${output_name}.exe"
           fi
-          go build -o "$output_name" ./cmd/soundtouch-cli
+          go build -trimpath -ldflags="-s -w" -o "$output_name" ./cmd/soundtouch-cli
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
@@ -220,7 +220,7 @@ jobs:
 
       - name: Test CLI build and help
         run: |
-          go build -o soundtouch-cli ./cmd/soundtouch-cli
+          go build -trimpath -ldflags="-s -w" -o soundtouch-cli ./cmd/soundtouch-cli
           ./soundtouch-cli -help
 
       - name: Test library imports

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,7 @@ jobs:
             rm -f "$OUTPUT_NAME" "$OUTPUT_NAME.sha256" "$OUTPUT_NAME.sha512"
 
             if ! go build \
+              -trimpath \
               -ldflags="-s -w" \
               -o "$OUTPUT_NAME" \
               "$CMD_PATH"; then


### PR DESCRIPTION
Consistent with the Makefile which already applies -trimpath globally.
