### PR TITLE
refactor(soundtouch-web): unify device add, lock the registry, atomic Status

### DIFF
--- a/cmd/soundtouch-web/handlers/handlers.go
+++ b/cmd/soundtouch-web/handlers/handlers.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/gesellix/bose-soundtouch/cmd/soundtouch-web/webtypes"
 	"github.com/gesellix/bose-soundtouch/pkg/models"
@@ -17,18 +18,34 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-// WebApp holds the application state and dependencies
+// WebApp holds the application state and dependencies.
+//
+// The device registry (devices map + devicesMu) is encapsulated:
+// callers go through GetDevice / DeviceSnapshot / AddDevice /
+// TouchDevice / DeviceCount instead of touching the map directly.
+// This prevents the concurrent-map-read/write panic that would
+// otherwise be reachable any time an HTTP handler runs while
+// discovery or the /api/discover endpoint is registering devices.
 type WebApp struct {
-	Devices   map[string]*webtypes.DeviceConnection
+	devicesMu sync.RWMutex
+	devices   map[string]*webtypes.DeviceConnection
+
 	Upgrader  websocket.Upgrader
 	WSClients map[*websocket.Conn]bool
 	WSMutex   sync.RWMutex
 }
 
+// DeviceEntry pairs a device id with its connection. Used by
+// DeviceSnapshot so callers can iterate without holding the lock.
+type DeviceEntry struct {
+	ID     string
+	Device *webtypes.DeviceConnection
+}
+
 // NewWebApp creates a new WebApp instance for SPA mode
 func NewWebApp() *WebApp {
 	return &WebApp{
-		Devices:   make(map[string]*webtypes.DeviceConnection),
+		devices:   make(map[string]*webtypes.DeviceConnection),
 		WSClients: make(map[*websocket.Conn]bool),
 		Upgrader: websocket.Upgrader{
 			CheckOrigin: func(_ *http.Request) bool { return true },
@@ -36,17 +53,89 @@ func NewWebApp() *WebApp {
 	}
 }
 
+// GetDevice returns the device for id and whether it exists.
+func (app *WebApp) GetDevice(id string) (*webtypes.DeviceConnection, bool) {
+	app.devicesMu.RLock()
+	defer app.devicesMu.RUnlock()
+
+	device, ok := app.devices[id]
+
+	return device, ok
+}
+
+// DeviceSnapshot returns a list of (id, *DeviceConnection) pairs taken
+// under a single read lock. Callers can iterate the result without
+// holding any registry lock. Devices added or removed after the call
+// are not reflected; the pointers themselves remain valid because
+// nothing deletes from the underlying map today.
+func (app *WebApp) DeviceSnapshot() []DeviceEntry {
+	app.devicesMu.RLock()
+	defer app.devicesMu.RUnlock()
+
+	out := make([]DeviceEntry, 0, len(app.devices))
+	for id, device := range app.devices {
+		out = append(out, DeviceEntry{ID: id, Device: device})
+	}
+
+	return out
+}
+
+// DeviceCount returns the number of registered devices at call time.
+func (app *WebApp) DeviceCount() int {
+	app.devicesMu.RLock()
+	defer app.devicesMu.RUnlock()
+
+	return len(app.devices)
+}
+
+// AddDevice atomically registers conn under id when id is not already
+// known. If id existed, its LastSeen is bumped and AddDevice returns
+// false (the caller should discard conn). Returns true if conn was
+// inserted.
+func (app *WebApp) AddDevice(id string, conn *webtypes.DeviceConnection) bool {
+	app.devicesMu.Lock()
+	defer app.devicesMu.Unlock()
+
+	if existing, ok := app.devices[id]; ok {
+		existing.LastSeen = time.Now()
+		return false
+	}
+
+	app.devices[id] = conn
+
+	return true
+}
+
+// TouchDevice bumps LastSeen for id if it exists; returns true if
+// found. Use this as a fast-path check before doing the network work
+// needed to construct a new DeviceConnection.
+func (app *WebApp) TouchDevice(id string) bool {
+	app.devicesMu.Lock()
+	defer app.devicesMu.Unlock()
+
+	existing, ok := app.devices[id]
+	if !ok {
+		return false
+	}
+
+	existing.LastSeen = time.Now()
+
+	return true
+}
+
 // HandleAPIDevices returns all devices as JSON
 func (app *WebApp) HandleAPIDevices(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	// Return all devices as JSON
-	devices := make(map[string]interface{})
-	for id, device := range app.Devices {
-		devices[id] = map[string]interface{}{
-			"info":     device.DeviceInfo,
-			"status":   device.Status,
-			"lastSeen": device.LastSeen,
+	snapshot := app.DeviceSnapshot()
+	devices := make(map[string]interface{}, len(snapshot))
+
+	for _, entry := range snapshot {
+		devices[entry.ID] = map[string]interface{}{
+			"info":     entry.Device.DeviceInfo,
+			"status":   entry.Device.Status,
+			"lastSeen": entry.Device.LastSeen,
 		}
 	}
 
@@ -68,7 +157,7 @@ func (app *WebApp) HandleAPIDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -107,7 +196,7 @@ func (app *WebApp) HandleAPIControl(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -318,7 +407,7 @@ func (app *WebApp) HandleDeviceKey(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "id")
 	key := chi.URLParam(r, "key")
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -350,7 +439,7 @@ func (app *WebApp) HandleDirectVolumeControl(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -376,7 +465,7 @@ func (app *WebApp) HandleDirectVolumeControl(w http.ResponseWriter, r *http.Requ
 func (app *WebApp) HandleDevicePower(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "id")
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -403,7 +492,7 @@ func (app *WebApp) HandleDevicePower(w http.ResponseWriter, r *http.Request) {
 func (app *WebApp) HandleDevicePowerStatus(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "id")
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, "Device not found", http.StatusNotFound)
 		return
@@ -444,12 +533,14 @@ func (app *WebApp) BroadcastDeviceList() {
 	app.WSMutex.RLock()
 	defer app.WSMutex.RUnlock()
 
-	devices := make(map[string]interface{})
-	for id, device := range app.Devices {
-		devices[id] = map[string]interface{}{
-			"info":     device.DeviceInfo,
-			"status":   device.Status,
-			"lastSeen": device.LastSeen,
+	snapshot := app.DeviceSnapshot()
+	devices := make(map[string]interface{}, len(snapshot))
+
+	for _, entry := range snapshot {
+		devices[entry.ID] = map[string]interface{}{
+			"info":     entry.Device.DeviceInfo,
+			"status":   entry.Device.Status,
+			"lastSeen": entry.Device.LastSeen,
 		}
 	}
 
@@ -598,7 +689,7 @@ func (app *WebApp) HandlePlayTuneIn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		app.sendError(w, fmt.Sprintf("Device '%s' not found", deviceID), http.StatusNotFound)
 		return

--- a/cmd/soundtouch-web/handlers/handlers.go
+++ b/cmd/soundtouch-web/handlers/handlers.go
@@ -134,7 +134,7 @@ func (app *WebApp) HandleAPIDevices(w http.ResponseWriter, _ *http.Request) {
 	for _, entry := range snapshot {
 		devices[entry.ID] = map[string]interface{}{
 			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status,
+			"status":   entry.Device.Status(),
 			"lastSeen": entry.Device.LastSeen,
 		}
 	}
@@ -177,7 +177,7 @@ func (app *WebApp) HandleAPIDevice(w http.ResponseWriter, r *http.Request) {
 		Success: true,
 		Data: map[string]interface{}{
 			"info":   device.DeviceInfo,
-			"status": device.Status,
+			"status": device.Status(),
 		},
 	}
 
@@ -539,7 +539,7 @@ func (app *WebApp) BroadcastDeviceList() {
 	for _, entry := range snapshot {
 		devices[entry.ID] = map[string]interface{}{
 			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status,
+			"status":   entry.Device.Status(),
 			"lastSeen": entry.Device.LastSeen,
 		}
 	}

--- a/cmd/soundtouch-web/handlers/handlers_test.go
+++ b/cmd/soundtouch-web/handlers/handlers_test.go
@@ -40,7 +40,7 @@ func createTestApp() *WebApp {
 		},
 	}
 
-	app.Devices["test-device"] = device
+	app.AddDevice("test-device", device)
 	return app
 }
 
@@ -59,13 +59,9 @@ func TestNewWebApp(t *testing.T) {
 	if app == nil {
 		t.Fatal("NewWebApp returned nil")
 	}
-	if app.Devices == nil {
-		t.Fatal("Devices map not initialized")
-	}
 
-	// At this point we know app and app.Devices are not nil
-	if len(app.Devices) != 0 {
-		t.Errorf("Expected empty devices map, got %d devices", len(app.Devices))
+	if count := app.DeviceCount(); count != 0 {
+		t.Errorf("Expected empty device registry, got %d devices", count)
 	}
 }
 
@@ -549,11 +545,11 @@ func BenchmarkHandleAPIDevices(b *testing.B) {
 	// Add more devices for realistic benchmarking
 	for i := 0; i < 10; i++ {
 		deviceID := "device-" + string(rune('0'+i))
-		app.Devices[deviceID] = &webtypes.DeviceConnection{
+		app.AddDevice(deviceID, &webtypes.DeviceConnection{
 			Client:     &client.Client{},
 			DeviceInfo: &models.DeviceInfo{Name: "Test Device " + deviceID},
 			Status:     webtypes.DeviceStatus{IsConnected: true},
-		}
+		})
 	}
 
 	req := httptest.NewRequest("GET", "/api/devices", nil)

--- a/cmd/soundtouch-web/handlers/handlers_test.go
+++ b/cmd/soundtouch-web/handlers/handlers_test.go
@@ -28,17 +28,13 @@ func createTestApp() *WebApp {
 		},
 	}
 
-	device := &webtypes.DeviceConnection{
-		Client:     nil, // No real client for unit tests
-		DeviceInfo: deviceInfo,
-		LastSeen:   time.Now(),
-		Status: webtypes.DeviceStatus{
-			Volume:       &models.Volume{ActualVolume: 50, MuteEnabled: false},
-			Bass:         &models.Bass{ActualBass: 0},
-			IsConnected:  true,
-			LastActivity: time.Now(),
-		},
-	}
+	device := webtypes.NewDeviceConnection(nil, deviceInfo)
+	device.SetStatus(&webtypes.DeviceStatus{
+		Volume:       &models.Volume{ActualVolume: 50, MuteEnabled: false},
+		Bass:         &models.Bass{ActualBass: 0},
+		IsConnected:  true,
+		LastActivity: time.Now(),
+	})
 
 	app.AddDevice("test-device", device)
 	return app
@@ -545,11 +541,9 @@ func BenchmarkHandleAPIDevices(b *testing.B) {
 	// Add more devices for realistic benchmarking
 	for i := 0; i < 10; i++ {
 		deviceID := "device-" + string(rune('0'+i))
-		app.AddDevice(deviceID, &webtypes.DeviceConnection{
-			Client:     &client.Client{},
-			DeviceInfo: &models.DeviceInfo{Name: "Test Device " + deviceID},
-			Status:     webtypes.DeviceStatus{IsConnected: true},
-		})
+		conn := webtypes.NewDeviceConnection(&client.Client{}, &models.DeviceInfo{Name: "Test Device " + deviceID})
+		conn.SetStatus(&webtypes.DeviceStatus{IsConnected: true})
+		app.AddDevice(deviceID, conn)
 	}
 
 	req := httptest.NewRequest("GET", "/api/devices", nil)

--- a/cmd/soundtouch-web/handlers/registry_test.go
+++ b/cmd/soundtouch-web/handlers/registry_test.go
@@ -1,0 +1,194 @@
+// Package handlers contains tests for the device registry API on
+// WebApp (GetDevice, AddDevice, TouchDevice, DeviceSnapshot,
+// DeviceCount).
+package handlers
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/cmd/soundtouch-web/webtypes"
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+func newRegistryDevice(name string) *webtypes.DeviceConnection {
+	return &webtypes.DeviceConnection{
+		DeviceInfo: &models.DeviceInfo{Name: name},
+		Status:     webtypes.DeviceStatus{IsConnected: true},
+	}
+}
+
+func TestAddDevice_Inserts(t *testing.T) {
+	app := NewWebApp()
+	conn := newRegistryDevice("first")
+
+	if !app.AddDevice("host-1", conn) {
+		t.Fatal("AddDevice returned false on first insert")
+	}
+
+	got, ok := app.GetDevice("host-1")
+	if !ok {
+		t.Fatal("GetDevice did not find the device after AddDevice")
+	}
+
+	if got != conn {
+		t.Errorf("GetDevice returned a different pointer than inserted")
+	}
+}
+
+func TestAddDevice_RejectsDuplicateAndBumpsLastSeen(t *testing.T) {
+	app := NewWebApp()
+	original := newRegistryDevice("first")
+	app.AddDevice("host-1", original)
+
+	originalSeen := original.LastSeen
+	replacement := newRegistryDevice("second")
+
+	if app.AddDevice("host-1", replacement) {
+		t.Fatal("AddDevice returned true on duplicate; expected false")
+	}
+
+	got, _ := app.GetDevice("host-1")
+	if got != original {
+		t.Error("Duplicate AddDevice replaced the existing device pointer")
+	}
+
+	if !got.LastSeen.After(originalSeen) {
+		t.Error("Duplicate AddDevice did not bump LastSeen on existing device")
+	}
+}
+
+func TestTouchDevice(t *testing.T) {
+	app := NewWebApp()
+
+	if app.TouchDevice("missing") {
+		t.Error("TouchDevice returned true for unknown id")
+	}
+
+	conn := newRegistryDevice("first")
+	app.AddDevice("host-1", conn)
+	seenBefore := conn.LastSeen
+
+	if !app.TouchDevice("host-1") {
+		t.Fatal("TouchDevice returned false for known id")
+	}
+
+	if !conn.LastSeen.After(seenBefore) {
+		t.Error("TouchDevice did not bump LastSeen")
+	}
+}
+
+func TestDeviceSnapshotAndCount(t *testing.T) {
+	app := NewWebApp()
+
+	if got := app.DeviceCount(); got != 0 {
+		t.Errorf("DeviceCount on empty app = %d; want 0", got)
+	}
+
+	if snap := app.DeviceSnapshot(); len(snap) != 0 {
+		t.Errorf("DeviceSnapshot on empty app = %v; want []", snap)
+	}
+
+	for i := 0; i < 5; i++ {
+		app.AddDevice(fmt.Sprintf("host-%d", i), newRegistryDevice(fmt.Sprintf("n%d", i)))
+	}
+
+	if got := app.DeviceCount(); got != 5 {
+		t.Errorf("DeviceCount after 5 adds = %d; want 5", got)
+	}
+
+	snap := app.DeviceSnapshot()
+	if len(snap) != 5 {
+		t.Errorf("DeviceSnapshot len = %d; want 5", len(snap))
+	}
+
+	// Spot-check that the snapshot ids match what we inserted.
+	seen := map[string]bool{}
+	for _, entry := range snap {
+		seen[entry.ID] = true
+	}
+
+	for i := 0; i < 5; i++ {
+		id := fmt.Sprintf("host-%d", i)
+		if !seen[id] {
+			t.Errorf("DeviceSnapshot missing %s", id)
+		}
+	}
+}
+
+// TestRegistryConcurrent exercises the registry from many goroutines
+// at once. Before the introduction of devicesMu this would either
+// panic with "fatal error: concurrent map read and map write" or be
+// flagged by the race detector. The test runs under `go test -race`
+// in CI so a future regression that re-exposes the underlying map
+// without locking would be caught here.
+func TestRegistryConcurrent(t *testing.T) {
+	app := NewWebApp()
+
+	const workers = 16
+
+	const opsPerWorker = 200
+
+	var wg sync.WaitGroup
+	wg.Add(workers * 4)
+
+	// Writers: insert distinct ids across workers.
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				id := fmt.Sprintf("w%d-%d", worker, i)
+				app.AddDevice(id, newRegistryDevice(id))
+			}
+		}(w)
+	}
+
+	// Touchers: bump LastSeen on a shared id (which may or may not
+	// exist yet — both branches are exercised).
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				app.TouchDevice("shared")
+			}
+		}()
+	}
+
+	// Readers via snapshot.
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				_ = app.DeviceSnapshot()
+			}
+		}()
+	}
+
+	// Readers via direct lookup.
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				_, _ = app.GetDevice("shared")
+				_ = app.DeviceCount()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity check: every writer inserted opsPerWorker devices, plus
+	// the "shared" entry was never AddDevice'd so should be absent.
+	if got, want := app.DeviceCount(), workers*opsPerWorker; got != want {
+		t.Errorf("DeviceCount after concurrent inserts = %d; want %d", got, want)
+	}
+
+	if _, ok := app.GetDevice("shared"); ok {
+		t.Error("shared device should not exist (only TouchDevice was called for it)")
+	}
+}

--- a/cmd/soundtouch-web/handlers/registry_test.go
+++ b/cmd/soundtouch-web/handlers/registry_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func newRegistryDevice(name string) *webtypes.DeviceConnection {
-	return &webtypes.DeviceConnection{
-		DeviceInfo: &models.DeviceInfo{Name: name},
-		Status:     webtypes.DeviceStatus{IsConnected: true},
-	}
+	conn := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{Name: name})
+	conn.SetStatus(&webtypes.DeviceStatus{IsConnected: true})
+
+	return conn
 }
 
 func TestAddDevice_Inserts(t *testing.T) {

--- a/cmd/soundtouch-web/handlers/websocket.go
+++ b/cmd/soundtouch-web/handlers/websocket.go
@@ -35,12 +35,14 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	app.WSMutex.Unlock()
 
 	// Send initial device list
-	devices := make(map[string]interface{})
-	for id, device := range app.Devices {
-		devices[id] = map[string]interface{}{
-			"info":     device.DeviceInfo,
-			"status":   device.Status,
-			"lastSeen": device.LastSeen,
+	snapshot := app.DeviceSnapshot()
+	devices := make(map[string]interface{}, len(snapshot))
+
+	for _, entry := range snapshot {
+		devices[entry.ID] = map[string]interface{}{
+			"info":     entry.Device.DeviceInfo,
+			"status":   entry.Device.Status,
+			"lastSeen": entry.Device.LastSeen,
 		}
 	}
 
@@ -88,12 +90,12 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Send periodic status updates
-		for id, device := range app.Devices {
-			if device.Status.IsConnected {
+		for _, entry := range app.DeviceSnapshot() {
+			if entry.Device.Status.IsConnected {
 				statusMessage := webtypes.WebSocketMessage{
 					Type:     "status_update",
-					DeviceID: id,
-					Data:     device.Status,
+					DeviceID: entry.ID,
+					Data:     entry.Device.Status,
 				}
 
 				if err := conn.WriteJSON(statusMessage); err != nil {
@@ -230,7 +232,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	device, exists := app.Devices[deviceID]
+	device, exists := app.GetDevice(deviceID)
 	if !exists {
 		http.Error(w, "Device not found", http.StatusNotFound)
 		return

--- a/cmd/soundtouch-web/handlers/websocket.go
+++ b/cmd/soundtouch-web/handlers/websocket.go
@@ -41,7 +41,7 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	for _, entry := range snapshot {
 		devices[entry.ID] = map[string]interface{}{
 			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status,
+			"status":   entry.Device.Status(),
 			"lastSeen": entry.Device.LastSeen,
 		}
 	}
@@ -91,11 +91,12 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 
 		// Send periodic status updates
 		for _, entry := range app.DeviceSnapshot() {
-			if entry.Device.Status.IsConnected {
+			status := entry.Device.Status()
+			if status.IsConnected {
 				statusMessage := webtypes.WebSocketMessage{
 					Type:     "status_update",
 					DeviceID: entry.ID,
-					Data:     entry.Device.Status,
+					Data:     status,
 				}
 
 				if err := conn.WriteJSON(statusMessage); err != nil {
@@ -136,25 +137,35 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 
 	wsClient := conn.Client.NewWebSocketClient(nil)
 
-	// Setup event handlers
+	// Setup event handlers. Each handler funnels its change through
+	// UpdateStatus so concurrent events and the periodic poller
+	// (UpdateDeviceStatus) cannot lose each other's writes.
 	wsClient.OnNowPlaying(func(event *models.NowPlayingUpdatedEvent) {
-		conn.Status.NowPlaying = &event.NowPlaying
-		conn.Status.LastActivity = time.Now()
+		conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+			s.NowPlaying = &event.NowPlaying
+			s.LastActivity = time.Now()
+		})
 	})
 
 	wsClient.OnVolumeUpdated(func(event *models.VolumeUpdatedEvent) {
-		conn.Status.Volume = &event.Volume
-		conn.Status.LastActivity = time.Now()
+		conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+			s.Volume = &event.Volume
+			s.LastActivity = time.Now()
+		})
 	})
 
 	wsClient.OnConnectionState(func(event *models.ConnectionStateUpdatedEvent) {
-		conn.Status.IsConnected = event.ConnectionState.IsConnected()
-		conn.Status.LastActivity = time.Now()
+		conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+			s.IsConnected = event.ConnectionState.IsConnected()
+			s.LastActivity = time.Now()
+		})
 	})
 
 	wsClient.OnPresetUpdated(func(event *models.PresetUpdatedEvent) {
-		conn.Status.Presets = &event.Presets
-		conn.Status.LastActivity = time.Now()
+		conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+			s.Presets = &event.Presets
+			s.LastActivity = time.Now()
+		})
 	})
 
 	// Connect WebSocket
@@ -164,64 +175,81 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 	}
 
 	conn.WebSocket = wsClient
-	conn.Status.IsConnected = true
+
+	conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+		s.IsConnected = true
+	})
 
 	log.Printf("WebSocket connected for device %s", deviceID)
 
 	// Wait for disconnection
 	wsClient.Wait()
 
-	conn.Status.IsConnected = false
+	conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+		s.IsConnected = false
+	})
 
 	log.Printf("WebSocket disconnected for device %s", deviceID)
 }
 
-// UpdateDeviceStatus fetches current status from device
+// UpdateDeviceStatus fetches current status from the device.
+//
+// Network calls run outside the atomic merge so the CAS loop in
+// UpdateStatus stays fast and doesn't retry slow IO. WebSocket event
+// handlers running concurrently are not lost: their UpdateStatus
+// runs against whichever snapshot they observe, and the merge below
+// sees their changes when it CAS-loops onto the latest status.
 func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection) {
 	// Skip status update if client is not available (e.g., in tests)
 	if conn.Client == nil {
 		return
 	}
 
-	statusUpdated := false
+	// Phase 1: slow network fetches. Local vars only, no shared state
+	// is touched yet. Errors are recorded so the merge below can tell
+	// "field N stayed unchanged" apart from "field N got refreshed".
+	nowPlaying, nowPlayingErr := conn.Client.GetNowPlaying()
+	volume, volumeErr := conn.Client.GetVolume()
+	presets, presetsErr := conn.Client.GetPresets()
+	sources, sourcesErr := conn.Client.GetSources()
+	bass, bassErr := conn.Client.GetBass()
 
-	// Get current now playing
-	if nowPlaying, err := conn.Client.GetNowPlaying(); err == nil {
-		conn.Status.NowPlaying = nowPlaying
-		statusUpdated = true
-	}
+	// Phase 2: fast merge. Only fields we successfully fetched
+	// overwrite; everything else keeps the value other goroutines may
+	// have just written.
+	conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
+		statusUpdated := false
 
-	// Get current volume
-	if volume, err := conn.Client.GetVolume(); err == nil {
-		conn.Status.Volume = volume
-		statusUpdated = true
-	}
+		if nowPlayingErr == nil {
+			s.NowPlaying = nowPlaying
+			statusUpdated = true
+		}
 
-	// Get presets
-	if presets, err := conn.Client.GetPresets(); err == nil {
-		conn.Status.Presets = presets
-		statusUpdated = true
-	}
+		if volumeErr == nil {
+			s.Volume = volume
+			statusUpdated = true
+		}
 
-	// Update last activity if any status was updated
-	if statusUpdated {
-		conn.Status.LastActivity = time.Now()
-	}
-	// Get sources
-	if sources, err := conn.Client.GetSources(); err == nil {
-		conn.Status.Sources = sources
-		statusUpdated = true
-	}
+		if presetsErr == nil {
+			s.Presets = presets
+			statusUpdated = true
+		}
 
-	// Get bass (if available)
-	if bass, err := conn.Client.GetBass(); err == nil {
-		conn.Status.Bass = bass
-		statusUpdated = true
-	}
+		if sourcesErr == nil {
+			s.Sources = sources
+			statusUpdated = true
+		}
 
-	// Mark as connected if we successfully got at least one status
-	conn.Status.IsConnected = statusUpdated
-	conn.Status.LastActivity = time.Now()
+		if bassErr == nil {
+			s.Bass = bass
+			statusUpdated = true
+		}
+
+		// Mark as connected if we successfully got at least one
+		// status from this round. Mirrors prior behaviour.
+		s.IsConnected = statusUpdated
+		s.LastActivity = time.Now()
+	})
 }
 
 // HandleDeviceWebSocket handles individual device WebSocket connections for real-time device-specific updates
@@ -253,7 +281,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 		DeviceID: deviceID,
 		Data: map[string]interface{}{
 			"info":   device.DeviceInfo,
-			"status": device.Status,
+			"status": device.Status(),
 		},
 	}
 
@@ -295,12 +323,13 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 		}
 
 		// Send device status update
+		status := device.Status()
 		statusMessage := webtypes.WebSocketMessage{
 			Type:     "device_status",
 			DeviceID: deviceID,
 			Data: map[string]interface{}{
 				"info":   device.DeviceInfo,
-				"status": device.Status,
+				"status": status,
 			},
 		}
 
@@ -311,13 +340,13 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 
 		// If device has active WebSocket connection to SoundTouch device,
 		// also send any real-time updates from that connection
-		if device.WebSocket != nil && device.Status.IsConnected {
+		if device.WebSocket != nil && status.IsConnected {
 			realtimeMessage := webtypes.WebSocketMessage{
 				Type:     "device_realtime",
 				DeviceID: deviceID,
 				Data: map[string]interface{}{
-					"nowPlaying": device.Status.NowPlaying,
-					"volume":     device.Status.Volume,
+					"nowPlaying": status.NowPlaying,
+					"volume":     status.Volume,
 					"timestamp":  time.Now(),
 				},
 			}

--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -103,7 +103,7 @@ func main() {
 				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 				defer cancel()
 
-				webApp.BroadcastDiscoveryStatus("starting", len(webApp.Devices))
+				webApp.BroadcastDiscoveryStatus("starting", webApp.DeviceCount())
 
 				for _, host := range manualHosts {
 					addDevice(webApp, host, 8090, "manual")
@@ -111,7 +111,7 @@ func main() {
 
 				discoverDevices(ctx, webApp, discoveryService)
 
-				webApp.BroadcastDiscoveryStatus("completed", len(webApp.Devices))
+				webApp.BroadcastDiscoveryStatus("completed", webApp.DeviceCount())
 				webApp.BroadcastDeviceList()
 			}()
 
@@ -217,8 +217,8 @@ func resolveBindAddr(bindAddr string) (string, error) {
 // mDNS/UPnP. If the host is already known, the existing entry's
 // LastSeen is bumped and the function returns without re-fetching.
 func addDevice(app *handlers.WebApp, host string, port int, source string) {
-	if existing, ok := app.Devices[host]; ok {
-		existing.LastSeen = time.Now()
+	// Fast path: skip the network call if we already know this host.
+	if app.TouchDevice(host) {
 		return
 	}
 
@@ -243,7 +243,12 @@ func addDevice(app *handlers.WebApp, host string, port int, source string) {
 			LastActivity: time.Now(),
 		},
 	}
-	app.Devices[host] = conn
+	if !app.AddDevice(host, conn) {
+		// Lost a race — another goroutine inserted the same host
+		// between TouchDevice and AddDevice. AddDevice bumped LastSeen
+		// on the existing entry; discard our conn.
+		return
+	}
 
 	go app.UpdateDeviceStatus(host, conn)
 
@@ -280,12 +285,12 @@ func setupRoutes(app *handlers.WebApp, discoveryService *discovery.UnifiedDiscov
 			defer cancel()
 
 			// Broadcast discovery start
-			app.BroadcastDiscoveryStatus("starting", len(app.Devices))
+			app.BroadcastDiscoveryStatus("starting", app.DeviceCount())
 
 			discoverDevices(ctx, app, discoveryService)
 
 			// Broadcast discovery completion and updated device list
-			app.BroadcastDiscoveryStatus("completed", len(app.Devices))
+			app.BroadcastDiscoveryStatus("completed", app.DeviceCount())
 			app.BroadcastDeviceList()
 		}()
 	})
@@ -321,7 +326,7 @@ func discoverDevices(ctx context.Context, app *handlers.WebApp, discoveryService
 	devices, err := discoveryService.DiscoverDevices(ctx)
 	if err != nil {
 		log.Printf("Discovery failed: %v", err)
-		app.BroadcastDiscoveryStatus("failed", len(app.Devices))
+		app.BroadcastDiscoveryStatus("failed", app.DeviceCount())
 
 		return
 	}

--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -234,15 +234,7 @@ func addDevice(app *handlers.WebApp, host string, port int, source string) {
 		return
 	}
 
-	conn := &webtypes.DeviceConnection{
-		Client:     c,
-		DeviceInfo: info,
-		LastSeen:   time.Now(),
-		Status: webtypes.DeviceStatus{
-			IsConnected:  false,
-			LastActivity: time.Now(),
-		},
-	}
+	conn := webtypes.NewDeviceConnection(c, info)
 	if !app.AddDevice(host, conn) {
 		// Lost a race — another goroutine inserted the same host
 		// between TouchDevice and AddDevice. AddDevice bumped LastSeen

--- a/cmd/soundtouch-web/main.go
+++ b/cmd/soundtouch-web/main.go
@@ -106,7 +106,7 @@ func main() {
 				webApp.BroadcastDiscoveryStatus("starting", len(webApp.Devices))
 
 				for _, host := range manualHosts {
-					addManualDevice(webApp, host, 8090)
+					addDevice(webApp, host, 8090, "manual")
 				}
 
 				discoverDevices(ctx, webApp, discoveryService)
@@ -210,36 +210,44 @@ func resolveBindAddr(bindAddr string) (string, error) {
 	}
 }
 
-func addManualDevice(app *handlers.WebApp, host string, port int) {
-	clientConfig := &client.Config{
+// addDevice registers a SoundTouch device with the WebApp by fetching
+// its /info and creating a DeviceConnection. The source label
+// ("manual" or "discovered") appears in log lines so the operator can
+// tell apart entries that came from --devices from those found via
+// mDNS/UPnP. If the host is already known, the existing entry's
+// LastSeen is bumped and the function returns without re-fetching.
+func addDevice(app *handlers.WebApp, host string, port int, source string) {
+	if existing, ok := app.Devices[host]; ok {
+		existing.LastSeen = time.Now()
+		return
+	}
+
+	c := client.NewClient(&client.Config{
 		Host:    host,
 		Port:    port,
 		Timeout: 10 * time.Second,
-	}
+	})
 
-	soundTouchClient := client.NewClient(clientConfig)
-
-	deviceInfo, err := soundTouchClient.GetDeviceInfo()
+	info, err := c.GetDeviceInfo()
 	if err != nil {
-		log.Printf("Failed to get device info for manual host %s: %v", host, err)
+		log.Printf("Failed to fetch device info from %s (%s): %v", host, source, err)
 		return
 	}
 
 	conn := &webtypes.DeviceConnection{
-		Client:     soundTouchClient,
-		DeviceInfo: deviceInfo,
+		Client:     c,
+		DeviceInfo: info,
 		LastSeen:   time.Now(),
 		Status: webtypes.DeviceStatus{
 			IsConnected:  false,
 			LastActivity: time.Now(),
 		},
 	}
+	app.Devices[host] = conn
 
 	go app.UpdateDeviceStatus(host, conn)
 
-	app.Devices[host] = conn
-
-	log.Printf("Added manual device: %s (%s) at %s:%d", deviceInfo.Name, deviceInfo.Type, host, port)
+	log.Printf("Added %s device %s (%s) at %s:%d", source, info.Name, info.Type, host, port)
 }
 
 func setupRoutes(app *handlers.WebApp, discoveryService *discovery.UnifiedDiscoveryService) *chi.Mux {
@@ -321,46 +329,6 @@ func discoverDevices(ctx context.Context, app *handlers.WebApp, discoveryService
 	log.Printf("Found %d devices", len(devices))
 
 	for _, device := range devices {
-		deviceID := device.Host // Use host as unique ID for now
-
-		// Skip if we already have this device
-		if _, exists := app.Devices[deviceID]; exists {
-			app.Devices[deviceID].LastSeen = time.Now()
-			continue
-		}
-
-		// Create new device connection
-		clientConfig := &client.Config{
-			Host:    device.Host,
-			Port:    device.Port,
-			Timeout: 10 * time.Second,
-		}
-
-		soundTouchClient := client.NewClient(clientConfig)
-
-		// Get device info
-		deviceInfo, err := soundTouchClient.GetDeviceInfo()
-		if err != nil {
-			log.Printf("Failed to get device info for %s: %v", device.Host, err)
-			continue
-		}
-
-		// Create device connection
-		conn := &webtypes.DeviceConnection{
-			Client:     soundTouchClient,
-			DeviceInfo: deviceInfo,
-			LastSeen:   time.Now(),
-			Status: webtypes.DeviceStatus{
-				IsConnected:  false,
-				LastActivity: time.Now(),
-			},
-		}
-
-		// Initial status fetch asynchronously to avoid blocking discovery
-		go app.UpdateDeviceStatus(deviceID, conn)
-
-		app.Devices[deviceID] = conn
-
-		log.Printf("Added device: %s (%s) at %s", deviceInfo.Name, deviceInfo.Type, device.Host)
+		addDevice(app, device.Host, device.Port, "discovered")
 	}
 }

--- a/cmd/soundtouch-web/spa_test.go
+++ b/cmd/soundtouch-web/spa_test.go
@@ -256,7 +256,7 @@ func TestControlAPIValidation(t *testing.T) {
 		LastSeen:   time.Now(),
 		Status:     webtypes.DeviceStatus{IsConnected: true},
 	}
-	app.Devices["testdevice"] = mockDevice
+	app.AddDevice("testdevice", mockDevice)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/soundtouch-web/spa_test.go
+++ b/cmd/soundtouch-web/spa_test.go
@@ -7,7 +7,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gesellix/bose-soundtouch/cmd/soundtouch-web/handlers"
 	"github.com/gesellix/bose-soundtouch/cmd/soundtouch-web/webtypes"
@@ -250,12 +249,8 @@ func TestControlAPIValidation(t *testing.T) {
 	}
 
 	// Add a mock device for testing unknown action validation
-	mockDevice := &webtypes.DeviceConnection{
-		Client:     nil,
-		DeviceInfo: &models.DeviceInfo{Name: "Test Device"},
-		LastSeen:   time.Now(),
-		Status:     webtypes.DeviceStatus{IsConnected: true},
-	}
+	mockDevice := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{Name: "Test Device"})
+	mockDevice.SetStatus(&webtypes.DeviceStatus{IsConnected: true})
 	app.AddDevice("testdevice", mockDevice)
 
 	for _, tt := range tests {

--- a/cmd/soundtouch-web/webtypes/status_test.go
+++ b/cmd/soundtouch-web/webtypes/status_test.go
@@ -1,0 +1,197 @@
+// Package webtypes tests for the atomic Status API on DeviceConnection
+// (Status, SetStatus, UpdateStatus, NewDeviceConnection).
+package webtypes
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+func TestNewDeviceConnection_InitialStatus(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+
+	status := conn.Status()
+	if status == nil {
+		t.Fatal("Status() returned nil from a NewDeviceConnection")
+	}
+
+	if status.IsConnected {
+		t.Error("IsConnected should default to false")
+	}
+
+	if status.LastActivity.IsZero() {
+		t.Error("LastActivity should be initialised, got zero time")
+	}
+}
+
+func TestSetStatus_ReplacesEntireStatus(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+	conn.SetStatus(&DeviceStatus{
+		Volume:      &models.Volume{ActualVolume: 42},
+		IsConnected: true,
+	})
+
+	got := conn.Status()
+	if got.Volume == nil || got.Volume.ActualVolume != 42 {
+		t.Errorf("Volume not stored: got %+v", got.Volume)
+	}
+
+	// Setting a sparser status should wipe previously-set fields.
+	conn.SetStatus(&DeviceStatus{IsConnected: false})
+
+	got = conn.Status()
+	if got.Volume != nil {
+		t.Error("SetStatus did not wipe previously-set Volume")
+	}
+
+	if got.IsConnected {
+		t.Error("SetStatus did not wipe IsConnected")
+	}
+}
+
+func TestUpdateStatus_AppliesMutator(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+
+	conn.UpdateStatus(func(s *DeviceStatus) {
+		s.IsConnected = true
+		s.Volume = &models.Volume{ActualVolume: 30}
+	})
+
+	got := conn.Status()
+	if !got.IsConnected {
+		t.Error("UpdateStatus did not set IsConnected")
+	}
+
+	if got.Volume == nil || got.Volume.ActualVolume != 30 {
+		t.Errorf("UpdateStatus did not set Volume: %+v", got.Volume)
+	}
+}
+
+func TestUpdateStatus_PreservesUnchangedFields(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+	conn.SetStatus(&DeviceStatus{
+		Volume:      &models.Volume{ActualVolume: 10},
+		Bass:        &models.Bass{ActualBass: 3},
+		IsConnected: true,
+	})
+
+	// Only touch Volume; Bass and IsConnected must survive.
+	conn.UpdateStatus(func(s *DeviceStatus) {
+		s.Volume = &models.Volume{ActualVolume: 99}
+	})
+
+	got := conn.Status()
+	if got.Volume.ActualVolume != 99 {
+		t.Errorf("Volume = %d, want 99", got.Volume.ActualVolume)
+	}
+
+	if got.Bass == nil || got.Bass.ActualBass != 3 {
+		t.Errorf("Bass not preserved: %+v", got.Bass)
+	}
+
+	if !got.IsConnected {
+		t.Error("IsConnected not preserved")
+	}
+}
+
+func TestStatusSnapshotIsolation(t *testing.T) {
+	// A snapshot returned by Status() must NOT change when a later
+	// UpdateStatus replaces a pointer field. This proves the atomic
+	// store gives readers a stable view (so long as the writer
+	// follows the docstring contract of replacing nested pointers).
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+	conn.SetStatus(&DeviceStatus{Volume: &models.Volume{ActualVolume: 1}})
+
+	first := conn.Status()
+
+	conn.UpdateStatus(func(s *DeviceStatus) {
+		s.Volume = &models.Volume{ActualVolume: 2}
+	})
+
+	if first.Volume.ActualVolume != 1 {
+		t.Errorf("Snapshot mutated after later UpdateStatus: got %d, want 1",
+			first.Volume.ActualVolume)
+	}
+
+	if conn.Status().Volume.ActualVolume != 2 {
+		t.Errorf("Current status not updated: got %d, want 2",
+			conn.Status().Volume.ActualVolume)
+	}
+}
+
+// TestStatusConcurrent runs many UpdateStatus writers alongside many
+// Status() readers. Before atomic.Pointer[DeviceStatus] this pattern
+// would be flagged by the race detector (writers mutate
+// conn.Status.X while readers copy conn.Status). With the atomic
+// pointer it must run clean under `go test -race`.
+func TestStatusConcurrent(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "concurrent"})
+
+	const writers = 16
+
+	const readersPerKind = 16
+
+	const opsPerGoroutine = 200
+
+	var wg sync.WaitGroup
+	wg.Add(writers + 2*readersPerKind)
+
+	// Writers: each goroutine replaces NowPlaying with a fresh struct
+	// carrying its worker id. Replacement (not in-place mutation)
+	// is what the UpdateStatus contract requires for nested
+	// pointers.
+	for w := 0; w < writers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			for i := 0; i < opsPerGoroutine; i++ {
+				conn.UpdateStatus(func(s *DeviceStatus) {
+					s.NowPlaying = &models.NowPlaying{
+						Track: fmt.Sprintf("w%d-%d", worker, i),
+					}
+					s.IsConnected = true
+				})
+			}
+		}(w)
+	}
+
+	// Readers via Status() — full snapshot.
+	for r := 0; r < readersPerKind; r++ {
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < opsPerGoroutine; i++ {
+				_ = conn.Status()
+			}
+		}()
+	}
+
+	// Readers that deref a single field. Tests the common
+	// "device.Status().IsConnected" pattern.
+	for r := 0; r < readersPerKind; r++ {
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < opsPerGoroutine; i++ {
+				_ = conn.Status().IsConnected
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// After all writers finish, IsConnected should be true (every
+	// writer sets it). The exact NowPlaying value is whichever
+	// writer landed last, but it must be a valid non-nil pointer.
+	final := conn.Status()
+	if !final.IsConnected {
+		t.Error("IsConnected should be true after writers ran")
+	}
+
+	if final.NowPlaying == nil {
+		t.Error("NowPlaying should be non-nil after writers ran")
+	}
+}

--- a/cmd/soundtouch-web/webtypes/types.go
+++ b/cmd/soundtouch-web/webtypes/types.go
@@ -2,6 +2,7 @@
 package webtypes
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/gesellix/bose-soundtouch/pkg/client"
@@ -29,13 +30,21 @@ type SoundTouchClient interface {
 	NewWebSocketClient(config interface{}) *client.WebSocketClient
 }
 
-// DeviceConnection wraps a SoundTouch client with WebSocket connection
+// DeviceConnection wraps a SoundTouch client with WebSocket connection.
+//
+// The Status field is stored behind atomic.Pointer so concurrent
+// readers (HTTP handlers, WebSocket broadcasters) never observe a
+// torn struct while a writer (UpdateDeviceStatus, WebSocket event
+// handlers) is mid-update. Access status through Status / SetStatus
+// / UpdateStatus rather than the private field; construct connections
+// via NewDeviceConnection to guarantee the status is initialised.
 type DeviceConnection struct {
 	Client     *client.Client
 	WebSocket  *client.WebSocketClient
 	DeviceInfo *models.DeviceInfo
 	LastSeen   time.Time
-	Status     DeviceStatus
+
+	status atomic.Pointer[DeviceStatus]
 }
 
 // DeviceStatus represents the current device state
@@ -47,6 +56,64 @@ type DeviceStatus struct {
 	Bass         *models.Bass       `json:"bass,omitempty"`
 	IsConnected  bool               `json:"isConnected"`
 	LastActivity time.Time          `json:"lastActivity"`
+}
+
+// NewDeviceConnection creates a fully-initialised connection. The
+// status starts with IsConnected=false and LastActivity set to now;
+// real values arrive via UpdateStatus once the device responds.
+func NewDeviceConnection(c *client.Client, info *models.DeviceInfo) *DeviceConnection {
+	conn := &DeviceConnection{
+		Client:     c,
+		DeviceInfo: info,
+		LastSeen:   time.Now(),
+	}
+	conn.status.Store(&DeviceStatus{
+		IsConnected:  false,
+		LastActivity: time.Now(),
+	})
+
+	return conn
+}
+
+// Status returns a snapshot of the current device status. The returned
+// pointer is read-only from the caller's perspective; mutating the
+// pointed-to struct has no effect on the stored status. Use
+// UpdateStatus or SetStatus to apply changes. Never returns nil for
+// connections built via NewDeviceConnection.
+func (c *DeviceConnection) Status() *DeviceStatus {
+	return c.status.Load()
+}
+
+// SetStatus atomically replaces the entire status. Use sparingly —
+// UpdateStatus is the preferred entry point because it preserves
+// concurrent changes from other goroutines.
+func (c *DeviceConnection) SetStatus(s *DeviceStatus) {
+	c.status.Store(s)
+}
+
+// UpdateStatus atomically applies mut to a copy of the current status
+// and stores the result. If another goroutine updates the status while
+// mut runs, UpdateStatus retries with the newer status — so concurrent
+// writers cannot silently lose each other's changes.
+//
+// The copy mut receives is a shallow value copy of the previous status.
+// Nested pointer fields (NowPlaying, Volume, Presets, Sources, Bass)
+// share their backing struct with the previous version: callers MUST
+// REPLACE these pointers (s.Volume = &models.Volume{...}) rather than
+// mutate through them (s.Volume.ActualVolume++ would race with any
+// reader still holding the previous snapshot). Production callers
+// receive these values fresh from the device API, so this is the
+// natural shape.
+func (c *DeviceConnection) UpdateStatus(mut func(*DeviceStatus)) {
+	for {
+		old := c.status.Load()
+		next := *old
+		mut(&next)
+
+		if c.status.CompareAndSwap(old, &next) {
+			return
+		}
+	}
 }
 
 // APIResponse is a standard JSON response wrapper

--- a/cmd/soundtouch-web/webtypes/types_test.go
+++ b/cmd/soundtouch-web/webtypes/types_test.go
@@ -145,31 +145,30 @@ func TestDeviceConnection(t *testing.T) {
 		MuteEnabled:  false,
 	}
 
-	conn := &DeviceConnection{
-		DeviceInfo: deviceInfo,
-		LastSeen:   time.Now(),
-		Status: DeviceStatus{
-			NowPlaying:   nowPlaying,
-			Volume:       volume,
-			IsConnected:  true,
-			LastActivity: time.Now(),
-		},
-	}
+	conn := NewDeviceConnection(nil, deviceInfo)
+	conn.SetStatus(&DeviceStatus{
+		NowPlaying:   nowPlaying,
+		Volume:       volume,
+		IsConnected:  true,
+		LastActivity: time.Now(),
+	})
 
 	t.Run("device connection fields", func(t *testing.T) {
 		if conn.DeviceInfo.Name != "Test Speaker" {
 			t.Errorf("Expected device name 'Test Speaker', got '%s'", conn.DeviceInfo.Name)
 		}
 
-		if conn.Status.NowPlaying.Track != "Test Track" {
-			t.Errorf("Expected track 'Test Track', got '%s'", conn.Status.NowPlaying.Track)
+		status := conn.Status()
+
+		if status.NowPlaying.Track != "Test Track" {
+			t.Errorf("Expected track 'Test Track', got '%s'", status.NowPlaying.Track)
 		}
 
-		if conn.Status.Volume.ActualVolume != 50 {
-			t.Errorf("Expected volume 50, got %d", conn.Status.Volume.ActualVolume)
+		if status.Volume.ActualVolume != 50 {
+			t.Errorf("Expected volume 50, got %d", status.Volume.ActualVolume)
 		}
 
-		if !conn.Status.IsConnected {
+		if !status.IsConnected {
 			t.Error("Expected device to be connected")
 		}
 	})


### PR DESCRIPTION
Three small refactors of `cmd/soundtouch-web`, each on its own commit:

1. **`81f1587`** — unify the manual (`--devices`) and discovered device-registration paths behind one `addDevice` helper. Same client setup, info fetch, log wording for both.
2. **`d1284d5`** — encapsulate `WebApp.Devices` behind `GetDevice` / `DeviceSnapshot` / `AddDevice` / `TouchDevice` / `DeviceCount`. Fixes the latent `concurrent map read and map write` panic between HTTP handlers and the discovery goroutine.
3. **`95688a9`** — make `DeviceConnection.Status` an `atomic.Pointer[DeviceStatus]` with `Status()` / `SetStatus()` / `UpdateStatus(func)` methods. Closes the per-connection struct race between the poller and the WebSocket event handlers.

All three pass `go test -race ./cmd/soundtouch-web/...`. New tests in `handlers/registry_test.go` and `webtypes/status_test.go` exercise the concurrent access patterns explicitly so future regressions trip CI.

Known follow-ups (not in this PR): the `WebSocket` and `LastSeen` fields on `DeviceConnection` are still cross-goroutine reads without their own synchronisation. Cosmetic at our scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)