### PR TITLE
fix: removing stale devices from datastore

### DIFF
--- a/pkg/service/bmx/radiobrowser.go
+++ b/pkg/service/bmx/radiobrowser.go
@@ -20,6 +20,7 @@ func RadioBrowserSearch(query string) (*models.BmxNavResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -1412,6 +1412,24 @@ func (ds *DataStore) RemoveDeviceDir(account, device string) error {
 	return ds.RemoveDevice(account, device)
 }
 
+// MoveDevice atomically moves a device directory from one account to another
+// on the same filesystem. If the target account directory doesn't exist it is
+// created. Returns an error if the rename fails (leaving the source intact).
+func (ds *DataStore) MoveDevice(oldAccount, newAccount, deviceID string) error {
+	ds.fileMutex.Lock()
+	defer ds.fileMutex.Unlock()
+
+	oldDir := ds.AccountDeviceDir(oldAccount, deviceID)
+	newDir := ds.AccountDeviceDir(newAccount, deviceID)
+
+	newAccountDir := filepath.Dir(newDir)
+	if err := ds.rootMkdirAll(newAccountDir, 0755); err != nil {
+		return err
+	}
+
+	return ds.rootRename(oldDir, newDir)
+}
+
 // DeduceSourceIDs updates the source IDs in the given slice by deducing them from recents and presets.
 func (ds *DataStore) DeduceSourceIDs(account, device string, sources []models.ConfiguredSource) {
 	// Deduce source IDs from recents and presets

--- a/pkg/service/datastore/datastore_test.go
+++ b/pkg/service/datastore/datastore_test.go
@@ -457,3 +457,40 @@ func TestSettingsPersistence(t *testing.T) {
 		t.Errorf("Expected DiscoveryEnabled %v, got %v", settings.DiscoveryEnabled, loaded.DiscoveryEnabled)
 	}
 }
+
+func TestMoveDeviceMigratesData(t *testing.T) {
+	tempDir := t.TempDir()
+	ds := NewDataStore(tempDir)
+
+	oldAccount := "default"
+	newAccount := "8637922"
+	deviceID := "F4E11E930BEB"
+
+	// Seed the device under the old account with presets
+	presets := []models.ServicePreset{
+		{ID: "1", ServiceContentItem: models.ServiceContentItem{Name: "Radio Preset", ContentItemType: "stationurl"}},
+	}
+	if err := ds.SavePresets(oldAccount, deviceID, presets); err != nil {
+		t.Fatalf("SavePresets under %s: %v", oldAccount, err)
+	}
+
+	// Move the device to the new account
+	if err := ds.MoveDevice(oldAccount, newAccount, deviceID); err != nil {
+		t.Fatalf("MoveDevice %s → %s: %v", oldAccount, newAccount, err)
+	}
+
+	// Verify presets survived the move under the new account
+	moved, err := ds.GetPresets(newAccount, deviceID)
+	if err != nil {
+		t.Fatalf("GetPresets under %s after move: %v", newAccount, err)
+	}
+	if len(moved) != 1 || moved[0].Name != "Radio Preset" {
+		t.Errorf("presets not preserved: got %+v", moved)
+	}
+
+	// Verify the old account no longer has the device
+	oldPresets, err := ds.GetPresets(oldAccount, deviceID)
+	if err == nil && len(oldPresets) > 0 {
+		t.Errorf("old account %s still has presets after move: %+v", oldAccount, oldPresets)
+	}
+}

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -998,10 +998,12 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	if existing := s.findExistingDeviceInfoByDeviceID(deviceID); existing != nil {
 		storedAccount = existing.AccountID
 	}
+
 	accountID := liveInfo.MargeAccountUUID
 	if accountID == "" {
 		accountID = storedAccount
 	}
+
 	if accountID == "" {
 		accountID = "default"
 	}

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -1007,19 +1007,12 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	}
 
 	// If the speaker reports a paired account that differs from the stored
-	// location, clean up the stale entry so ListAllDevices doesn't return duplicates.
+	// location, migrate the device directory so ListAllDevices doesn't return duplicates.
 	if liveInfo.MargeAccountUUID != "" && storedAccount != "" && liveInfo.MargeAccountUUID != storedAccount {
-		// Preserve presets, recents and sources before cleaning up
-		if presets, err := s.ds.GetPresets(storedAccount, deviceID); err == nil && len(presets) > 0 {
-			_ = s.ds.SavePresets(liveInfo.MargeAccountUUID, deviceID, presets)
+		if err := s.ds.MoveDevice(storedAccount, accountID, deviceID); err != nil {
+			log.Printf("Failed to migrate device %s from %s to %s: %v",
+				deviceID, storedAccount, accountID, err)
 		}
-		if recents, err := s.ds.GetRecents(storedAccount, deviceID); err == nil && len(recents) > 0 {
-			_ = s.ds.SaveRecents(liveInfo.MargeAccountUUID, deviceID, recents)
-		}
-		if sources, err := s.ds.GetConfiguredSources(storedAccount, deviceID); err == nil && len(sources) > 0 {
-			_ = s.ds.SaveConfiguredSources(liveInfo.MargeAccountUUID, deviceID, sources)
-		}
-		s.ds.RemoveDevice(storedAccount, deviceID)
 	}
 
 	// 4. Get primary MAC address from networkInfo

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -994,16 +994,32 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	log.Printf("Using deviceID '%s' from /info for device %s at %s", deviceID, d.Name, d.Host)
 
 	// 3. Get account ID from live info or fallback to existing/default
+	storedAccount := ""
+	if existing := s.findExistingDeviceInfoByDeviceID(deviceID); existing != nil {
+		storedAccount = existing.AccountID
+	}
 	accountID := liveInfo.MargeAccountUUID
 	if accountID == "" {
-		// Try to find account ID from existing device entries
-		if existing := s.findExistingDeviceInfoByDeviceID(deviceID); existing != nil {
-			accountID = existing.AccountID
-		}
+		accountID = storedAccount
 	}
-
 	if accountID == "" {
 		accountID = "default"
+	}
+
+	// If the speaker reports a paired account that differs from the stored
+	// location, clean up the stale entry so ListAllDevices doesn't return duplicates.
+	if liveInfo.MargeAccountUUID != "" && storedAccount != "" && liveInfo.MargeAccountUUID != storedAccount {
+		// Preserve presets, recents and sources before cleaning up
+		if presets, err := s.ds.GetPresets(storedAccount, deviceID); err == nil && len(presets) > 0 {
+			_ = s.ds.SavePresets(liveInfo.MargeAccountUUID, deviceID, presets)
+		}
+		if recents, err := s.ds.GetRecents(storedAccount, deviceID); err == nil && len(recents) > 0 {
+			_ = s.ds.SaveRecents(liveInfo.MargeAccountUUID, deviceID, recents)
+		}
+		if sources, err := s.ds.GetConfiguredSources(storedAccount, deviceID); err == nil && len(sources) > 0 {
+			_ = s.ds.SaveConfiguredSources(liveInfo.MargeAccountUUID, deviceID, sources)
+		}
+		s.ds.RemoveDevice(storedAccount, deviceID)
 	}
 
 	// 4. Get primary MAC address from networkInfo

--- a/pkg/service/health/checks_refresh_sources.go
+++ b/pkg/service/health/checks_refresh_sources.go
@@ -114,6 +114,7 @@ func postSourcesUpdated(ds *datastore.DataStore, target Target) (string, error) 
 	if err != nil {
 		return "", fmt.Errorf("post to speaker: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {

--- a/pkg/service/health/checks_test_playback.go
+++ b/pkg/service/health/checks_test_playback.go
@@ -132,6 +132,7 @@ func playDingOnDevice(ds *datastore.DataStore, serverURL string, target Target) 
 	if err != nil {
 		return "", fmt.Errorf("post to speaker: %w", err)
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {

--- a/pkg/service/health/probe.go
+++ b/pkg/service/health/probe.go
@@ -63,6 +63,7 @@ func ProbeGet(ctx context.Context, rawURL string, timeout time.Duration) ProbeRe
 		result.Err = err.Error()
 		return result
 	}
+
 	defer func() { _ = resp.Body.Close() }()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1 MiB cap


### PR DESCRIPTION
## Description

Fixes #346.

I am not entirely sure if we should merge this as is... The thing that confuses me, is that `/setup/devices` still returns the old name, while `/setup/info/<id>` returns the new one.