### PR TITLE
feat: smarter :443 preflight + persisted TLS extra hosts with QuickFix

### DIFF
--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1304,7 +1304,12 @@ func runHTTPSPreflight(httpsServerURL, serverURL string, dnsEnabled bool, resolv
 
 	guidance := handlers.FormatPreflightGuidance(port, res)
 	if guidance == "" {
-		if !res.Skipped {
+		switch {
+		case res.Skipped:
+			// Listener already on :443 — nothing to say.
+		case res.NotApplicable:
+			log.Printf("HTTPS pre-flight: :443 check skipped — %s", res.Reason)
+		default:
 			log.Printf("HTTPS pre-flight: :443 reachable at localhost and %s ✓", res.LANHost)
 		}
 

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -810,7 +810,42 @@ func applyPersistedSettings(ds *datastore.DataStore, config *serviceConfig) data
 	// CLI/env args take precedence; only apply persisted credentials when not set via CLI.
 	applyPersistedMusicServiceCredentials(config, persisted)
 
+	config.tlsExtraHosts = mergeTLSExtraHosts(config.tlsExtraHosts, persisted.TLSExtraHosts)
+
 	return persisted
+}
+
+// mergeTLSExtraHosts merges the CLI/env-supplied hosts with the persisted
+// list. CLI/env wins (so an operator who pinned a host via systemd unit
+// always sees it applied); persisted values are additive. Returns a
+// deduplicated, order-preserving slice with CLI/env entries first.
+func mergeTLSExtraHosts(cli, persisted []string) []string {
+	seen := make(map[string]bool, len(cli)+len(persisted))
+	out := make([]string, 0, len(cli)+len(persisted))
+
+	for _, h := range cli {
+		h = strings.TrimSpace(h)
+		if h == "" || seen[h] {
+			continue
+		}
+
+		seen[h] = true
+
+		out = append(out, h)
+	}
+
+	for _, h := range persisted {
+		h = strings.TrimSpace(h)
+		if h == "" || seen[h] {
+			continue
+		}
+
+		seen[h] = true
+
+		out = append(out, h)
+	}
+
+	return out
 }
 
 // applyPersistedMusicServiceCredentials fills in music service credentials from persisted

--- a/cmd/soundtouch-service/main_test.go
+++ b/cmd/soundtouch-service/main_test.go
@@ -90,3 +90,64 @@ func TestApplyPersistedSettings(t *testing.T) {
 		}
 	})
 }
+
+func TestMergeTLSExtraHosts(t *testing.T) {
+	cases := []struct {
+		name      string
+		cli       []string
+		persisted []string
+		want      []string
+	}{
+		{
+			name:      "CLI only",
+			cli:       []string{"a.example"},
+			persisted: nil,
+			want:      []string{"a.example"},
+		},
+		{
+			name:      "Persisted only",
+			cli:       nil,
+			persisted: []string{"b.example"},
+			want:      []string{"b.example"},
+		},
+		{
+			name:      "CLI wins ordering, persisted appended",
+			cli:       []string{"a.example"},
+			persisted: []string{"b.example"},
+			want:      []string{"a.example", "b.example"},
+		},
+		{
+			name:      "Dedupes overlap",
+			cli:       []string{"a.example", "b.example"},
+			persisted: []string{"b.example", "c.example"},
+			want:      []string{"a.example", "b.example", "c.example"},
+		},
+		{
+			name:      "Drops empty + whitespace",
+			cli:       []string{"  ", "a.example", ""},
+			persisted: []string{"", "  b.example  "},
+			want:      []string{"a.example", "b.example"},
+		},
+		{
+			name:      "Both empty",
+			cli:       nil,
+			persisted: nil,
+			want:      []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mergeTLSExtraHosts(tc.cli, tc.persisted)
+			if len(got) != len(tc.want) {
+				t.Fatalf("len mismatch: got %v, want %v", got, tc.want)
+			}
+
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("index %d: got %q, want %q (full: %v vs %v)", i, got[i], tc.want[i], got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/docs/guides/HTTPS-SETUP.md
+++ b/docs/guides/HTTPS-SETUP.md
@@ -58,6 +58,8 @@ Speakers expect HTTPS on the default port 443. Since binding to port 443 require
 
     The first rule covers traffic arriving from speakers; the second covers loopback connections from the host itself (useful for the in-built pre-flight probe).
 
+    > **Caveat — OUTPUT chain.** The second rule catches **all** outbound `:443` traffic from this host, including the AfterTouch host's own connections to the wider internet (browsers, `go install` against `proxy.golang.org`, `apt-get`, `git clone https://...`, etc.). Speakers reaching AfterTouch from the LAN only ever pass through `PREROUTING`. If you don't run the in-built pre-flight probe from this host, or if you've seen other software break with TLS errors after adding both rules, add only the `PREROUTING` rule and skip `OUTPUT`. The pre-flight's "localhost:443" probe will then report unreachable — that's expected and harmless.
+
 2. **Capabilities**: Grant the binary permission to bind low ports and start the listener directly on `:443`:
 
     ```bash
@@ -82,7 +84,11 @@ The same check runs once at service startup and prints a `[WARN]` log line if `:
 
 The `:443` indicator is only displayed when **AfterTouch's DNS interception is enabled** (Settings → "Enable DNS Discovery Server"). The check is only meaningful for the **DNS migration method**, where speakers reach AfterTouch via intercepted Bose hostnames and therefore on the implicit `:443`. The other migration method — writing direct `https://<host>:8443/...` URLs into the speaker's private config via SSH — uses the port that's literally in the URL, so `:443` is irrelevant and the check would only add noise.
 
-If you intercept Bose hostnames **outside** AfterTouch (Pi-hole, router DNS rule, `/etc/hosts` on a gateway), the UI gate above will hide the indicator. The data is still in the `GET /setup/settings` JSON response (`https_443_localhost_reachable`, `https_443_lan_reachable`, `https_443_lan_host`) if you want to inspect it directly, or you can briefly enable AfterTouch's DNS server to see the indicator render.
+#### Not applicable in HTTP-only deployments
+
+When AfterTouch's configured `--server-url` is `http://…`, the pre-flight short-circuits to an `ℹ️ :443 reachability check not applicable` info line. Speakers that were migrated to that HTTP URL never connect to `:443`, so the iptables / setcap / reverse-proxy work is only needed if you also expect unmigrated speakers to fall back to `streaming.bose.com:443` via DNS hijack. If that's not your situation, the iptables rules above are optional.
+
+If you intercept Bose hostnames **outside** AfterTouch (Pi-hole, router DNS rule, `/etc/hosts` on a gateway), the UI gate above will hide the indicator. The data is still in the `GET /setup/settings` JSON response (`https_443_localhost_reachable`, `https_443_lan_reachable`, `https_443_lan_host`, `https_443_not_applicable`, `https_443_reason`) if you want to inspect it directly, or you can briefly enable AfterTouch's DNS server to see the indicator render.
 
 ---
 

--- a/docs/guides/HTTPS-SETUP.md
+++ b/docs/guides/HTTPS-SETUP.md
@@ -88,6 +88,15 @@ The `:443` indicator is only displayed when **AfterTouch's DNS interception is e
 
 When AfterTouch's configured `--server-url` is `http://…`, the pre-flight short-circuits to an `ℹ️ :443 reachability check not applicable` info line. Speakers that were migrated to that HTTP URL never connect to `:443`, so the iptables / setcap / reverse-proxy work is only needed if you also expect unmigrated speakers to fall back to `streaming.bose.com:443` via DNS hijack. If that's not your situation, the iptables rules above are optional.
 
+#### Adding extra hosts to the TLS certificate
+
+If speakers reach AfterTouch via a hostname or IP that isn't already covered by the served certificate, the speaker rejects the TLS handshake (typical syslog: `CURLE_SSL_CACERT (60)`). Two paths to fix this:
+
+* **One-click QuickFix on the Health tab.** The `speaker_marge_url` check detects the mismatch and offers an `Add <host> to TLS hosts` button. Clicking it appends the missing host to `settings.json` (`tls_extra_hosts`). A subsequent service restart regenerates the certificate.
+* **Settings tab → "TLS extra hosts" textarea.** Add one host per line and click Save. Same persistence path; restart required to apply. The textarea is pre-filled with the persisted list; the read-only "Currently covered by TLS cert" line below it shows the full effective SAN list (including the values from `--server-url`, `--https-server-url`, the system hostname, and any `--tls-extra-host` / `TLS_EXTRA_HOST` CLI/env entries).
+
+CLI/env values still win over persisted ones, so an operator who pinned a host via systemd unit doesn't have to migrate it into `settings.json` — the merge in `applyPersistedSettings` deduplicates while preserving order.
+
 If you intercept Bose hostnames **outside** AfterTouch (Pi-hole, router DNS rule, `/etc/hosts` on a gateway), the UI gate above will hide the indicator. The data is still in the `GET /setup/settings` JSON response (`https_443_localhost_reachable`, `https_443_lan_reachable`, `https_443_lan_host`, `https_443_not_applicable`, `https_443_reason`) if you want to inspect it directly, or you can briefly enable AfterTouch's DNS server to see the indicator render.
 
 ---

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -2346,6 +2346,14 @@ type Settings struct {
 	// different host within a known-good private subnet.
 	TrustedProxyCIDRs []string `json:"trusted_proxy_cidrs,omitempty"`
 
+	// TLSExtraHosts is the persisted list of additional DNS names or IPs
+	// to include in the TLS certificate SAN list. Merged with the
+	// CLI/env --tls-extra-host values at startup (CLI/env wins; persisted
+	// values are additive and deduplicated). Applying a change requires a
+	// service restart so the TLS cert can be regenerated. Used by the
+	// `speaker_marge_url` health check's QuickFix and the Settings tab UI.
+	TLSExtraHosts []string `json:"tls_extra_hosts,omitempty"`
+
 	// TuneInStreamFormats overrides the comma-separated format list
 	// AfterTouch sends to TuneIn's Tune.ashx (formats=…). Empty value
 	// uses bmx.DefaultTuneInStreamFormats ("mp3,aac,ogg"), which

--- a/pkg/service/handlers/handlers_setup.go
+++ b/pkg/service/handlers/handlers_setup.go
@@ -195,6 +195,8 @@ func (s *Server) HandleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"https_server_url":              httpsServerURL,
 		"https_listener_port":           httpsListenerPort,
 		"https_443_check_skipped":       probe443.Skipped,
+		"https_443_not_applicable":      probe443.NotApplicable,
+		"https_443_reason":              probe443.Reason,
 		"https_443_localhost_reachable": probe443.Localhost.Reachable,
 		"https_443_localhost_error":     probe443.Localhost.Error,
 		"https_443_lan_reachable":       probe443.LAN.Reachable,

--- a/pkg/service/handlers/handlers_setup.go
+++ b/pkg/service/handlers/handlers_setup.go
@@ -197,6 +197,8 @@ func (s *Server) HandleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"https_443_check_skipped":       probe443.Skipped,
 		"https_443_not_applicable":      probe443.NotApplicable,
 		"https_443_reason":              probe443.Reason,
+		"tls_extra_hosts":               s.persistedTLSExtraHosts(),
+		"tls_san_hosts":                 s.ExpectedHosts(),
 		"https_443_localhost_reachable": probe443.Localhost.Reachable,
 		"https_443_localhost_error":     probe443.Localhost.Error,
 		"https_443_lan_reachable":       probe443.LAN.Reachable,
@@ -245,6 +247,7 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		AmazonClientID      string         `json:"amazon_client_id"`
 		AmazonClientSecret  string         `json:"amazon_client_secret"`
 		AmazonRedirectURI   string         `json:"amazon_redirect_uri"`
+		TLSExtraHosts       *[]string      `json:"tls_extra_hosts"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -324,6 +327,13 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 	currentRecord := s.recordEnabled
 	currentHTTPS := s.httpsServerURL
 
+	// Resolve TLS extra hosts: nil pointer means "field omitted, preserve existing";
+	// non-nil (even empty) means "replace with this list".
+	resolvedTLSExtraHosts := s.persistedTLSExtraHosts()
+	if settings.TLSExtraHosts != nil {
+		resolvedTLSExtraHosts = normaliseTLSExtraHosts(*settings.TLSExtraHosts)
+	}
+
 	log.Printf("Saving updated settings to %s/settings.json", s.ds.DataDir)
 	err = s.ds.SaveSettings(datastore.Settings{
 		ServerURL:           s.serverURL,
@@ -344,6 +354,7 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		AmazonClientID:      s.amazonClientID,
 		AmazonClientSecret:  s.amazonClientSecret,
 		AmazonRedirectURI:   s.amazonRedirectURI,
+		TLSExtraHosts:       resolvedTLSExtraHosts,
 	})
 
 	dnsEnabled := s.dnsEnabled
@@ -375,6 +386,28 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return
 	}
+}
+
+// normaliseTLSExtraHosts trims whitespace from each entry, drops empty
+// values, and deduplicates while preserving the first occurrence's
+// position. The settings endpoint applies this before persisting so the
+// stored list is always canonical.
+func normaliseTLSExtraHosts(in []string) []string {
+	out := make([]string, 0, len(in))
+	seen := make(map[string]bool, len(in))
+
+	for _, h := range in {
+		h = strings.TrimSpace(h)
+		if h == "" || seen[h] {
+			continue
+		}
+
+		seen[h] = true
+
+		out = append(out, h)
+	}
+
+	return out
 }
 
 // HandleGetDeviceInfo returns live information for a device.

--- a/pkg/service/handlers/handlers_tls_hosts_fix.go
+++ b/pkg/service/handlers/handlers_tls_hosts_fix.go
@@ -1,0 +1,109 @@
+package handlers
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/service/health"
+)
+
+// addMargeHostToTLSFix is the FixFunc registered for the
+// (CheckIDSpeakerMargeURL, FixIDAddMargeHostToTLS) pair. It re-probes
+// the target device's <margeURL>, extracts the host portion, and
+// appends it to the persisted Settings.TLSExtraHosts. A subsequent
+// service restart picks up the change via the regular settings
+// merge path in applyPersistedSettings (cmd/soundtouch-service/main.go).
+//
+// The re-probe is deliberate: the persisted Settings only become
+// authoritative after the operator restarts AfterTouch, so reading
+// the margeURL fresh from the speaker avoids racing a stale finding
+// that was rendered before the speaker rebooted.
+//
+// Returns a success message that names the host and instructs the
+// operator to restart the service. Returns an error if the device
+// can't be located, the probe fails, or the marge URL is empty /
+// unparseable.
+func (s *Server) addMargeHostToTLSFix(target health.Target) (string, error) {
+	if target.Device == "" {
+		return "", fmt.Errorf("device is required")
+	}
+
+	deviceIP, err := s.resolveDeviceIDToIP(target.Device)
+	if err != nil {
+		return "", fmt.Errorf("locate device %s: %w", target.Device, err)
+	}
+
+	probeURL := fmt.Sprintf("http://%s:8090/info", deviceIP)
+
+	margeHost, err := fetchMargeHostFromSpeaker(probeURL, 2*time.Second)
+	if err != nil {
+		return "", err
+	}
+
+	if margeHost == "" {
+		return "", fmt.Errorf("speaker %s has no <margeURL>; nothing to add", target.Device)
+	}
+
+	persisted, err := s.ds.GetSettings()
+	if err != nil {
+		return "", fmt.Errorf("load settings: %w", err)
+	}
+
+	for _, existing := range persisted.TLSExtraHosts {
+		if strings.EqualFold(strings.TrimSpace(existing), margeHost) {
+			return fmt.Sprintf("%s is already in the persisted TLS hosts. Restart AfterTouch to regenerate the TLS certificate if you haven't already.", margeHost), nil
+		}
+	}
+
+	persisted.TLSExtraHosts = append(persisted.TLSExtraHosts, margeHost)
+
+	if err := s.ds.SaveSettings(persisted); err != nil {
+		return "", fmt.Errorf("save settings: %w", err)
+	}
+
+	return fmt.Sprintf("Added %s to persisted TLS hosts (tls_extra_hosts). Restart AfterTouch for the TLS certificate to be regenerated and include this host in its SAN list.", margeHost), nil
+}
+
+// fetchMargeHostFromSpeaker probes the given speaker /info URL and
+// returns the host portion of the <margeURL> XML element. Returns an
+// empty string with no error when the speaker responds but doesn't
+// carry a margeURL. Returns a non-nil error when the probe itself
+// fails or the response can't be parsed.
+func fetchMargeHostFromSpeaker(probeURL string, timeout time.Duration) (string, error) {
+	res := health.ProbeGet(context.Background(), probeURL, timeout)
+	if !res.Reachable {
+		return "", fmt.Errorf("speaker probe failed: %s", res.Err)
+	}
+
+	if res.Status != 200 {
+		return "", fmt.Errorf("speaker /info returned HTTP %d", res.Status)
+	}
+
+	var parsed struct {
+		MargeURL string `xml:"margeURL"`
+	}
+
+	if err := xml.Unmarshal(res.Body, &parsed); err != nil {
+		return "", fmt.Errorf("parse /info: %w", err)
+	}
+
+	if parsed.MargeURL == "" {
+		return "", nil
+	}
+
+	u, err := url.Parse(parsed.MargeURL)
+	if err != nil {
+		return "", fmt.Errorf("parse margeURL %q: %w", parsed.MargeURL, err)
+	}
+
+	host := u.Hostname()
+	if host == "" {
+		host = strings.TrimSpace(parsed.MargeURL)
+	}
+
+	return host, nil
+}

--- a/pkg/service/handlers/handlers_tls_hosts_fix_test.go
+++ b/pkg/service/handlers/handlers_tls_hosts_fix_test.go
@@ -1,0 +1,92 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func stubInfoForFix(t *testing.T, margeURL string) string {
+	t.Helper()
+
+	body := `<?xml version="1.0" encoding="UTF-8" ?><info deviceID="DEVICEID01"><name>Test</name><margeAccountUUID>1000001</margeAccountUUID><margeURL>` + margeURL + `</margeURL></info>`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/info" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(srv.Close)
+
+	return srv.URL + "/info"
+}
+
+func TestFetchMargeHostFromSpeaker_ReturnsHostOnly(t *testing.T) {
+	cases := []struct {
+		name     string
+		margeURL string
+		want     string
+	}{
+		{
+			name:     "HTTPS with port",
+			margeURL: "https://aftertouch.example:8443/",
+			want:     "aftertouch.example",
+		},
+		{
+			name:     "HTTP IP with port",
+			margeURL: "http://192.0.2.10:8000/",
+			want:     "192.0.2.10",
+		},
+		{
+			name:     "Bare host fallback",
+			margeURL: "aftertouch.example",
+			want:     "aftertouch.example",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			probeURL := stubInfoForFix(t, tc.margeURL)
+
+			got, err := fetchMargeHostFromSpeaker(probeURL, 2*time.Second)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFetchMargeHostFromSpeaker_EmptyMargeURLReturnsEmpty(t *testing.T) {
+	probeURL := stubInfoForFix(t, "")
+
+	got, err := fetchMargeHostFromSpeaker(probeURL, 2*time.Second)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got != "" {
+		t.Errorf("expected empty host for empty margeURL, got %q", got)
+	}
+}
+
+func TestFetchMargeHostFromSpeaker_UnreachableReturnsError(t *testing.T) {
+	// Point at a closed port; the probe should fail without panicking.
+	_, err := fetchMargeHostFromSpeaker("http://127.0.0.1:1/info", 200*time.Millisecond)
+	if err == nil {
+		t.Errorf("expected error for unreachable speaker, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "probe failed") {
+		t.Errorf("expected 'probe failed' in error, got %q", err.Error())
+	}
+}

--- a/pkg/service/handlers/preflight.go
+++ b/pkg/service/handlers/preflight.go
@@ -5,17 +5,26 @@ import (
 	"net"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 )
 
 // Probe443Result captures the outcome of probing a host on :443.
 // Skipped is true when the running HTTPS listener is already on :443
 // (in which case the listener itself is the proof of reachability).
+// NotApplicable is true when the operator has chosen an HTTP-only
+// deployment (configured serverURL is http://...) — speakers migrated
+// to that URL never connect to :443, so the iptables/setcap dance
+// would only matter for unmigrated speakers falling back to
+// streaming.bose.com via DNS hijack. Reason carries a short
+// human-readable explanation rendered in the UI.
 type Probe443Result struct {
-	Skipped   bool
-	Localhost ProbeOutcome
-	LAN       ProbeOutcome
-	LANHost   string
+	Skipped       bool
+	NotApplicable bool
+	Reason        string
+	Localhost     ProbeOutcome
+	LAN           ProbeOutcome
+	LANHost       string
 }
 
 // ProbeOutcome describes a single TCP-connect probe. Exactly one of
@@ -72,6 +81,14 @@ func Check443Reachability(
 		return Probe443Result{Skipped: true}
 	}
 
+	if scheme := schemeOf(serverURL); scheme == "http" {
+		return Probe443Result{
+			NotApplicable: true,
+			Reason: "AfterTouch's configured serverURL is HTTP, so migrated speakers connect over plain HTTP and never use :443. " +
+				"The iptables / setcap / reverse-proxy dance is only needed if you also expect unmigrated speakers to fall back to streaming.bose.com via DNS hijack.",
+		}
+	}
+
 	res := Probe443Result{}
 
 	if err := ProbeTCP("127.0.0.1", 443, timeout); err != nil {
@@ -95,6 +112,22 @@ func Check443Reachability(
 	}
 
 	return res
+}
+
+// schemeOf returns the lowercased URL scheme of s, or "" if s is empty or
+// unparseable. Used to decide whether the :443 reachability check is even
+// applicable to the deployment.
+func schemeOf(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	u, err := url.Parse(s)
+	if err != nil {
+		return ""
+	}
+
+	return strings.ToLower(u.Scheme)
 }
 
 // PortFromHTTPSServerURL extracts the numeric port from httpsServerURL. It
@@ -129,7 +162,7 @@ func PortFromHTTPSServerURL(httpsServerURL string) int {
 // returned string ends without a trailing newline so callers may use it
 // with log.Print or log.Printf as they prefer.
 func FormatPreflightGuidance(httpsListenerPort int, res Probe443Result) string {
-	if res.Skipped {
+	if res.Skipped || res.NotApplicable {
 		return ""
 	}
 
@@ -161,6 +194,7 @@ func FormatPreflightGuidance(httpsListenerPort int, res Probe443Result) string {
 		"    1. iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port "+strconv.Itoa(httpsListenerPort),
 		"    2. setcap cap_net_bind_service=+ep <binary> and pass --https-port=443",
 		"    3. reverse proxy (nginx/caddy) terminating TLS on :443",
+		"  Caveat: do NOT add the same REDIRECT rule on the OUTPUT chain. That would catch this host's own outbound :443 traffic (browsers, `go install`, `apt-get`) and route it to AfterTouch.",
 		"  See docs/guides/HTTPS-SETUP.md for details.",
 	)
 

--- a/pkg/service/handlers/preflight_test.go
+++ b/pkg/service/handlers/preflight_test.go
@@ -48,7 +48,8 @@ func TestCheck443Reachability_SkipsWhenListenerOn443(t *testing.T) {
 }
 
 func TestCheck443Reachability_ReportsResolverError(t *testing.T) {
-	res := Check443Reachability(8443, "http://broken", func(string) (string, error) {
+	// Use an HTTPS server URL so the NotApplicable short-circuit doesn't fire.
+	res := Check443Reachability(8443, "https://broken", func(string) (string, error) {
 		return "", errResolve("no DNS")
 	}, 100*time.Millisecond)
 
@@ -62,6 +63,57 @@ func TestCheck443Reachability_ReportsResolverError(t *testing.T) {
 
 	if !strings.Contains(res.LAN.Error, "cannot resolve LAN target") {
 		t.Errorf("expected LAN.Error to wrap resolver failure, got %q", res.LAN.Error)
+	}
+}
+
+func TestCheck443Reachability_NotApplicableWhenServerURLIsHTTP(t *testing.T) {
+	res := Check443Reachability(8443, "http://aftertouch.local:8000", func(string) (string, error) {
+		t.Errorf("resolver should not be called when serverURL scheme is HTTP")
+		return "", nil
+	}, 100*time.Millisecond)
+
+	if !res.NotApplicable {
+		t.Errorf("expected NotApplicable=true when serverURL is HTTP, got %+v", res)
+	}
+
+	if res.Reason == "" {
+		t.Errorf("expected NotApplicable verdict to carry a human-readable Reason, got empty")
+	}
+
+	if res.Skipped {
+		t.Errorf("Skipped should only be set when the listener is already on :443; got Skipped=true for HTTP serverURL")
+	}
+}
+
+func TestCheck443Reachability_NotApplicableTakesPrecedenceOverProbe(t *testing.T) {
+	// Even if the listener isn't on :443 and probes would fail, an HTTP
+	// serverURL should short-circuit to NotApplicable.
+	res := Check443Reachability(8443, "http://1.2.3.4:8000", func(string) (string, error) {
+		return "1.2.3.4", nil
+	}, 100*time.Millisecond)
+
+	if !res.NotApplicable {
+		t.Errorf("expected NotApplicable=true, got %+v", res)
+	}
+
+	if res.LAN.Error != "" || res.Localhost.Error != "" {
+		t.Errorf("expected no probe errors when NotApplicable short-circuits, got %+v", res)
+	}
+}
+
+func TestCheck443Reachability_HTTPSServerURLStillProbes(t *testing.T) {
+	resolverCalled := false
+	res := Check443Reachability(8443, "https://aftertouch.local:8443", func(string) (string, error) {
+		resolverCalled = true
+		return "127.0.0.1", nil
+	}, 100*time.Millisecond)
+
+	if !resolverCalled {
+		t.Errorf("resolver should be called for HTTPS serverURL")
+	}
+
+	if res.NotApplicable {
+		t.Errorf("HTTPS serverURL should not produce NotApplicable, got %+v", res)
 	}
 }
 
@@ -98,6 +150,10 @@ func TestFormatPreflightGuidance_SkippedAndAllOK(t *testing.T) {
 	if FormatPreflightGuidance(8443, bothOK) != "" {
 		t.Errorf("expected empty guidance when both probes succeed")
 	}
+
+	if FormatPreflightGuidance(8443, Probe443Result{NotApplicable: true, Reason: "HTTP only"}) != "" {
+		t.Errorf("expected empty guidance when NotApplicable (UI renders the reason separately)")
+	}
 }
 
 func TestFormatPreflightGuidance_BothFailMentionsRedirectPort(t *testing.T) {
@@ -121,6 +177,19 @@ func TestFormatPreflightGuidance_BothFailMentionsRedirectPort(t *testing.T) {
 	}
 }
 
+func TestFormatPreflightGuidance_IncludesOutputChainCaveat(t *testing.T) {
+	res := Probe443Result{
+		Localhost: ProbeOutcome{Error: "connection refused"},
+		LAN:       ProbeOutcome{Error: "connection refused"},
+		LANHost:   "192.0.2.151",
+	}
+
+	out := FormatPreflightGuidance(8443, res)
+	if !strings.Contains(out, "OUTPUT") {
+		t.Errorf("guidance must warn about the iptables OUTPUT chain side-effect, got: %s", out)
+	}
+}
+
 type errResolve string
 
 func (e errResolve) Error() string { return string(e) }
@@ -131,8 +200,9 @@ func TestCheck443Reachability_LANProbeMatchesListenerOutcome(t *testing.T) {
 	// nothing answers on :443 in test environments. The point of this test
 	// is to lock in the result-shape: when localhost:443 is closed (the
 	// default in CI), the function still returns a well-formed result and
-	// reports the resolved LAN host.
-	res := Check443Reachability(8443, "http://1.2.3.4:8000", func(string) (string, error) {
+	// reports the resolved LAN host. Uses HTTPS so the NotApplicable
+	// short-circuit doesn't fire.
+	res := Check443Reachability(8443, "https://1.2.3.4:8443", func(string) (string, error) {
 		return "1.2.3.4", nil
 	}, 200*time.Millisecond)
 

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -145,6 +145,15 @@ func NewServer(ds *datastore.DataStore, sm *setup.Manager, serverURL string, red
 		health.FixIDCompleteSpeakerPairing,
 		s.completeSpeakerPairingFix,
 	)
+
+	// QuickFix executor for the speaker_marge_url mismatch finding.
+	// Adds the speaker's actual margeURL host to settings.TLSExtraHosts
+	// so a subsequent restart picks it up via applyPersistedSettings.
+	s.healthRegistry.RegisterFix(
+		health.CheckIDSpeakerMargeURL,
+		health.FixIDAddMargeHostToTLS,
+		s.addMargeHostToTLSFix,
+	)
 	health.RegisterDNSSanityCheck(
 		s.healthRegistry,
 		s.GetDNSRunning,
@@ -184,6 +193,25 @@ func (s *Server) ExpectedHosts() []string {
 
 	out := make([]string, len(s.expectedHosts))
 	copy(out, s.expectedHosts)
+
+	return out
+}
+
+// persistedTLSExtraHosts returns the slice of TLS extra hosts that
+// live in settings.json. Used by HandleGetSettings to render the
+// "edit list" UI separately from the full effective SAN list
+// (ExpectedHosts also contains serverURL host, httpsServerURL host,
+// hostname, and CLI/env-pinned extras). Returns an empty slice if
+// the settings file is missing or unreadable — the caller should
+// treat that the same as "operator hasn't added anything yet".
+func (s *Server) persistedTLSExtraHosts() []string {
+	persisted, err := s.ds.GetSettings()
+	if err != nil {
+		return []string{}
+	}
+
+	out := make([]string, len(persisted.TLSExtraHosts))
+	copy(out, persisted.TLSExtraHosts)
 
 	return out
 }

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -169,22 +169,39 @@
             <strong>TLS extra hosts:</strong>
             <span class="info-toggle" onclick="toggleInfo('tls-extra-hosts-info')">ⓘ</span>
             <div id="tls-extra-hosts-info" class="info-details">
-                Additional DNS names or IPs the served TLS certificate
-                should cover. Speakers that talk to AfterTouch via a
-                hostname or IP not already in the cert's SAN list
-                reject the TLS handshake — typically symptom:
+                <strong>When you need this:</strong> rarely. The TLS
+                certificate already covers AfterTouch's configured
+                server URL, HTTPS URL, and the host's own name. Add
+                entries here only when a speaker can't reach
+                AfterTouch over TLS — typical symptoms include
+                presets resetting on reboot, the BoseApp showing
+                the speaker as offline, or
                 <code>CURLE_SSL_CACERT (60)</code> in the speaker
-                syslog. The
-                <code>speaker_marge_url</code> health check on the
-                Health tab detects this and offers a one-click
-                QuickFix that appends the missing host here.<br/>
-                <strong>Applying changes requires a service restart.</strong>
-                The TLS certificate is regenerated at startup from
-                the merged list of <code>--server-url</code> host,
+                syslog.<br/>
+                <strong>How to tell:</strong> open the
+                <strong>Health tab</strong> and look for
+                <code>speaker_marge_url</code> warnings. Each
+                warning names the host a speaker is pointing at;
+                clicking the <em>Add &lt;host&gt; to TLS hosts</em>
+                QuickFix fills this list for you. If that check is
+                clean, this list can stay empty.<br/>
+                <strong>Manual path:</strong> add one host per line
+                and save. The TLS certificate is regenerated at
+                startup from the merged list of
+                <code>--server-url</code> host,
                 <code>--https-server-url</code> host, the system
                 hostname, any <code>--tls-extra-host</code> /
                 <code>TLS_EXTRA_HOST</code> CLI/env values, and the
-                hosts persisted below.
+                hosts persisted here. CLI/env wins over persisted
+                on overlap.<br/>
+                <strong>Applying changes requires a service
+                restart.</strong>
+            </div>
+            <div style="font-size: 0.85em; color: #666; margin-top: 4px;">
+                Usually empty. Add a host here only if the
+                <a href="#" onclick="openTab(null, 'tab-health'); return false;">Health tab</a>
+                flags a <code>speaker_marge_url</code> warning — or use
+                the one-click QuickFix on that warning to fill it for you.
             </div>
             <div style="margin-top: 5px">
                 <textarea

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -1548,32 +1548,36 @@
     <div id="tab-health" class="tab-content">
         <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px;">
             <h2 style="margin: 0;">Service Health Checks</h2>
-            <div style="display: flex; gap: 8px; align-items: center; flex-wrap: wrap;">
-                <button onclick="fetchHealth()">Refresh</button>
-                <button onclick="downloadDiagnostic()" title="Download an encrypted diagnostic report to share with the project maintainer">Download diagnostic report</button>
-            </div>
+            <button onclick="fetchHealth()">Refresh</button>
         </div>
         <p style="font-size: 0.9em; color: #555;">
             Runs a set of checks against the local datastore and flags
             findings that may need attention. Quick fixes are offered
             for issues the service knows how to remediate.
         </p>
-        <details style="font-size: 0.85em; color: #555; margin-bottom: 10px;">
-            <summary style="cursor: pointer;">What does the diagnostic report contain?</summary>
-            <ul style="margin: 6px 0 0 0; padding-left: 1.4em;">
-                <li>Health check results and current device state</li>
-                <li>Device XML files from the datastore (no passwords)</li>
-                <li>HTTP response samples from speaker endpoints</li>
-                <li>System files: CA bundle, DNS resolver config</li>
-                <li>Speaker CA bundle and kernel log (via SSH, if reachable)</li>
-                <li>Service log tail</li>
-                <li>Settings file with secrets redacted</li>
-            </ul>
-            <p style="margin: 6px 0 0 0;">The archive is encrypted with the project maintainer's public key — only they can open it.</p>
-        </details>
         <div id="health-generated-at" style="font-size: 0.8em; color: #888; margin-bottom: 10px;"></div>
-        <div id="health-diagnostic-status" style="font-size: 0.85em; margin-bottom: 8px;"></div>
         <div id="health-findings">Loading…</div>
+
+        <div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee;">
+            <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
+                <button onclick="downloadDiagnostic()" title="Download an encrypted diagnostic report to share with the project maintainer">Download diagnostic report</button>
+                <span style="font-size: 0.9em; color: #555;">Share a diagnostic snapshot with the project maintainer.</span>
+            </div>
+            <details style="font-size: 0.85em; color: #555; margin-top: 8px;">
+                <summary style="cursor: pointer;">What does the diagnostic report contain?</summary>
+                <ul style="margin: 6px 0 0 0; padding-left: 1.4em;">
+                    <li>Health check results and current device state</li>
+                    <li>Device XML files from the datastore (no passwords)</li>
+                    <li>HTTP response samples from speaker endpoints</li>
+                    <li>System files: CA bundle, DNS resolver config</li>
+                    <li>Speaker CA bundle and kernel log (via SSH, if reachable)</li>
+                    <li>Service log tail</li>
+                    <li>Settings file with secrets redacted</li>
+                </ul>
+                <p style="margin: 6px 0 0 0;">The archive is encrypted with the project maintainer's public key — only they can open it.</p>
+            </details>
+            <div id="health-diagnostic-status" style="font-size: 0.85em; margin-top: 8px;"></div>
+        </div>
     </div>
 
     <!-- Tab 8: Logs -->

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -1555,10 +1555,8 @@
             findings that may need attention. Quick fixes are offered
             for issues the service knows how to remediate.
         </p>
-        <div id="health-generated-at" style="font-size: 0.8em; color: #888; margin-bottom: 10px;"></div>
-        <div id="health-findings">Loading…</div>
 
-        <div style="margin-top: 24px; padding-top: 16px; border-top: 1px solid #eee;">
+        <div style="margin: 12px 0 16px 0; padding: 10px 12px; background: #fafafa; border: 1px solid #eee; border-radius: 4px;">
             <div style="display: flex; align-items: center; gap: 12px; flex-wrap: wrap;">
                 <button onclick="downloadDiagnostic()" title="Download an encrypted diagnostic report to share with the project maintainer">Download diagnostic report</button>
                 <span style="font-size: 0.9em; color: #555;">Share a diagnostic snapshot with the project maintainer.</span>
@@ -1578,6 +1576,9 @@
             </details>
             <div id="health-diagnostic-status" style="font-size: 0.85em; margin-top: 8px;"></div>
         </div>
+
+        <div id="health-generated-at" style="font-size: 0.8em; color: #888; margin-bottom: 10px;"></div>
+        <div id="health-findings">Loading…</div>
     </div>
 
     <!-- Tab 8: Logs -->

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -166,6 +166,36 @@
             <div id="https-443-status" style="font-size: 0.85em; margin-top: 4px; min-height: 1.2em"></div>
         </div>
         <div style="margin-bottom: 20px">
+            <strong>TLS extra hosts:</strong>
+            <span class="info-toggle" onclick="toggleInfo('tls-extra-hosts-info')">ⓘ</span>
+            <div id="tls-extra-hosts-info" class="info-details">
+                Additional DNS names or IPs the served TLS certificate
+                should cover. Speakers that talk to AfterTouch via a
+                hostname or IP not already in the cert's SAN list
+                reject the TLS handshake — typically symptom:
+                <code>CURLE_SSL_CACERT (60)</code> in the speaker
+                syslog. The
+                <code>speaker_marge_url</code> health check on the
+                Health tab detects this and offers a one-click
+                QuickFix that appends the missing host here.<br/>
+                <strong>Applying changes requires a service restart.</strong>
+                The TLS certificate is regenerated at startup from
+                the merged list of <code>--server-url</code> host,
+                <code>--https-server-url</code> host, the system
+                hostname, any <code>--tls-extra-host</code> /
+                <code>TLS_EXTRA_HOST</code> CLI/env values, and the
+                hosts persisted below.
+            </div>
+            <div style="margin-top: 5px">
+                <textarea
+                    id="tls-extra-hosts"
+                    placeholder="One host per line, e.g. 192.0.2.10 or aftertouch.lan"
+                    style="width: 360px; height: 84px; font-family: monospace; font-size: 0.9em;"
+                ></textarea>
+            </div>
+            <div id="tls-san-effective" style="font-size: 0.8em; color: #666; margin-top: 4px;"></div>
+        </div>
+        <div style="margin-bottom: 20px">
             <strong>Device Discovery:</strong>
             <div style="margin-top: 5px">
                 <label style="display: block; margin-bottom: 5px">

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -216,6 +216,10 @@ async function fetchSettings() {
             } else if (settings.https_443_check_skipped) {
                 port443.style.color = "#2e7d32";
                 port443.innerHTML = "✅ HTTPS listener bound directly to <code>:443</code> — speakers can connect.";
+            } else if (settings.https_443_not_applicable) {
+                port443.style.color = "#1565c0";
+                port443.innerHTML = "ℹ️ <code>:443</code> reachability check not applicable. " +
+                    (settings.https_443_reason || "");
             } else {
                 const localhostOK = settings.https_443_localhost_reachable;
                 const lanOK = settings.https_443_lan_reachable;

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -283,6 +283,18 @@ async function fetchSettings() {
             document.getElementById("internal-paths").value = settings.internal_paths.join("\n");
         }
 
+        if (Array.isArray(settings.tls_extra_hosts)) {
+            document.getElementById("tls-extra-hosts").value = settings.tls_extra_hosts.join("\n");
+        }
+        const effective = document.getElementById("tls-san-effective");
+        if (effective) {
+            if (Array.isArray(settings.tls_san_hosts) && settings.tls_san_hosts.length) {
+                effective.innerText = "Currently covered by TLS cert: " + settings.tls_san_hosts.join(", ");
+            } else {
+                effective.innerText = "";
+            }
+        }
+
         // Spotify credential fields
         if (settings.spotify_client_id !== undefined) {
             document.getElementById("spotify-client-id").value = settings.spotify_client_id || "";
@@ -376,6 +388,11 @@ async function updateSettings() {
         amazon_client_id: document.getElementById("amazon-client-id").value,
         amazon_client_secret: document.getElementById("amazon-client-secret").value,
         amazon_redirect_uri: document.getElementById("amazon-redirect-uri").value,
+        tls_extra_hosts: document
+            .getElementById("tls-extra-hosts")
+            .value.split("\n")
+            .map((s) => s.trim())
+            .filter((s) => s !== ""),
     };
     const status = document.getElementById("settings-status");
     status.innerText = "Saving...";

--- a/pkg/service/health/checks_marge_url.go
+++ b/pkg/service/health/checks_marge_url.go
@@ -11,6 +11,15 @@ import (
 	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
 )
 
+// FixIDAddMargeHostToTLS is the QuickFix that re-probes the speaker
+// at the target device's known IP, extracts the host portion of its
+// <margeURL>, and appends it to the persisted TLSExtraHosts in
+// settings.json. A service restart is then required for the TLS cert
+// to be regenerated. The fix lives in the handlers package because
+// it needs the datastore writer; the constant lives here so check
+// and fix share the same identifier.
+const FixIDAddMargeHostToTLS = "add_marge_host_to_tls"
+
 // CheckIDSpeakerMargeURL is the registry id of the Marge-URL
 // consistency check.
 const CheckIDSpeakerMargeURL = "speaker_marge_url"
@@ -112,11 +121,16 @@ func assessMargeURLForDeviceWithURL(account, deviceID, probeURL string, expected
 			parsed.MargeURL,
 		),
 		Details: fmt.Sprintf(
-			"Configured hosts: %s. If the speaker should reach this service via %q, restart with `--tls-extra-host=%s` so the served TLS cert covers it. Otherwise, re-migrate the speaker to the correct URL.",
+			"Configured hosts: %s. If the speaker should reach this service via %q, click the QuickFix below (or restart with `--tls-extra-host=%s`) so the served TLS cert covers it. Otherwise, re-migrate the speaker to the correct URL.",
 			joinHosts(expected), margeHost, margeHost,
 		),
+		QuickFixes: []QuickFix{{
+			ID:      FixIDAddMargeHostToTLS,
+			Label:   fmt.Sprintf("Add %s to TLS hosts", margeHost),
+			Confirm: fmt.Sprintf("This will append %s to settings.json (tls_extra_hosts) and persist it. A service restart is required afterwards for the TLS certificate to be regenerated.", margeHost),
+		}},
 		ManualCommands: []ManualCommand{{
-			Label:   "Add the speaker's expected hostname to AfterTouch's TLS cert:",
+			Label:   "Or set via CLI/env and restart:",
 			Command: fmt.Sprintf("soundtouch-service --tls-extra-host=%s …", margeHost),
 			Hint:    "Append to your existing service command-line / env (TLS_EXTRA_HOST). Requires a restart.",
 		}},

--- a/pkg/service/health/checks_marge_url_test.go
+++ b/pkg/service/health/checks_marge_url_test.go
@@ -64,6 +64,18 @@ func TestMargeURL_FlagsMismatch(t *testing.T) {
 	if !strings.Contains(cmd, "tls-extra-host=other-host.example") {
 		t.Errorf("expected --tls-extra-host suggestion, got %q", cmd)
 	}
+
+	if len(got[0].QuickFixes) != 1 || got[0].QuickFixes[0].ID != FixIDAddMargeHostToTLS {
+		t.Fatalf("expected QuickFix with ID=%s, got %+v", FixIDAddMargeHostToTLS, got[0].QuickFixes)
+	}
+
+	if !strings.Contains(got[0].QuickFixes[0].Label, "other-host.example") {
+		t.Errorf("expected QuickFix label to name the missing host, got %q", got[0].QuickFixes[0].Label)
+	}
+
+	if got[0].QuickFixes[0].Confirm == "" {
+		t.Errorf("expected QuickFix to carry a Confirm message (operator needs to know a restart is required)")
+	}
 }
 
 func TestMargeURL_SkipsWhenMargeURLEmpty(t *testing.T) {


### PR DESCRIPTION
Closes the UX gap behind #218 + #344: AfterTouch was emitting a red `:443 unreachable` warning on HTTP-only deployments where speakers never connect to :443, and the iptables-OUTPUT-chain workaround caught the host's own outbound HTTPS. Operators who needed `--tls-extra-host` had to SSH in and restart with a CLI flag; now it's a one-click Health-tab QuickFix or a Settings-tab textarea.

## What's in this PR

- **`:443` preflight is now scheme-aware.** `Check443Reachability` returns `NotApplicable` (rendered as an ℹ️ info badge, not red ✗) when the configured serverURL is HTTP. The iptables hint grows a caveat warning against the OUTPUT chain.
- **`TLSExtraHosts` is persisted.** New field on `datastore.Settings`. Startup merges CLI/env (still wins) with persisted (additive, deduped). Editable via a Settings-tab textarea; the effective SAN list is shown read-only below.
- **`speaker_marge_url` QuickFix.** New `add_marge_host_to_tls` fix re-probes the device's `/info`, extracts the margeURL host, and appends it to settings.json. Idempotent.
- **Settings-tab copy answers "do I need this?" first.** Always-visible hint points to the Health tab as the trigger condition.
- **Health-tab layout.** Diagnostic-export button + "What does the report contain?" details block are now adjacent in a bordered subsection above the findings, so the Download button stays visible regardless of findings count.
- **Docs.** `HTTPS-SETUP.md` documents the new verdicts, the OUTPUT-chain caveat, and the UI workflow.

## Tests

New cases in `preflight_test.go`, `checks_marge_url_test.go`, `main_test.go`, and a new `handlers_tls_hosts_fix_test.go`. `make check` and `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)