### PR TITLE
fix(client): default sourceAccount to "AUX" for AUX source selection

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -783,7 +783,11 @@ func (c *Client) SelectSource(source, sourceAccount string) error {
 	case "BLUETOOTH":
 		contentItem.ItemName = "Bluetooth"
 	case "AUX":
-		contentItem.ItemName = "AUX Input"
+		contentItem.ItemName = "AUX IN"
+		// The speaker rejects AUX with empty sourceAccount as INVALID_SOURCE.
+		if contentItem.SourceAccount == "" {
+			contentItem.SourceAccount = "AUX"
+		}
 	case "TUNEIN":
 		contentItem.ItemName = "TuneIn"
 	case "PANDORA":
@@ -818,7 +822,7 @@ func (c *Client) SelectBluetooth() error {
 	return c.SelectSource("BLUETOOTH", "")
 }
 
-// SelectAux is a convenience method to select AUX input
+// SelectAux is a convenience method to select AUX input.
 func (c *Client) SelectAux() error {
 	return c.SelectSource("AUX", "")
 }

--- a/pkg/client/source_selection_test.go
+++ b/pkg/client/source_selection_test.go
@@ -38,7 +38,7 @@ func TestClient_SelectSource(t *testing.T) {
 		{
 			name:          "Valid AUX source",
 			source:        "AUX",
-			sourceAccount: "",
+			sourceAccount: "AUX",
 			wantError:     false,
 		},
 		{
@@ -305,7 +305,7 @@ func TestClient_ConvenienceSourceMethods(t *testing.T) {
 			method:          "aux",
 			sourceAccount:   "",
 			expectedSource:  "AUX",
-			expectedAccount: "",
+			expectedAccount: "AUX",
 		},
 		{
 			name:            "SelectTuneIn",
@@ -530,7 +530,7 @@ func getExpectedItemName(source string) string {
 	case "BLUETOOTH":
 		return "Bluetooth"
 	case "AUX":
-		return "AUX Input"
+		return "AUX IN"
 	case "TUNEIN":
 		return "TuneIn"
 	case "PANDORA":


### PR DESCRIPTION
The speaker rejects /select with source="AUX" and an empty sourceAccount as INVALID_SOURCE, so the audio path never reaches APAuxSrc. Default the sourceAccount to "AUX" inside SelectSource and align ItemName to "AUX IN" to match the device's own button-press payload.

Relates to https://github.com/gesellix/Bose-SoundTouch/issues/195
