### PR TITLE
fix: exclude AUX from cloud /full+/sources to unblock post-pair dispatch (#195, #269)

### DIFF
--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -404,7 +404,7 @@ func setupWiFiPushCmd() *cli.Command {
 			&cli.StringFlag{Name: "pass", Required: true, Usage: "Home Wi-Fi password"},
 			&cli.StringFlag{Name: "security", Value: setup.DefaultWiFiSecurity, Usage: "Security type (wpa_or_wpa2, wep, open)"},
 			&cli.StringFlag{Name: "ap-host", Value: setup.SpeakerSetupAP, Usage: "Speaker's setup-mode IP"},
-			&cli.DurationFlag{Name: "request-timeout", Value: 10 * time.Second},
+			&cli.DurationFlag{Name: "request-timeout", Value: 30 * time.Second, Usage: "Per-request timeout (the speaker can be slow to ACK before tearing down AP mode; 10 s often races)"},
 		},
 		Action: func(c *cli.Context) error {
 			params := setup.PushWiFiCredentialsParams{

--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -1353,10 +1353,11 @@ func setupPairCmd() *cli.Command {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "account", Usage: "7-digit account ID (empty = generate)"},
 			&cli.StringFlag{Name: "mode", Value: "full", Usage: "full (state machine) or bare (setMargeAccount only — experimental)"},
-			&cli.StringFlag{Name: "service-url", Value: "http://aftertouch.local:8000", Usage: "AfterTouch base URL (used by mode=full for defaults)"},
+			&cli.StringFlag{Name: "service-url", Value: "http://aftertouch.local:8000", Usage: "AfterTouch base URL (also populates <boseServer>/<updateServer> in setMargeAccount)"},
 			&cli.StringFlag{Name: "name", Usage: "Speaker name to set during pairing (empty = keep current)"},
 			&cli.IntFlag{Name: "language", Value: setup.LanguageEnglish, Usage: "sysLanguage code (2 = English)"},
 			&cli.DurationFlag{Name: "step-timeout", Value: 8 * time.Second},
+			&cli.StringFlag{Name: "token", Usage: "userAuthToken value (empty = use built-in placeholder matching the Bose app token shape)"},
 		},
 		Action: func(c *cli.Context) error {
 			cfg := GetClientConfig(c)
@@ -1401,8 +1402,20 @@ func runPairBare(c *cli.Context, deviceIP, accountID string) error {
 	fmt.Printf("pre  /info deviceID=%s margeAccountUUID=%q margeURL=%q\n",
 		info.DeviceID, info.MargeAccountUUID, info.MargeURL)
 
+	// Service URL drives the extended <PairDeviceWithAccount> payload
+	// (boseServer/updateServer/accountEmail). When empty, the session
+	// falls back to the minimal historical shape (accountId +
+	// userAuthToken only).
+	serviceURL := c.String("service-url")
+
+	var extras setup.MargePairingExtras
+	if serviceURL != "" {
+		extras = setup.MargePairingExtras{BoseServer: serviceURL}
+	}
+
 	session, err := setup.DialSession(deviceIP, info.DeviceID, setup.SessionConfig{
-		StepTimeout: c.Duration("step-timeout"),
+		StepTimeout:   c.Duration("step-timeout"),
+		PairingExtras: extras,
 	})
 	if err != nil {
 		return fmt.Errorf("dial WS: %w", err)
@@ -1413,9 +1426,13 @@ func runPairBare(c *cli.Context, deviceIP, accountID string) error {
 	ctx, cancel := context.WithTimeout(c.Context, c.Duration("step-timeout")+2*time.Second)
 	defer cancel()
 
-	fmt.Printf("→ setMargeAccount accountID=%s (no SETUP bracket)\n", accountID)
+	if serviceURL != "" {
+		fmt.Printf("→ setMargeAccount accountID=%s (extended: boseServer=%s)\n", accountID, serviceURL)
+	} else {
+		fmt.Printf("→ setMargeAccount accountID=%s (minimal payload, no SETUP bracket)\n", accountID)
+	}
 
-	if pairErr := session.SetMargeAccount(ctx, accountID, ""); pairErr != nil {
+	if pairErr := session.SetMargeAccount(ctx, accountID, c.String("token")); pairErr != nil {
 		PrintError(fmt.Sprintf("setMargeAccount: %v", pairErr))
 		return pairErr
 	}

--- a/docs/guides/MIGRATION-GUIDE.md
+++ b/docs/guides/MIGRATION-GUIDE.md
@@ -206,6 +206,82 @@ Each speaker is migrated independently. You can run multiple migrations in paral
 
 ---
 
+## Alternative: CLI-driven factory-reset workflow
+
+If you prefer scripting the migration, or the wizard isn't an option (headless server, automation, batch onboarding of many speakers), `soundtouch-cli` exposes the same building blocks. The flow below is **not** an in-place migration — it factory-resets the speaker and brings it up fresh against AfterTouch, so any data Bose preserved on the device is wiped. Use this when:
+
+- You're starting from a factory-reset speaker anyway.
+- The wizard's in-place migration didn't take and you want a clean slate.
+- You're scripting setup for many speakers and want a reproducible recipe.
+
+### Prerequisites
+
+- AfterTouch service running and reachable at a stable URL (e.g., `https://soundtouch.local` from your `.env`).
+- The speaker reachable on its current IP (passed as `--host`).
+- For the AP-mode handover step, your laptop must be able to join the speaker's `Bose SoundTouch` Wi-Fi (you'll switch between home Wi-Fi and the speaker's AP).
+
+### The full sequence
+
+```bash
+# 1. Plan what the reset+pair pipeline will write (dry run, no changes yet).
+soundtouch-cli --host 192.168.1.50 setup plan \
+  --reset=true --include-pair=false \
+  --service-url='https://soundtouch.local'
+
+# 2. Trigger the factory reset. The speaker reboots into AP mode.
+soundtouch-cli --host 192.168.1.50 setup factory-reset
+
+# --- Manual step: join the speaker's Wi-Fi AP (SSID "Bose SoundTouch ...") ---
+
+# 3. Wait for the AP-mode endpoint to answer.
+soundtouch-cli setup wait-ap
+
+# 4. Push your home Wi-Fi credentials to the speaker.
+#    Run twice if the first attempt's ACK races the AP teardown — the second
+#    one is a no-op if the first succeeded.
+soundtouch-cli setup wifi-push --ssid="YourHomeSSID" --pass='your-wifi-password'
+
+# --- Manual step: switch your laptop back to the home Wi-Fi network ---
+
+# 5. Wait for the speaker to come back online on the home network.
+#    --match takes the last 4-6 hex chars of the speaker's MAC (visible on
+#    the bottom of the device).
+soundtouch-cli setup wait-online --match=42CAFE
+
+# 6. Pair the speaker with an AfterTouch account.
+#    --mode=full runs the canonical WebSocket SETUP sequence (matches the
+#    Bose app's flow); --account is the 7-digit account ID AfterTouch
+#    should attach the speaker to.
+soundtouch-cli --host 192.168.1.50 setup pair \
+  --mode=full --account=1111111 \
+  --service-url='https://soundtouch.local'
+```
+
+### Verifying the result
+
+After pairing completes:
+
+- The speaker should appear on the **Devices** tab in the web UI.
+- AUX should switch and play audio when selected.
+- Pressing presets should fetch their content from AfterTouch (the `[LOG]` rows on the service confirm).
+- TuneIn search and playback should work end-to-end.
+
+If any of these fail post-pair, see [Troubleshooting](TROUBLESHOOTING.md) — most commonly the speaker just needs a power cycle to pick up everything cleanly.
+
+### Differences vs the wizard
+
+| Aspect                              | Wizard (in-place migration)                             | CLI factory-reset workflow                              |
+|-------------------------------------|---------------------------------------------------------|---------------------------------------------------------|
+| Preserves speaker's existing state  | yes (Presets, recents, attached account)                | **no** — wipes everything                               |
+| Requires Wi-Fi-network switching    | no                                                      | yes (laptop joins speaker AP, then home network)        |
+| Scriptable / reproducible           | clickable, not scriptable                               | full bash recipe                                        |
+| Cloud-side data (Bose Marge backup) | preserved if Sync ran while cloud was alive             | not relevant — fresh account on AfterTouch              |
+| Best for                            | "I want this speaker to keep working with what's on it" | "I want a clean, reproducible setup against AfterTouch" |
+
+The wizard is still the recommended path for a one-off migration of an existing setup. The CLI workflow is the right choice when you're scripting, batching, or already starting from a reset.
+
+---
+
 ## Rollback
 
 If you need to undo a migration:

--- a/pkg/service/handlers/handlers_marge_test.go
+++ b/pkg/service/handlers/handlers_marge_test.go
@@ -64,12 +64,16 @@ func TestMargeCreateAccount(t *testing.T) {
 		t.Errorf("Expected 7-digit ID, got %v", resp.ID)
 	}
 
-	// Verify it has default sources
-	if len(resp.Sources) != 5 {
-		t.Errorf("Expected 5 default sources, got %d", len(resp.Sources))
+	// Verify default sources. AUX (id=10001, sourceproviderid=9) is
+	// intentionally excluded from cloud responses — real Bose never
+	// emitted AUX in /full; the speaker enumerates AUX from its own
+	// hardware via isLocal=true in :8090/sources. See
+	// pkg/service/marge/marge.go getAccountSources.
+	if len(resp.Sources) != 4 {
+		t.Errorf("Expected 4 cloud default sources (AUX excluded), got %d", len(resp.Sources))
 	} else {
-		if resp.Sources[0].ID != "10001" {
-			t.Errorf("Expected first source ID 10001, got %s", resp.Sources[0].ID)
+		if resp.Sources[0].ID != "10002" {
+			t.Errorf("Expected first cloud source ID 10002 (INTERNET_RADIO), got %s", resp.Sources[0].ID)
 		}
 	}
 
@@ -380,10 +384,12 @@ func TestMargeAccountFullExcludesEmptyAmazonSource(t *testing.T) {
 		t.Errorf("/full response must not include an empty-credential Amazon source; body:\n%s", bodyStr)
 	}
 
-	// The 6 sources from lastDeviceID's stored Sources.xml must all be present.
-	// Checked by sourceproviderid since <name> may hold a display name rather than the type string.
+	// The cloud-visible sources from lastDeviceID's stored Sources.xml
+	// must all be present. AUX (sourceproviderid=9) is intentionally
+	// excluded — real Bose never emitted AUX in /full; the speaker
+	// enumerates AUX from its own hardware via isLocal=true. See
+	// pkg/service/marge/marge.go getAccountSources.
 	for _, wantProviderID := range []string{
-		"<sourceproviderid>9</sourceproviderid>",  // AUX
 		"<sourceproviderid>2</sourceproviderid>",  // INTERNET_RADIO
 		"<sourceproviderid>11</sourceproviderid>", // LOCAL_INTERNET_RADIO
 		"<sourceproviderid>25</sourceproviderid>", // TUNEIN
@@ -393,6 +399,11 @@ func TestMargeAccountFullExcludesEmptyAmazonSource(t *testing.T) {
 		if !strings.Contains(bodyStr, wantProviderID) {
 			t.Errorf("/full response is missing source with %s; body:\n%s", wantProviderID, bodyStr)
 		}
+	}
+
+	// And explicitly assert AUX is NOT present.
+	if strings.Contains(bodyStr, "<sourceproviderid>9</sourceproviderid>") {
+		t.Errorf("/full response must not include AUX (sourceproviderid=9); body:\n%s", bodyStr)
 	}
 }
 
@@ -627,19 +638,26 @@ func TestMargeAccountSourcesNoDevices(t *testing.T) {
 	body, _ := io.ReadAll(res.Body)
 	bodyStr := string(body)
 
-	// Verify that we get the default sources with correct IDs and empty display names
+	// Verify that we get the default cloud sources with correct IDs. AUX
+	// (id=10001) is intentionally excluded — real Bose never emitted AUX
+	// in cloud responses; the speaker enumerates AUX from its own
+	// hardware (isLocal=true on :8090/sources). See
+	// pkg/service/marge/marge.go getAccountSources.
 	expectedSnippets := []string{
 		"<sources>",
 		"<source id=\"10004\" type=\"Audio\"",
 		"<source id=\"10003\" type=\"Audio\"",
 		"<source id=\"10002\" type=\"Audio\"",
-		"<source id=\"10001\" type=\"Audio\"",
 	}
 
 	for _, snippet := range expectedSnippets {
 		if !strings.Contains(bodyStr, snippet) {
 			t.Errorf("Response missing expected snippet [%s]: %s", snippet, bodyStr)
 		}
+	}
+
+	if strings.Contains(bodyStr, "<source id=\"10001\"") {
+		t.Errorf("Response must not include AUX (id=10001); body:\n%s", bodyStr)
 	}
 
 	// Verify that no sources have empty display names

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -1036,6 +1036,25 @@ func getAccountSources(ds *datastore.DataStore, account, lastDeviceID string) []
 
 	for i := range sources {
 		s := sources[i]
+		// Real Bose's /streaming/account/{a}/full never emitted AUX as
+		// a cloud-side <source> (verified across 61 captured upstream
+		// /full responses in scripts/android/captures/.../
+		// parity_mismatches/). AUX is hardware-local — the speaker
+		// enumerates it via isLocal=true in its own /sources response,
+		// it doesn't need the cloud to list it. AfterTouch emitting a
+		// malformed AUX entry here (with displayName=, empty
+		// <credential>, non-empty <name>/<username>) is the suspected
+		// trigger for issue #195: the speaker's source-reconciliation
+		// code marks AUX as cloud-side inconsistent and refuses
+		// dispatch, even though the local availability check reports
+		// it READY. We still keep AUX in getDefaultSources() because
+		// other call sites (default-sources init at startup, the
+		// SoundTouch web UI source picker) rely on it; the filter
+		// just keeps it out of /full's wire shape.
+		if s.SourceKeyType == constants.ProviderAux {
+			continue
+		}
+
 		PrepareConfiguredSource(&s)
 		fullSources = append(fullSources, mapToFullResponseSource(s))
 	}

--- a/pkg/service/setup/init_plan.go
+++ b/pkg/service/setup/init_plan.go
@@ -199,7 +199,7 @@ func (m *Manager) ExecuteInitPlan(ctx context.Context, plan InitPlan, progress P
 }
 
 // applyInitPlanDefaults validates required fields and fills in defaults
-// from Manager.ServerURL / sysLanguage 2 / "Bearer aftertouch".
+// from Manager.ServerURL / sysLanguage 2 / DefaultMargeAuthToken.
 func applyInitPlanDefaults(plan InitPlan, serverURL string) (InitPlan, error) {
 	if plan.DeviceIP == "" {
 		return plan, errors.New("InitPlan.DeviceIP is required")
@@ -218,7 +218,7 @@ func applyInitPlanDefaults(plan InitPlan, serverURL string) (InitPlan, error) {
 	}
 
 	if plan.AuthToken == "" {
-		plan.AuthToken = "Bearer aftertouch"
+		plan.AuthToken = DefaultMargeAuthToken
 	}
 
 	return plan, nil

--- a/pkg/service/setup/init_plan_test.go
+++ b/pkg/service/setup/init_plan_test.go
@@ -147,7 +147,7 @@ func TestExecuteInitPlan_FactoryReset_GeneratesAccountAndRunsAllSteps(t *testing
 		"Enter",
 		"IdentifyLeave",
 		"SetName(Living Room)",
-		"SetMargeAccount(1234567,Bearer aftertouch)",
+		"SetMargeAccount(1234567," + DefaultMargeAuthToken + ")",
 		"Leave",
 		"PushCustomerSupportInfo",
 	}

--- a/pkg/service/setup/setup_session.go
+++ b/pkg/service/setup/setup_session.go
@@ -21,7 +21,52 @@ const (
 	// LanguageEnglish is the sysLanguage code for English. ‹2› is the
 	// value the official Bose app sends during English-locale setup.
 	LanguageEnglish = 2
+
+	// DefaultMargeAuthToken is the placeholder userAuthToken sent in
+	// <PairDeviceWithAccount> when the caller didn't supply one. The
+	// speaker accepts any non-empty value; a real Bose-issued token
+	// shape (128-char base64 per docs/reference/DEVICE-PAIRING-FLOW.md
+	// line 154) is not required — verified during #195 investigation
+	// where the speaker happily persisted "Bearer AfterTouch" and
+	// re-derived its post-pair state from the marge endpoints
+	// regardless of token content.
+	DefaultMargeAuthToken = "Bearer AfterTouch"
+
+	// DefaultMargePairingEmail is the synthetic accountEmail used when
+	// PairingExtras requests the extended <PairDeviceWithAccount> payload
+	// but doesn't supply an email. RFC 2606 reserves ".invalid" as a TLD
+	// guaranteed never to resolve, which is what we want here — the
+	// speaker writes it into its persistent state but no real address
+	// receives anything.
+	DefaultMargePairingEmail = "local@aftertouch.invalid"
 )
+
+// MargePairingExtras carries the optional fields that the official Bose
+// Android app and Zimbo88's USB-less OpenCloudTouch script include in
+// their <PairDeviceWithAccount> payloads. AfterTouch historically sent
+// only <accountId> + <userAuthToken>; that minimal shape is the
+// suspected trigger for the post-pair AUX/preset breakage tracked in
+// issues #195 and #269.
+//
+// Set BoseServer (and optionally UpdateServer/AccountEmail) on the
+// SessionConfig to opt into the richer payload. Empty fields are
+// omitted from the XML so callers can choose any subset.
+//
+// Reference: docs/reference/DEVICE-PAIRING-FLOW.md and
+// https://github.com/scheilch/opencloudtouch/discussions/201.
+type MargePairingExtras struct {
+	// BoseServer is the marge server URL the speaker should use after
+	// pairing. Typically equal to AfterTouch's service URL.
+	BoseServer string
+	// UpdateServer is the firmware-update server URL. If empty and
+	// BoseServer is set, SetMargeAccount derives it as
+	// BoseServer + "/updates/soundtouch".
+	UpdateServer string
+	// AccountEmail is the synthetic email persisted alongside the
+	// account. If empty and BoseServer is set, SetMargeAccount fills
+	// in DefaultMargePairingEmail.
+	AccountEmail string
+}
 
 // StateMachine is the surface the InitPlan orchestrator drives. The
 // concrete WebSocket-backed implementation is *Session; tests inject
@@ -52,6 +97,11 @@ type SessionConfig struct {
 	WSScheme string
 	// WSPort overrides 8080 when deviceIP does not already carry a port.
 	WSPort int
+	// PairingExtras opts the session into the richer
+	// <PairDeviceWithAccount> payload (boseServer / updateServer /
+	// accountEmail) used by the official Bose Android app. Zero value
+	// retains the historical minimal payload.
+	PairingExtras MargePairingExtras
 }
 
 // Session is a synchronous request/response WebSocket session driving
@@ -60,10 +110,11 @@ type SessionConfig struct {
 // and stateful) — setup is a short, linear sequence and benefits from a
 // purpose-built transport.
 type Session struct {
-	deviceID    string
-	conn        *websocket.Conn
-	reqID       atomic.Int64
-	stepTimeout time.Duration
+	deviceID      string
+	conn          *websocket.Conn
+	reqID         atomic.Int64
+	stepTimeout   time.Duration
+	pairingExtras MargePairingExtras
 }
 
 // DialSession opens a WebSocket to the speaker at deviceIP and
@@ -117,7 +168,12 @@ func DialSession(deviceIP, deviceID string, cfg SessionConfig) (*Session, error)
 		step = defaultSetupStepTimeout
 	}
 
-	return &Session{deviceID: deviceID, conn: conn, stepTimeout: step}, nil
+	return &Session{
+		deviceID:      deviceID,
+		conn:          conn,
+		stepTimeout:   step,
+		pairingExtras: cfg.PairingExtras,
+	}, nil
 }
 
 // Close sends a normal-closure frame and closes the underlying socket.
@@ -243,24 +299,55 @@ func (s *Session) SetName(ctx context.Context, name string) error {
 }
 
 // SetMargeAccount sends the canonical PairDeviceWithAccount envelope.
-// authToken defaults to "Bearer aftertouch" when empty — our local
-// service does not validate it, but a non-empty value matches the
-// official app's shape.
+// authToken defaults to DefaultMargeAuthToken when empty.
+//
+// If SessionConfig.PairingExtras.BoseServer is set, the payload is
+// extended with <boseServer>, <updateServer>, and <accountEmail>
+// matching the official Bose app's shape (and Zimbo88's OpenCloudTouch
+// USB-less script). UpdateServer and AccountEmail derive from
+// BoseServer when not explicitly set.
 func (s *Session) SetMargeAccount(ctx context.Context, accountID, authToken string) error {
 	if accountID == "" {
 		return errors.New("SetMargeAccount: accountID is required")
 	}
 
 	if authToken == "" {
-		authToken = "Bearer aftertouch"
+		authToken = DefaultMargeAuthToken
 	}
 
-	body := fmt.Sprintf(
-		`<PairDeviceWithAccount><accountId>%s</accountId><userAuthToken>%s</userAuthToken></PairDeviceWithAccount>`,
-		xmlBodyEscape(accountID), xmlBodyEscape(authToken),
-	)
+	return s.sendStep(ctx, "setMargeAccount", "POST", buildPairDeviceWithAccountXML(accountID, authToken, s.pairingExtras))
+}
 
-	return s.sendStep(ctx, "setMargeAccount", "POST", body)
+// buildPairDeviceWithAccountXML serializes the <PairDeviceWithAccount>
+// body. Extracted so tests can pin the exact shape without driving a
+// full WebSocket session.
+func buildPairDeviceWithAccountXML(accountID, authToken string, extras MargePairingExtras) string {
+	var b strings.Builder
+	b.WriteString(`<PairDeviceWithAccount>`)
+	b.WriteString(`<accountId>` + xmlBodyEscape(accountID) + `</accountId>`)
+	b.WriteString(`<userAuthToken>` + xmlBodyEscape(authToken) + `</userAuthToken>`)
+
+	if extras.BoseServer != "" {
+		b.WriteString(`<boseServer>` + xmlBodyEscape(extras.BoseServer) + `</boseServer>`)
+
+		updateServer := extras.UpdateServer
+		if updateServer == "" {
+			updateServer = strings.TrimRight(extras.BoseServer, "/") + "/updates/soundtouch"
+		}
+
+		b.WriteString(`<updateServer>` + xmlBodyEscape(updateServer) + `</updateServer>`)
+
+		email := extras.AccountEmail
+		if email == "" {
+			email = DefaultMargePairingEmail
+		}
+
+		b.WriteString(`<accountEmail>` + xmlBodyEscape(email) + `</accountEmail>`)
+	}
+
+	b.WriteString(`</PairDeviceWithAccount>`)
+
+	return b.String()
 }
 
 // Leave sends SETUP_LEAVE.

--- a/pkg/service/setup/setup_session_test.go
+++ b/pkg/service/setup/setup_session_test.go
@@ -184,7 +184,7 @@ func TestSession_SendsCanonicalEnvelopes(t *testing.T) {
 	mustContain(t, frames[3], `<setupState state="SETUP_ENTER"/>`)
 	mustContain(t, frames[4], `<setupState state="SETUP_IDENTIFY_DEVICE_LEAVE"/>`)
 	mustContain(t, frames[5], `url="name"`, `<name>Living Room</name>`)
-	mustContain(t, frames[6], `url="setMargeAccount"`, `<accountId>1234567</accountId>`, `<userAuthToken>Bearer aftertouch</userAuthToken>`)
+	mustContain(t, frames[6], `url="setMargeAccount"`, `<accountId>1234567</accountId>`, `<userAuthToken>`+DefaultMargeAuthToken+`</userAuthToken>`)
 	mustContain(t, frames[7], `<setupState state="SETUP_LEAVE"/>`)
 	mustContain(t, frames[8], `url="pushCustomerSupportInfoToMarge"`, `method="GET"`)
 }
@@ -299,6 +299,69 @@ func TestSession_XMLAttributeEscape(t *testing.T) {
 	}
 
 	mustContain(t, frames[0], `deviceID="quoted&quot;&lt;id>"`)
+}
+
+// TestBuildPairDeviceWithAccountXML pins both the minimal-payload
+// shape (historical AfterTouch behaviour) and the extended-payload
+// shape introduced for #195/#269 investigation. The extended path
+// mirrors what the official Bose app and Zimbo88's OpenCloudTouch
+// USB-less script send (see docs/reference/DEVICE-PAIRING-FLOW.md
+// and https://github.com/scheilch/opencloudtouch/discussions/201).
+func TestBuildPairDeviceWithAccountXML(t *testing.T) {
+	t.Run("minimal payload — no extras", func(t *testing.T) {
+		got := buildPairDeviceWithAccountXML("1234567", "Bearer tok", MargePairingExtras{})
+
+		want := `<PairDeviceWithAccount>` +
+			`<accountId>1234567</accountId>` +
+			`<userAuthToken>Bearer tok</userAuthToken>` +
+			`</PairDeviceWithAccount>`
+		if got != want {
+			t.Errorf("\n got: %s\nwant: %s", got, want)
+		}
+	})
+
+	t.Run("extended payload — BoseServer triggers derived defaults", func(t *testing.T) {
+		got := buildPairDeviceWithAccountXML(
+			"1234567", "Bearer tok",
+			MargePairingExtras{BoseServer: "https://soundtouch.local"},
+		)
+
+		mustContain(t, got,
+			`<boseServer>https://soundtouch.local</boseServer>`,
+			`<updateServer>https://soundtouch.local/updates/soundtouch</updateServer>`,
+			`<accountEmail>`+DefaultMargePairingEmail+`</accountEmail>`,
+		)
+	})
+
+	t.Run("extended payload — explicit UpdateServer + AccountEmail honoured", func(t *testing.T) {
+		got := buildPairDeviceWithAccountXML(
+			"1234567", "Bearer tok",
+			MargePairingExtras{
+				BoseServer:   "https://example.test",
+				UpdateServer: "https://updates.example.test/firmware",
+				AccountEmail: "user@example.test",
+			},
+		)
+
+		mustContain(t, got,
+			`<boseServer>https://example.test</boseServer>`,
+			`<updateServer>https://updates.example.test/firmware</updateServer>`,
+			`<accountEmail>user@example.test</accountEmail>`,
+		)
+	})
+
+	t.Run("extended payload — BoseServer trailing slash trimmed when deriving UpdateServer", func(t *testing.T) {
+		got := buildPairDeviceWithAccountXML(
+			"1234567", "Bearer tok",
+			MargePairingExtras{BoseServer: "https://soundtouch.local/"},
+		)
+
+		// Derived path uses TrimRight on BoseServer so we don't get
+		// "soundtouch.local//updates/soundtouch".
+		mustContain(t, got,
+			`<updateServer>https://soundtouch.local/updates/soundtouch</updateServer>`,
+		)
+	})
 }
 
 func mustContain(t *testing.T, s string, needles ...string) {

--- a/pkg/service/setup/wifi_provision.go
+++ b/pkg/service/setup/wifi_provision.go
@@ -42,6 +42,11 @@ type PushWiFiCredentialsParams struct {
 //
 // The speaker confirms the request before disconnecting; expect to lose
 // the AP link within ~30 seconds.
+//
+// Empirically the first POST often races the speaker's setup endpoint
+// readiness — the connection times out, then a second POST a few seconds
+// later succeeds immediately. We retry once internally so the caller
+// doesn't have to.
 func PushWiFiCredentials(ctx context.Context, p PushWiFiCredentialsParams) error {
 	if p.SSID == "" {
 		return fmt.Errorf("PushWiFiCredentials: SSID is required")
@@ -69,35 +74,78 @@ func PushWiFiCredentials(ctx context.Context, p PushWiFiCredentialsParams) error
 
 	url := "http://" + hostPort + "/addWirelessProfile"
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
-	if err != nil {
-		return fmt.Errorf("build request: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "text/xml")
-
 	httpClient := p.HTTPClient
 	if httpClient == nil {
-		// No client-side timeout: let the caller's context govern.
-		// The CLI passes a context deadline (default 30 s in
-		// setupWiFiPushCmd) and a hard-coded 10 s here would race
-		// it for no benefit.
+		// No client-side timeout: let the per-attempt sub-context
+		// govern. The CLI passes a context deadline (default 30 s
+		// in setupWiFiPushCmd) and a hard-coded 10 s here would
+		// race it for no benefit.
 		httpClient = &http.Client{}
 	}
 
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("POST %s: %w", url, err)
+	// Per-attempt cap so a stuck first attempt doesn't burn the whole
+	// budget. 12 s is well above the typical sub-second response time
+	// when the endpoint is healthy, and the failure mode we're working
+	// around (first attempt hangs until the deadline elapses) means
+	// any value here is mostly a sub-budget for a stuck attempt.
+	const perAttemptTimeout = 12 * time.Second
+	// Pause between attempts gives the speaker's setup endpoint a
+	// moment to finish whatever initialization the first POST kicked
+	// off (the empirical workaround that motivated this retry).
+	const interAttemptDelay = 2 * time.Second
+
+	attempt := func(ctx context.Context) error {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(body))
+		if err != nil {
+			return fmt.Errorf("build request: %w", err)
+		}
+
+		req.Header.Set("Content-Type", "text/xml")
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return fmt.Errorf("POST %s: %w", url, err)
+		}
+
+		defer func() { _ = resp.Body.Close() }()
+
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			respBody, _ := io.ReadAll(resp.Body)
+			return fmt.Errorf("POST %s returned %d: %s", url, resp.StatusCode, strings.TrimSpace(string(respBody)))
+		}
+
+		return nil
 	}
 
-	defer func() { _ = resp.Body.Close() }()
+	// Two attempts: the second is silent on the wire when the first
+	// already succeeded (returns at the first non-error), or carries
+	// the recovery when the first failed.
+	const maxAttempts = 2
 
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		respBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("POST %s returned %d: %s", url, resp.StatusCode, strings.TrimSpace(string(respBody)))
+	var lastErr error
+
+	for i := 0; i < maxAttempts; i++ {
+		if i > 0 {
+			select {
+			case <-time.After(interAttemptDelay):
+			case <-ctx.Done():
+				return fmt.Errorf("PushWiFiCredentials: %w (last attempt error: %w)", ctx.Err(), lastErr)
+			}
+		}
+
+		attemptCtx, cancel := context.WithTimeout(ctx, perAttemptTimeout)
+		err := attempt(attemptCtx)
+
+		cancel()
+
+		if err == nil {
+			return nil
+		}
+
+		lastErr = err
 	}
 
-	return nil
+	return fmt.Errorf("PushWiFiCredentials: both attempts failed (last: %w)", lastErr)
 }
 
 // PollConfig governs the retry cadence of WaitForAP and WaitForOnline.

--- a/pkg/service/setup/wifi_provision.go
+++ b/pkg/service/setup/wifi_provision.go
@@ -78,7 +78,11 @@ func PushWiFiCredentials(ctx context.Context, p PushWiFiCredentialsParams) error
 
 	httpClient := p.HTTPClient
 	if httpClient == nil {
-		httpClient = &http.Client{Timeout: 10 * time.Second}
+		// No client-side timeout: let the caller's context govern.
+		// The CLI passes a context deadline (default 30 s in
+		// setupWiFiPushCmd) and a hard-coded 10 s here would race
+		// it for no benefit.
+		httpClient = &http.Client{}
 	}
 
 	resp, err := httpClient.Do(req)

--- a/tests/integration/http-client/get_account_sources.http
+++ b/tests/integration/http-client/get_account_sources.http
@@ -18,14 +18,20 @@ Authorization: Bearer dummy-token
         client.assert(sources.nodeName === "sources", "Root element is not 'sources'");
 
         const sourceList = sources.getElementsByTagName("source");
-        client.assert(sourceList.length >= 4, "Expected at least 4 source elements, found " + sourceList.length);
+        client.assert(sourceList.length >= 3, "Expected at least 3 source elements, found " + sourceList.length);
 
-        const expectedIds = ["10001", "10002", "10003", "10004"];
+        // AUX (id=10001, sourceproviderid=9) is intentionally excluded from
+        // cloud responses — real Bose never emitted AUX in /full or /sources;
+        // the speaker enumerates AUX from its own hardware via isLocal=true
+        // in :8090/sources. See pkg/service/marge/marge.go getAccountSources
+        // and commit 2b40481 (#195/#269).
+        const expectedIds = ["10002", "10003", "10004"];
         for (let i = 0; i < sourceList.length; i++) {
             const source = sourceList.item(i);
             const sourceId = source.getAttribute("id");
+            client.assert(sourceId !== "10001", "Cloud /sources must not include AUX (id=10001)");
             if (i < expectedIds.length) {
-                client.assert(sourceId === expectedIds[i], "Wrong source ID at index " + i);
+                client.assert(sourceId === expectedIds[i], "Wrong source ID at index " + i + ": got " + sourceId + ", want " + expectedIds[i]);
             }
             client.assert(source.getAttribute("type") === "Audio", "Wrong source type for source " + sourceId);
 

--- a/tests/integration/http-client/get_full_account.http
+++ b/tests/integration/http-client/get_full_account.http
@@ -47,6 +47,18 @@ Authorization: Bearer {{token}}
         client.assert(sources !== null, "Missing 'sources' element");
         var sourceCount = sources.getElementsByTagName("source").length;
         client.assert(sourceCount > 0, "No 'source' elements found in account sources");
-        client.assert(sourceCount === 6, "Expected 6 sources (AUX, INTERNET_RADIO, LOCAL_INTERNET_RADIO, TUNEIN, RADIO_BROWSER, Spotify) but got " + sourceCount);
+        // AUX (sourceproviderid=9) is intentionally excluded from cloud-side
+        // /full responses — real Bose never emitted it; the speaker enumerates
+        // AUX from its own hardware via isLocal=true in :8090/sources. See
+        // pkg/service/marge/marge.go getAccountSources for the reasoning and
+        // commit 2b40481 for the fix that closed #195/#269.
+        client.assert(sourceCount === 5, "Expected 5 cloud sources (INTERNET_RADIO, LOCAL_INTERNET_RADIO, TUNEIN, RADIO_BROWSER, Spotify; AUX is hardware-local) but got " + sourceCount);
+
+        // Explicit negative assertion: AUX must not appear in /full.
+        var sourceList = sources.getElementsByTagName("source");
+        for (var i = 0; i < sourceList.length; i++) {
+            var pid = sourceList[i].getElementsByTagName("sourceproviderid")[0];
+            client.assert(!pid || pid.textContent !== "9", "/full must not include AUX (sourceproviderid=9)");
+        }
     });
 %}


### PR DESCRIPTION
## Summary

Closes #195 (AUX broken after migration) and #269 (presets fail after migration).

Both issues reported the same symptom on freshly-paired speakers: AUX selection and preset playback failed post-pair, even though `:8090/sources` on the speaker still reported the sources as `READY`. The bug turned out to be upstream — in AfterTouch's cloud-side responses, not in transport, pairing, DNS, or any of the other suspects we chased for several sessions.

## Root cause

Real Bose's `/streaming/account/{a}/full` never emitted AUX as a cloud `<source>` element. Verified across **61 captured upstream `/full` bodies covering 4669 source elements**: zero match `sourceproviderid=9` (AUX), zero match the literal string "AUX". The captured speakers are SoundTouch 20s — which **do have a physical AUX input** — so Bose deliberately kept AUX out of `/full` and let the speaker enumerate it locally via `isLocal="true"` in its own `:8090/sources`.

AfterTouch unconditionally included AUX (id=10001) with a malformed shape: a `displayName="AUX IN"` attribute (real Bose: never present), `<name>AUX</name>` (real Bose: empty), an empty `<credential>` (real Bose: empty *only* for INTERNET_RADIO; absent entirely for AUX since AUX wasn't there at all). The speaker's source-reconciliation code treated AfterTouch's cloud-side AUX entry as inconsistent and refused dispatch — even though the local availability check kept reporting AUX as READY.

This was the probable cause behind a long red-herring trail (TPDA `:30034` storm, IoT.xml/AVS bootstrap, userAuthToken shape, SETUP state machine bracket). All of those proved universal across the firmware family — the working baseline speaker has the same TPDA storm in `logread` and AUX still works there. **Only the cloud-source-list shape diverged between working and broken speakers.**

## How fixed

`pkg/service/marge/marge.go` `getAccountSources` now filters `ProviderAux` from cloud responses (both `/full` and `/sources` go through this builder). AUX stays in `GetDefaultSources()` for non-cloud consumers (web UI source picker, default-sources init). 4-line change with a long doc comment carrying the evidence.

## Verification

- ✅ Unit tests pass (`go test ./...`)
- ✅ HTTP-client integration tests pass (`make test-http-client` — 49 requests, 0 failures)
- ✅ End-to-end on a real ST20: factory-reset → wifi-push → `setup pair --mode=full` → press AUX → audio plays
- ✅ Presets dispatch correctly post-pair on the same speaker

## Commit-by-commit

| Commit    | Topic                                                                                                                                                                                                                                                                                                                 |
|-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `2b40481` | **The fix.** AUX filter in `getAccountSources` + three handler tests assert AUX is intentionally excluded from cloud responses                                                                                                                                                                                        |
| `2e659de` | Updates two HTTP-client integration tests (`get_full_account.http`, `get_account_sources.http`) for the new shape; both now also explicitly assert AUX is absent                                                                                                                                                      |
| `068d59e` | Bumps `wifi-push --request-timeout` from 10 s to 30 s — but this alone wasn't enough (see next)                                                                                                                                                                                                                       |
| `1e9d7ce` | Adds an implicit single retry to `PushWiFiCredentials`. Empirically the first POST to the speaker's AP endpoint frequently hangs; a second POST a few seconds later succeeds immediately. Folds the workaround into the function so the CLI just works                                                                |
| `17992d3` | Aligns `<PairDeviceWithAccount>` with the official Bose-app payload shape (`<boseServer>`/`<updateServer>`/`<accountEmail>`, opt-in via `--service-url`); adds `--token` flag. Cosmetic protocol parity — **did not** fix the bug — but the wiring stays so the switches are ready for future token-shape experiments |
| `a78d0c1` | Documents the CLI-driven factory-reset workflow as an alternative to the wizard's in-place migration in `docs/guides/MIGRATION-GUIDE.md`                                                                                                                                                                              |

## Test plan

- [x] CI green
- [ ] Reviewers reproduce on their own speakers if available: factory-reset via `soundtouch-cli setup factory-reset` → wifi-push → `setup pair --mode=full` → AUX works, presets play
- [ ] Optional: spot-check that an *already-migrated* speaker (paired pre-PR) still behaves correctly after upgrading — the AUX-from-cloud entry was always wrong, so removing it shouldn't regress an existing pairing. The `getAccountSources` filter applies on every `/full` request, so currently-broken paired speakers should recover at the next sync without re-pairing.

## Risk / blast radius

- `/full` and `/sources` responses change shape (one source removed). The HTTP-client integration suite is updated to assert the new shape.
- No persistent data model changes; the on-disk default-sources list keeps AUX so non-cloud consumers are unaffected.
- AUX hardware functionality has never depended on the cloud entry — confirmed by the working baseline speaker and the 61 upstream captures.

## What's *not* in this PR

- AfterTouch-side handling of the `voice.api.bose.io` `/alexa/certificate` endpoint — investigated as a candidate root cause, returned to 501 stub when it proved unrelated.
- A separate `<presetsUpdated/>` nudge / preset-sync mechanism for #253. Out of scope.

## Related

- Relates to #195
- Relates to #269
