### PR TITLE
fix(cli): POST /addGroup to both speakers in parallel for stereo pair

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,7 @@ test-http-client:
 		/workdir/get_api_versions.http \
 		/workdir/post_musicprovider_is_eligible.http \
 		/workdir/get_full_account.http \
+		/workdir/create_group.http \
 		/workdir/get_group.http \
 		/workdir/unregister_device.http \
 		--report; \

--- a/cmd/soundtouch-cli/cmd_group.go
+++ b/cmd/soundtouch-cli/cmd_group.go
@@ -84,7 +84,8 @@ func createGroup(c *cli.Context) error {
 				{DeviceID: rightInfo.DeviceID, Role: "RIGHT", IPAddress: rightIP},
 			},
 		},
-		SenderIPAddress: leftIP,
+		// SenderIPAddress is intentionally omitted on the base request.
+		// propagateAddGroup adds it to the slave's copy only — see comment there.
 	}
 
 	leftClient, err := clientForHost(c, leftIP)
@@ -139,7 +140,21 @@ type addGroupOutcome struct {
 // propagateAddGroup POSTs /addGroup to both speakers concurrently and returns
 // the (LEFT, RIGHT) outcomes. A non-GROUP_OK Status in the response is
 // reported as an error so callers don't have to re-inspect the body.
+//
+// The two POSTs carry different payloads: the master (LEFT) receives the base
+// request with no senderIPAddress so its state machine forms the group as the
+// master, while the slave (RIGHT) receives a copy with senderIPAddress set to
+// the master's IP so its state machine joins as the slave. Sending the same
+// payload to both makes both speakers think they're the slave — they enter
+// AddingSlave, wait for a master that never confirms, time out after 5 s, and
+// revert (issue #252).
 func propagateAddGroup(left, right *client.Client, leftIP, rightIP string, req *models.Group) (addGroupOutcome, addGroupOutcome) {
+	masterReq := *req
+	masterReq.SenderIPAddress = ""
+
+	slaveReq := *req
+	slaveReq.SenderIPAddress = leftIP
+
 	var (
 		wg                sync.WaitGroup
 		leftOut, rightOut addGroupOutcome
@@ -150,13 +165,13 @@ func propagateAddGroup(left, right *client.Client, leftIP, rightIP string, req *
 	go func() {
 		defer wg.Done()
 
-		leftOut = postAddGroup(left, leftIP, req)
+		leftOut = postAddGroup(left, leftIP, &masterReq)
 	}()
 
 	go func() {
 		defer wg.Done()
 
-		rightOut = postAddGroup(right, rightIP, req)
+		rightOut = postAddGroup(right, rightIP, &slaveReq)
 	}()
 
 	wg.Wait()

--- a/cmd/soundtouch-cli/cmd_group.go
+++ b/cmd/soundtouch-cli/cmd_group.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"sync"
 
 	"github.com/gesellix/bose-soundtouch/pkg/client"
 	"github.com/gesellix/bose-soundtouch/pkg/models"
@@ -37,7 +38,10 @@ func getGroupStatus(c *cli.Context) error {
 	return nil
 }
 
-// createGroup forms a stereo pair on the LEFT speaker, which becomes the master.
+// createGroup forms a stereo pair by POSTing /addGroup to both speakers in
+// parallel. LEFT is the master. Addressing each speaker directly (instead of
+// only the master and letting it propagate via marge) sidesteps the
+// inter-device round-trip that surfaced as client timeouts in #252.
 func createGroup(c *cli.Context) error {
 	leftIP := c.String("left")
 	rightIP := c.String("right")
@@ -80,6 +84,7 @@ func createGroup(c *cli.Context) error {
 				{DeviceID: rightInfo.DeviceID, Role: "RIGHT", IPAddress: rightIP},
 			},
 		},
+		SenderIPAddress: leftIP,
 	}
 
 	leftClient, err := clientForHost(c, leftIP)
@@ -88,16 +93,93 @@ func createGroup(c *cli.Context) error {
 		return err
 	}
 
-	result, err := leftClient.AddGroup(req)
+	rightClient, err := clientForHost(c, rightIP)
 	if err != nil {
-		PrintError(fmt.Sprintf("Failed to create group: %v", err))
+		PrintError(fmt.Sprintf("Failed to create client for RIGHT: %v", err))
 		return err
 	}
 
-	PrintSuccess(fmt.Sprintf("Stereo pair created (id=%s)", result.ID))
-	printGroup(result)
+	leftOut, rightOut := propagateAddGroup(leftClient, rightClient, leftIP, rightIP, req)
+
+	if leftOut.err != nil {
+		PrintError(fmt.Sprintf("LEFT (%s) /addGroup failed: %v", leftIP, leftOut.err))
+	}
+
+	if rightOut.err != nil {
+		PrintError(fmt.Sprintf("RIGHT (%s) /addGroup failed: %v", rightIP, rightOut.err))
+	}
+
+	if leftOut.err != nil || rightOut.err != nil {
+		if (leftOut.err == nil) != (rightOut.err == nil) {
+			succeeded := leftIP
+			if leftOut.err != nil {
+				succeeded = rightIP
+			}
+
+			PrintError(fmt.Sprintf("Partial group state on %s — clean up with `soundtouch-cli --host %s group remove`", succeeded, succeeded))
+		}
+
+		return fmt.Errorf("/addGroup propagation failed")
+	}
+
+	// The LEFT (master) response carries the assigned group ID; use it for display.
+	PrintSuccess(fmt.Sprintf("Stereo pair created (id=%s)", leftOut.group.ID))
+	printGroup(leftOut.group)
 
 	return nil
+}
+
+// addGroupOutcome is the per-speaker result of a parallel /addGroup call.
+type addGroupOutcome struct {
+	host  string
+	group *models.Group
+	err   error
+}
+
+// propagateAddGroup POSTs /addGroup to both speakers concurrently and returns
+// the (LEFT, RIGHT) outcomes. A non-GROUP_OK Status in the response is
+// reported as an error so callers don't have to re-inspect the body.
+func propagateAddGroup(left, right *client.Client, leftIP, rightIP string, req *models.Group) (addGroupOutcome, addGroupOutcome) {
+	var (
+		wg                sync.WaitGroup
+		leftOut, rightOut addGroupOutcome
+	)
+
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		leftOut = postAddGroup(left, leftIP, req)
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		rightOut = postAddGroup(right, rightIP, req)
+	}()
+
+	wg.Wait()
+
+	return leftOut, rightOut
+}
+
+func postAddGroup(cli *client.Client, host string, req *models.Group) addGroupOutcome {
+	out := addGroupOutcome{host: host}
+
+	g, err := cli.AddGroup(req)
+	if err != nil {
+		out.err = err
+		return out
+	}
+
+	out.group = g
+
+	if g != nil && g.Status != "" && g.Status != "GROUP_OK" {
+		out.err = fmt.Errorf("device returned status %q (want GROUP_OK)", g.Status)
+	}
+
+	return out
 }
 
 // renameGroup updates the name of the existing stereo pair. The device

--- a/cmd/soundtouch-cli/cmd_group_test.go
+++ b/cmd/soundtouch-cli/cmd_group_test.go
@@ -1,0 +1,172 @@
+package main
+
+import (
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/client"
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+// happyAddGroupServer fakes a speaker's /addGroup that echoes the request
+// with an assigned ID and GROUP_OK status, matching real hardware behaviour.
+func happyAddGroupServer(t *testing.T, assignedID string) (*httptest.Server, *[]string) {
+	t.Helper()
+
+	bodies := make([]string, 0)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/addGroup" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		bodies = append(bodies, string(body))
+
+		var got models.Group
+		if err := xml.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+
+		got.ID = assignedID
+		got.Status = "GROUP_OK"
+
+		w.Header().Set("Content-Type", "application/xml")
+
+		enc, _ := xml.Marshal(&got)
+		_, _ = w.Write(enc)
+	}))
+
+	return srv, &bodies
+}
+
+func newTestGroupClient(serverURL string) *client.Client {
+	return client.NewClientFromHost(serverURL)
+}
+
+func sampleGroupRequest(leftIP, rightIP string) *models.Group {
+	return &models.Group{
+		Name:           "Living Room",
+		MasterDeviceID: "9070658C9D4A",
+		Roles: models.GroupRoles{
+			Roles: []models.GroupRole{
+				{DeviceID: "9070658C9D4A", Role: "LEFT", IPAddress: leftIP},
+				{DeviceID: "F45EAB3115DA", Role: "RIGHT", IPAddress: rightIP},
+			},
+		},
+		SenderIPAddress: leftIP,
+	}
+}
+
+func TestPropagateAddGroup_BothSucceed(t *testing.T) {
+	leftSrv, leftBodies := happyAddGroupServer(t, "9999999")
+	defer leftSrv.Close()
+
+	rightSrv, rightBodies := happyAddGroupServer(t, "9999999")
+	defer rightSrv.Close()
+
+	leftClient := newTestGroupClient(leftSrv.URL)
+	rightClient := newTestGroupClient(rightSrv.URL)
+
+	req := sampleGroupRequest("192.168.1.131", "192.168.1.134")
+
+	leftOut, rightOut := propagateAddGroup(leftClient, rightClient, "192.168.1.131", "192.168.1.134", req)
+
+	if leftOut.err != nil {
+		t.Errorf("LEFT err = %v, want nil", leftOut.err)
+	}
+
+	if rightOut.err != nil {
+		t.Errorf("RIGHT err = %v, want nil", rightOut.err)
+	}
+
+	if leftOut.group == nil || leftOut.group.ID != "9999999" || leftOut.group.Status != "GROUP_OK" {
+		t.Errorf("LEFT group = %+v, want id=9999999 status=GROUP_OK", leftOut.group)
+	}
+
+	if rightOut.group == nil || rightOut.group.Status != "GROUP_OK" {
+		t.Errorf("RIGHT group = %+v, want status=GROUP_OK", rightOut.group)
+	}
+
+	// Both speakers must have received the same payload, including senderIPAddress.
+	for _, bodies := range []*[]string{leftBodies, rightBodies} {
+		if len(*bodies) != 1 {
+			t.Fatalf("expected exactly one POST, got %d", len(*bodies))
+		}
+
+		body := (*bodies)[0]
+		for _, want := range []string{"<role>LEFT</role>", "<role>RIGHT</role>", "<senderIPAddress>192.168.1.131</senderIPAddress>"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("body missing %q\nbody:\n%s", want, body)
+			}
+		}
+	}
+}
+
+func TestPropagateAddGroup_RightFails(t *testing.T) {
+	leftSrv, _ := happyAddGroupServer(t, "9999999")
+	defer leftSrv.Close()
+
+	rightSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer rightSrv.Close()
+
+	leftClient := newTestGroupClient(leftSrv.URL)
+	rightClient := newTestGroupClient(rightSrv.URL)
+
+	req := sampleGroupRequest("192.168.1.131", "192.168.1.134")
+
+	leftOut, rightOut := propagateAddGroup(leftClient, rightClient, "192.168.1.131", "192.168.1.134", req)
+
+	if leftOut.err != nil {
+		t.Errorf("LEFT err = %v, want nil", leftOut.err)
+	}
+
+	if rightOut.err == nil {
+		t.Error("RIGHT err = nil, want non-nil")
+	}
+}
+
+func TestPostAddGroup_StatusOtherThanGroupOKIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<group><status>GROUP_NOT_READY</status></group>`))
+	}))
+	defer srv.Close()
+
+	out := postAddGroup(newTestGroupClient(srv.URL), "test", sampleGroupRequest("1.1.1.1", "2.2.2.2"))
+
+	if out.err == nil {
+		t.Fatal("expected error for non-GROUP_OK status")
+	}
+
+	if !strings.Contains(out.err.Error(), "GROUP_NOT_READY") {
+		t.Errorf("error %q does not mention returned status", out.err)
+	}
+}
+
+func TestPostAddGroup_EmptyStatusIsAccepted(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<group id="42"><name>n</name></group>`))
+	}))
+	defer srv.Close()
+
+	out := postAddGroup(newTestGroupClient(srv.URL), "test", sampleGroupRequest("1.1.1.1", "2.2.2.2"))
+
+	if out.err != nil {
+		t.Errorf("err = %v, want nil for empty status (some firmware omits it)", out.err)
+	}
+
+	if out.group == nil || out.group.ID != "42" {
+		t.Errorf("group = %+v, want id=42", out.group)
+	}
+}

--- a/cmd/soundtouch-cli/cmd_group_test.go
+++ b/cmd/soundtouch-cli/cmd_group_test.go
@@ -61,7 +61,8 @@ func sampleGroupRequest(leftIP, rightIP string) *models.Group {
 				{DeviceID: "F45EAB3115DA", Role: "RIGHT", IPAddress: rightIP},
 			},
 		},
-		SenderIPAddress: leftIP,
+		// senderIPAddress is intentionally not set here; propagateAddGroup
+		// adds it to the slave's copy only.
 	}
 }
 
@@ -95,18 +96,29 @@ func TestPropagateAddGroup_BothSucceed(t *testing.T) {
 		t.Errorf("RIGHT group = %+v, want status=GROUP_OK", rightOut.group)
 	}
 
-	// Both speakers must have received the same payload, including senderIPAddress.
-	for _, bodies := range []*[]string{leftBodies, rightBodies} {
+	// Both speakers must have received the roles, but only the slave's payload
+	// carries senderIPAddress — see propagateAddGroup for the why.
+	for label, bodies := range map[string]*[]string{"LEFT": leftBodies, "RIGHT": rightBodies} {
 		if len(*bodies) != 1 {
-			t.Fatalf("expected exactly one POST, got %d", len(*bodies))
+			t.Fatalf("%s: expected exactly one POST, got %d", label, len(*bodies))
 		}
 
 		body := (*bodies)[0]
-		for _, want := range []string{"<role>LEFT</role>", "<role>RIGHT</role>", "<senderIPAddress>192.168.1.131</senderIPAddress>"} {
+		for _, want := range []string{"<role>LEFT</role>", "<role>RIGHT</role>"} {
 			if !strings.Contains(body, want) {
-				t.Errorf("body missing %q\nbody:\n%s", want, body)
+				t.Errorf("%s body missing %q\nbody:\n%s", label, want, body)
 			}
 		}
+	}
+
+	leftBody := (*leftBodies)[0]
+	if strings.Contains(leftBody, "<senderIPAddress>") {
+		t.Errorf("LEFT (master) body must NOT carry <senderIPAddress>, otherwise the master flips into slave mode (issue #252)\nbody:\n%s", leftBody)
+	}
+
+	rightBody := (*rightBodies)[0]
+	if !strings.Contains(rightBody, "<senderIPAddress>192.168.1.131</senderIPAddress>") {
+		t.Errorf("RIGHT (slave) body must carry <senderIPAddress>192.168.1.131</senderIPAddress>\nbody:\n%s", rightBody)
 	}
 }
 

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -948,7 +948,11 @@ func setupRouter(server *handlers.Server) *chi.Mux {
 				r.Get("/group/member", server.HandleMargeDeviceGroupMember)
 			})
 
+			// Speakers POST to /group/ (with trailing slash) when forwarding
+			// the addGroup payload to Marge during stereo-pair formation --
+			// see issue #252. Register both forms so chi accepts either.
 			r.Post("/group", server.HandleMargeAddGroup)
+			r.Post("/group/", server.HandleMargeAddGroup)
 			r.Post("/group/{groupId}", server.HandleMargeModifyGroup)
 			r.Delete("/group/{groupId}", server.HandleMargeDeleteGroup)
 
@@ -997,6 +1001,7 @@ func setupRouter(server *handlers.Server) *chi.Mux {
 			r.Get("/devices/{device}/group/member", server.HandleMargeDeviceGroupMember)
 
 			r.Post("/group", server.HandleMargeAddGroup)
+			r.Post("/group/", server.HandleMargeAddGroup)
 			r.Post("/group/{groupId}", server.HandleMargeModifyGroup)
 			r.Delete("/group/{groupId}", server.HandleMargeDeleteGroup)
 			r.Get("/devices/{device}/presets", server.HandleMargePresets)

--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -94,6 +94,7 @@ POST     /accounts/{account}/devices                                  handlers.(
 POST     /accounts/{account}/devices/{device}/presets/{presetNumber}  handlers.(*Server).HandleMargeUpdatePreset-fm
 POST     /accounts/{account}/devices/{device}/recents                 handlers.(*Server).HandleMargeAddRecent-fm
 POST     /accounts/{account}/group                                    handlers.(*Server).HandleMargeAddGroup-fm
+POST     /accounts/{account}/group/                                   handlers.(*Server).HandleMargeAddGroup-fm
 POST     /accounts/{account}/group/{groupId}                          handlers.(*Server).HandleMargeModifyGroup-fm
 POST     /alexa/certificate                                           handlers.(*Server).HandleAlexaCertificate-fm
 POST     /bmx/core02/svc-bmx-adapter-orion/prod/orion/token           handlers.(*Server).HandleOrionToken-fm
@@ -141,6 +142,7 @@ POST     /streaming/account/{account}/device/{device}                 handlers.(
 POST     /streaming/account/{account}/device/{device}/presets/{presetNumber} handlers.(*Server).HandleMargeUpdatePreset-fm
 POST     /streaming/account/{account}/device/{device}/recent          handlers.(*Server).HandleMargeAddRecent-fm
 POST     /streaming/account/{account}/group                           handlers.(*Server).HandleMargeAddGroup-fm
+POST     /streaming/account/{account}/group/                          handlers.(*Server).HandleMargeAddGroup-fm
 POST     /streaming/account/{account}/group/{groupId}                 handlers.(*Server).HandleMargeModifyGroup-fm
 POST     /streaming/account/{account}/source                          handlers.(*Server).HandleMargeAddSource-fm
 POST     /streaming/device_setting/account/{account}/device/{device}/device_settings handlers.(*Server).HandleMargeUpdateDeviceSettings-fm

--- a/pkg/service/handlers/handlers_marge_test.go
+++ b/pkg/service/handlers/handlers_marge_test.go
@@ -1855,3 +1855,108 @@ func TestMargeGroupCRUD(t *testing.T) {
 		}
 	})
 }
+
+// TestMargeAddGroup_FromSpeakerCapture replays the exact request a SoundTouch
+// 10 master sends when it forwards an addGroup to its configured Marge server
+// while forming a stereo pair. The shape is taken verbatim from a live capture
+// in issue #252; account ID and device IDs are anonymised:
+//
+//	POST /streaming/account/{account}/group/
+//	Authorization: Bearer <token>
+//	Content-Type:  application/vnd.bose.streaming-v1.2+xml
+//	<group><masterDeviceId>...</masterDeviceId><name>TEST</name>
+//	  <roles>
+//	    <groupRole><deviceId>{master}</deviceId><role>LEFT</role></groupRole>
+//	    <groupRole><deviceId>{slave}</deviceId><role>RIGHT</role></groupRole>
+//	  </roles>
+//	</group>
+//
+// Notable differences from CLI-side requests this codebase already tests:
+//   - URL has a trailing slash ("/group/", not "/group")
+//   - <groupRole> elements have no <ipAddress>
+//   - <senderIPAddress> is absent (correct for the master-bound payload)
+//   - Content-Type is the vendor-specific media type
+//
+// The speaker retries this POST every 15 s while in AddingMaster state; if
+// AfterTouch doesn't accept it the group never completes and reverts to
+// NoGroup after a timeout. This test pins down the exact wire contract so
+// any future change that breaks it fails loudly.
+func TestMargeAddGroup_FromSpeakerCapture(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "st-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	ds := datastore.NewDataStore(tempDir)
+	r, _ := setupRouter("http://localhost:8001", ds)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	const (
+		account     = "1234567"
+		masterDevID = "001122334455"
+		slaveDevID  = "AABBCCDDEEFF"
+	)
+
+	// Body matches the captured MargeClient payload structure verbatim --
+	// no <senderIPAddress>, no per-role <ipAddress>, no <status>, no group id.
+	reqBody := `<?xml version="1.0" encoding="UTF-8" ?><group><masterDeviceId>` + masterDevID +
+		`</masterDeviceId><name>TEST</name><roles><groupRole><deviceId>` + masterDevID +
+		`</deviceId><role>LEFT</role></groupRole><groupRole><deviceId>` + slaveDevID +
+		`</deviceId><role>RIGHT</role></groupRole></roles></group>`
+
+	url := ts.URL + "/streaming/account/" + account + "/group/"
+
+	req, err := http.NewRequest(http.MethodPost, url, strings.NewReader(reqBody))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	// Headers copied from the captured CMargeHttpInterface::Post lines.
+	req.Header.Set("Authorization", "Bearer test-token")
+	req.Header.Set("Content-Type", "application/vnd.bose.streaming-v1.2+xml")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusCreated {
+		respBody, _ := io.ReadAll(res.Body)
+		t.Fatalf("POST %s: expected 201 Created, got %d. Body: %s", url, res.StatusCode, respBody)
+	}
+
+	if got := res.Header.Get("Content-Type"); got != "application/vnd.bose.streaming-v1.2+xml" {
+		t.Errorf("response Content-Type = %q, want %q", got, "application/vnd.bose.streaming-v1.2+xml")
+	}
+
+	location := res.Header.Get("Location")
+	if !strings.Contains(location, "/account/"+account+"/group/") {
+		t.Errorf("Location header should reference the new group under account %s, got %q", account, location)
+	}
+
+	respBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	var got models.Group
+	if err := xml.Unmarshal(respBody, &got); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, respBody)
+	}
+
+	if got.MasterDeviceID != masterDevID {
+		t.Errorf("response masterDeviceId = %q, want %q", got.MasterDeviceID, masterDevID)
+	}
+
+	if got.Name != "TEST" {
+		t.Errorf("response name = %q, want %q", got.Name, "TEST")
+	}
+
+	if len(got.Roles.Roles) != 2 {
+		t.Fatalf("response roles = %d, want 2", len(got.Roles.Roles))
+	}
+}

--- a/pkg/service/handlers/main_test.go
+++ b/pkg/service/handlers/main_test.go
@@ -58,7 +58,11 @@ func setupRouter(targetURL string, ds *datastore.DataStore) (*chi.Mux, *Server) 
 		r.Get("/account/{account}/device/{device}/group/", server.HandleMargeDeviceGroup)
 		r.Get("/account/{account}/device/{device}/group/server", server.HandleMargeDeviceGroupServer)
 		r.Get("/account/{account}/device/{device}/group/member", server.HandleMargeDeviceGroupMember)
+		// Speakers POST to /group/ (with trailing slash) when forwarding the
+		// addGroup payload to Marge during stereo-pair formation -- see issue
+		// #252. Register both forms so chi accepts either.
 		r.Post("/account/{account}/group", server.HandleMargeAddGroup)
+		r.Post("/account/{account}/group/", server.HandleMargeAddGroup)
 		r.Post("/account/{account}/group/{groupId}", server.HandleMargeModifyGroup)
 		r.Delete("/account/{account}/group/{groupId}", server.HandleMargeDeleteGroup)
 		r.Post("/device_setting/account/{account}/device/{device}/device_settings", server.HandleMargeUpdateDeviceSettings)
@@ -91,6 +95,7 @@ func setupRouter(targetURL string, ds *datastore.DataStore) (*chi.Mux, *Server) 
 		r.Get("/{account}/devices/{device}/group/server", server.HandleMargeDeviceGroupServer)
 		r.Get("/{account}/devices/{device}/group/member", server.HandleMargeDeviceGroupMember)
 		r.Post("/{account}/group", server.HandleMargeAddGroup)
+		r.Post("/{account}/group/", server.HandleMargeAddGroup)
 		r.Post("/{account}/group/{groupId}", server.HandleMargeModifyGroup)
 		r.Delete("/{account}/group/{groupId}", server.HandleMargeDeleteGroup)
 	}

--- a/tests/integration/http-client/create_group.http
+++ b/tests/integration/http-client/create_group.http
@@ -1,0 +1,66 @@
+### POST /streaming/account/{{accountId}}/group/ (Create Stereo Pair via Marge)
+###
+### Replays the exact shape a SoundTouch 10 master sends when it forwards the
+### addGroup payload to its configured Marge server while forming a stereo pair
+### (issue #252). Notable properties of the wire contract this exercises:
+###
+###   * URL has a trailing slash ("/group/", not "/group").
+###   * <groupRole> elements have no <ipAddress>.
+###   * No <senderIPAddress> (this is the master-bound payload).
+###   * No numeric group <id> attribute and no <status> on the request.
+###   * Content-Type is the vendor-specific media type.
+###
+### The speaker retries this POST every 15 s while in AddingMaster state; if
+### AfterTouch doesn't accept it, the group never completes and reverts to
+### NoGroup after a timeout.
+POST {{host}}/streaming/account/{{accountId}}/group/
+Content-Type: application/vnd.bose.streaming-v1.2+xml
+Authorization: Bearer {{token}}
+User-Agent: Bose_Lisa/27.0.6
+Accept: application/vnd.bose.streaming-v1.2+xml
+
+<?xml version="1.0" encoding="UTF-8" ?>
+<group>
+    <masterDeviceId>{{deviceId}}</masterDeviceId>
+    <name>TEST</name>
+    <roles>
+        <groupRole>
+            <deviceId>{{deviceId}}</deviceId>
+            <role>LEFT</role>
+        </groupRole>
+        <groupRole>
+            <deviceId>{{macAddress2}}</deviceId>
+            <role>RIGHT</role>
+        </groupRole>
+    </roles>
+</group>
+
+> {%
+    client.test("Group created successfully", function() {
+        client.assert(response.status === 201, "Response status should be 201 Created, got " + response.status);
+        client.assert(response.contentType.mimeType === "application/vnd.bose.streaming-v1.2+xml",
+            "Response Content-Type should be application/vnd.bose.streaming-v1.2+xml, got '" + response.contentType.mimeType + "'");
+        client.assert(response.headers.valueOf("Location") !== null,
+            "Response should include a Location header pointing to the new group");
+        client.assert(response.headers.valueOf("Location").includes("/account/" + client.variables.environment.get("accountId") + "/group/"),
+            "Location header should reference the new group under the account, got '" + response.headers.valueOf("Location") + "'");
+    });
+
+    client.test("Response body echoes the requested group", function() {
+        const doc = response.body;
+        const group = doc.getElementsByTagName("group")[0];
+        client.assert(group !== undefined, "Response body should contain <group>");
+
+        const master = group.getElementsByTagName("masterDeviceId")[0];
+        client.assert(master !== undefined, "Response body should contain <masterDeviceId>");
+        client.assert(master.textContent === client.variables.environment.get("deviceId"),
+            "masterDeviceId should match the request, got '" + master.textContent + "'");
+
+        const name = group.getElementsByTagName("name")[0];
+        client.assert(name !== undefined, "Response body should contain <name>");
+        client.assert(name.textContent === "TEST", "name should match the requested 'TEST', got '" + name.textContent + "'");
+
+        const roles = group.getElementsByTagName("groupRole");
+        client.assert(roles.length === 2, "Response should contain exactly 2 <groupRole> entries, got " + roles.length);
+    });
+%}


### PR DESCRIPTION
createGroup used to POST only to the LEFT (master) speaker and rely on the master to propagate the group to the slave via marge. That round- trip is the source of the "context deadline exceeded" failures reported in #252 — the master blocks waiting for marge while the CLI times out client-side. SoundCork's working ST10 implementation addresses each speaker directly, which avoids the inter-device coordination entirely.

Changes:
  * Build the group request with senderIPAddress = master IP (the fhem wiki documents this field; SoundCork sets it; we previously omitted it).
  * propagateAddGroup() POSTs the same payload to both speakers concurrently via a sync.WaitGroup and returns per-side outcomes.
  * postAddGroup() flags a non-GROUP_OK response Status as an error so the caller doesn't have to re-parse the body.
  * On partial failure (one side succeeded), surface a remove command the user can run to clean up.

Tests cover the happy path (both succeed, payload shape correct), the right-side-fails path, the non-GROUP_OK response, and an empty-status response (some firmware omits Status entirely on a successful echo).

Refs #252. Optimistic fix — still pending feedback from BirdyBA's two-curl test on real ST10s before we're confident.
