### PR TITLE
feat(soundtouch-web): add --host flag for manual device IP

### DIFF
--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -108,11 +108,13 @@ func main() {
 				for _, host := range manualHosts {
 					addManualDevice(webApp, host, 8090)
 				}
+
 				discoverDevices(ctx, webApp, discoveryService)
 
 				webApp.BroadcastDiscoveryStatus("completed", len(webApp.Devices))
 				webApp.BroadcastDeviceList()
 			}()
+
 			r := setupRoutes(webApp, discoveryService)
 
 			log.Printf("SoundTouch Web UI starting on http://%s", addr)

--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -46,6 +46,11 @@ func main() {
 				Usage:   "Network interface name (e.g. eth0) for mDNS and UPnP device discovery. Defaults to the --bind interface name when one was given; leave empty otherwise to auto-pick",
 				EnvVars: []string{"DISCOVERY_INTERFACE"},
 			},
+			&cli.StringFlag{
+				Name:    "host",
+				Usage:   "SoundTouch device IP address to add manually",
+				EnvVars: []string{"SOUNDTOUCH_HOST"},
+			},
 		},
 		Action: func(c *cli.Context) error {
 			port := c.String("port")
@@ -61,6 +66,7 @@ func main() {
 			}
 
 			rawIface := c.String("interface")
+			manualHost := c.String("host")
 
 			ifaceName := defaultDiscoveryInterface(rawIface, rawBind, bindAddr)
 			if rawIface == "" && ifaceName != "" {
@@ -99,12 +105,14 @@ func main() {
 
 				webApp.BroadcastDiscoveryStatus("starting", len(webApp.Devices))
 
+				if manualHost != "" {
+					addManualDevice(webApp, manualHost, 8090)
+				}
 				discoverDevices(ctx, webApp, discoveryService)
 
 				webApp.BroadcastDiscoveryStatus("completed", len(webApp.Devices))
 				webApp.BroadcastDeviceList()
 			}()
-
 			r := setupRoutes(webApp, discoveryService)
 
 			log.Printf("SoundTouch Web UI starting on http://%s", addr)
@@ -198,6 +206,38 @@ func resolveBindAddr(bindAddr string) (string, error) {
 	default:
 		return "", fmt.Errorf("--bind %q: interface has no usable IPv4 or IPv6 address", bindAddr)
 	}
+}
+
+func addManualDevice(app *handlers.WebApp, host string, port int) {
+	clientConfig := &client.Config{
+		Host:    host,
+		Port:    port,
+		Timeout: 10 * time.Second,
+	}
+
+	soundTouchClient := client.NewClient(clientConfig)
+
+	deviceInfo, err := soundTouchClient.GetDeviceInfo()
+	if err != nil {
+		log.Printf("Failed to get device info for manual host %s: %v", host, err)
+		return
+	}
+
+	conn := &webtypes.DeviceConnection{
+		Client:     soundTouchClient,
+		DeviceInfo: deviceInfo,
+		LastSeen:   time.Now(),
+		Status: webtypes.DeviceStatus{
+			IsConnected:  false,
+			LastActivity: time.Now(),
+		},
+	}
+
+	go app.UpdateDeviceStatus(host, conn)
+
+	app.Devices[host] = conn
+
+	log.Printf("Added manual device: %s (%s) at %s:%d", deviceInfo.Name, deviceInfo.Type, host, port)
 }
 
 func setupRoutes(app *handlers.WebApp, discoveryService *discovery.UnifiedDiscoveryService) *chi.Mux {

--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -46,10 +46,10 @@ func main() {
 				Usage:   "Network interface name (e.g. eth0) for mDNS and UPnP device discovery. Defaults to the --bind interface name when one was given; leave empty otherwise to auto-pick",
 				EnvVars: []string{"DISCOVERY_INTERFACE"},
 			},
-			&cli.StringFlag{
-				Name:    "host",
-				Usage:   "SoundTouch device IP address to add manually",
-				EnvVars: []string{"SOUNDTOUCH_HOST"},
+			&cli.StringSliceFlag{
+				Name:    "devices",
+				Usage:   "SoundTouch device IP address(es) to add manually (can be specified multiple times)",
+				EnvVars: []string{"SOUNDTOUCH_DEVICES"},
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -66,7 +66,7 @@ func main() {
 			}
 
 			rawIface := c.String("interface")
-			manualHost := c.String("host")
+			manualHosts := c.StringSlice("devices")
 
 			ifaceName := defaultDiscoveryInterface(rawIface, rawBind, bindAddr)
 			if rawIface == "" && ifaceName != "" {
@@ -105,8 +105,8 @@ func main() {
 
 				webApp.BroadcastDiscoveryStatus("starting", len(webApp.Devices))
 
-				if manualHost != "" {
-					addManualDevice(webApp, manualHost, 8090)
+				for _, host := range manualHosts {
+					addManualDevice(webApp, host, 8090)
 				}
 				discoverDevices(ctx, webApp, discoveryService)
 


### PR DESCRIPTION
## Description

soundtouch-web relies entirely on mDNS and UPnP discovery to find SoundTouch devices. Some devices (e.g. SoundTouch 30) do not respond to active mDNS queries within the discovery timeout, making it impossible to use soundtouch-web with these devices.

This PR adds a `--host` flag (and `SOUNDTOUCH_HOST` env var) to allow manually specifying a device IP address. When `--host` is set, the device is added directly without waiting for discovery. Automatic discovery still runs in parallel.

## Type of Change

Please check the type of change your PR introduces:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring (no functional changes)
- [ ] Test improvements
- [ ] Build/CI improvements

## Related Issues

## Changes Made

### API Changes
- [ ] Added new endpoints
- [ ] Modified existing endpoints
- [x] Added new CLI commands
- [ ] Modified existing CLI commands
- [x] Added new configuration options

### Implementation Details
- Added --host / SOUNDTOUCH_HOST flag to soundtouch-web
- Added addManualDevice() helper function
- Manual device is added before discovery runs, discovery still runs in parallel
- No new dependencies

## Testing

### Automated Tests
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] All existing tests pass
- [ ] Test coverage maintained or improved

### Manual Testing
- [x] Tested with real SoundTouch device(s)
- [ ] Tested CLI changes manually
- [ ] Tested in different network environments

**Device(s) tested with:**
Device model: SoundTouch 30
Firmware: 27.0.6.46330
Test results: Device discovered and controlled successfully via soundtouch-web --host 192.168.178.19

### Test Commands
```bash
go vet ./cmd/soundtouch-web/...
go build ./cmd/soundtouch-web/
./soundtouch-web --port 8081 --host 192.168.178.19
```

## Documentation

- [ ] Updated relevant documentation
- [ ] Added code comments for complex logic
- [x] Updated CLI help text
- [ ] Added usage examples
- [ ] Updated API documentation

**Documentation files updated:**
- [ ] README.md
- [ ] docs/API-Endpoints-Overview.md
- [ ] docs/CLI-REFERENCE.md
- [ ] Code documentation (godoc)

## Backward Compatibility

- [x] This change is backward compatible
- [ ] This change includes breaking changes (requires major version bump)
- [ ] This change requires configuration migration

**Breaking changes (if any):**

## Security Considerations

- [x] No security implications
- [ ] Security review required
- [ ] Added input validation
- [ ] Updated authentication/authorization

## Performance Impact

- [x] No performance impact
- [ ] Performance improvement
- [ ] Potential performance regression (justify why)

**Performance notes:**

## Code Quality

- [ ] Code follows project style guidelines
- [x] No linting errors
- [x] No security warnings
- [ ] Memory leaks checked (if applicable)

### Pre-submission Checklist

- [ ] `make check` passes (format, lint, vet)
- [ ] `make test` passes
- [ ] No TODO comments left in production code
- [ ] Error handling is comprehensive
- [ ] Logging is appropriate (not too verbose, not too quiet)

## Deployment Notes

No special deployment considerations. The flag is optional and backward compatible.

## Screenshots (if applicable)

```bash
# Before
$ soundtouch-web --port 8081
2026/05/16 22:18:59 Found 0 devices
# (SoundTouch 30 not discovered via mDNS/UPnP)

# After
$ soundtouch-web --port 8081 --host 192.168.178.19
2026/05/16 23:11:57 Added manual device: soundtouch (SoundTouch 30) at 192.168.178.19:8090
```

## Additional Notes

The SoundTouch 30 announces itself via _soundtouch._tcp mDNS but does not respond 
to active queries within the discovery timeout. The --host flag is a practical 
workaround for this and similar cases.