### PR TITLE
feat(export): improve diagnostic report web UI

### DIFF
--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -1511,6 +1511,19 @@
             findings that may need attention. Quick fixes are offered
             for issues the service knows how to remediate.
         </p>
+        <details style="font-size: 0.85em; color: #555; margin-bottom: 10px;">
+            <summary style="cursor: pointer;">What does the diagnostic report contain?</summary>
+            <ul style="margin: 6px 0 0 0; padding-left: 1.4em;">
+                <li>Health check results and current device state</li>
+                <li>Device XML files from the datastore (no passwords)</li>
+                <li>HTTP response samples from speaker endpoints</li>
+                <li>System files: CA bundle, DNS resolver config</li>
+                <li>Speaker CA bundle and kernel log (via SSH, if reachable)</li>
+                <li>Service log tail</li>
+                <li>Settings file with secrets redacted</li>
+            </ul>
+            <p style="margin: 6px 0 0 0;">The archive is encrypted with the project maintainer's public key — only they can open it.</p>
+        </details>
         <div id="health-generated-at" style="font-size: 0.8em; color: #888; margin-bottom: 10px;"></div>
         <div id="health-diagnostic-status" style="font-size: 0.85em; margin-bottom: 8px;"></div>
         <div id="health-findings">Loading…</div>

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -4038,7 +4038,16 @@ async function downloadDiagnostic() {
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
 
-        if (statusEl) statusEl.textContent = `Downloaded: ${filename}`;
+        if (statusEl) {
+            const safe = filename.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            statusEl.innerHTML =
+                `Downloaded: <strong>${safe}</strong><br>` +
+                `To share it, please <strong>prefer email</strong>: ` +
+                `<a href="mailto:aftertouch-support@gesellix.net?subject=Diagnostic%20report&body=Please%20attach%20${encodeURIComponent(safe)}%20to%20this%20email.">aftertouch-support@gesellix.net</a>. ` +
+                `Alternatively, open a <a href="https://github.com/gesellix/Bose-SoundTouch/issues" target="_blank" rel="noopener">GitHub issue</a> ` +
+                `and attach the file renamed to <code>${safe}.txt</code> ` +
+                `(GitHub blocks <code>.age</code> uploads; adding <code>.txt</code> works around that).`;
+        }
     } catch (e) {
         if (statusEl) statusEl.textContent = `Failed to download diagnostic: ${e.message || e}`;
     }


### PR DESCRIPTION
Add a `<details>` block listing what the encrypted archive contains so reporters know what they're sharing before clicking. After a successful download, show two submission options with email preferred: aftertouch-support@gesellix.net (mailto link with pre-filled subject and filename) or a GitHub issue with the file renamed to `<filename>.txt` (GitHub blocks `.age` uploads).
