### PR TITLE
fix(web): skip auto-discovery on page load when periodic discovery is disabled

### DIFF
--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -216,7 +216,7 @@
             <strong>Device Discovery:</strong>
             <div style="margin-top: 5px">
                 <label style="display: block; margin-bottom: 5px">
-                    <input type="checkbox" id="discovery-enabled"/> Enable Automated Discovery
+                    <input type="checkbox" id="discovery-enabled"/> Enable Periodic Discovery
                 </label>
                 <div style="margin-left: 20px">
                     <label for="discovery-interval">Discovery Interval:</label>

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -382,6 +382,7 @@ async function fetchSettings() {
 
         fetchLoggingSettings();
         fetchSpotifyStatus();
+        return settings;
     } catch (error) {
         console.error("Failed to fetch settings", error);
     }
@@ -1665,8 +1666,10 @@ function formatXML(xml) {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
-    fetchSettings();
-    triggerDiscovery();
+    const cfg = await fetchSettings();
+    if (cfg?.discovery_enabled !== false) {
+        triggerDiscovery();
+    }
     fetchVersion();
     await fetchDevices();
 
@@ -4051,10 +4054,12 @@ async function applyCustomPlan() {
     }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
     fetchDevices();
-    fetchSettings();
-    triggerDiscovery();
+    const cfg = await fetchSettings();
+    if (cfg?.discovery_enabled !== false) {
+        triggerDiscovery();
+    }
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- When `discovery_enabled` is `false`, the page no longer fires a discovery scan on load — both `DOMContentLoaded` handlers now `await fetchSettings()` and gate `triggerDiscovery()` on the returned flag.
- Default is `true` so existing installations that never changed the setting are unaffected.
- Renames the UI checkbox label from "Enable Automated Discovery" → "Enable Periodic Discovery" to make clear it controls the background timer, not the manual trigger button or IP-entry form.

No backend changes needed — the `discovery_enabled` bool and its persistence in `settings.json` are already correct.

Relates to #269

## Test plan

- [ ] `make check` green
- [ ] With discovery enabled (default): page load fires discovery as before
- [ ] Disable "Enable Periodic Discovery", save, reload — no discovery spinner on load; device list still populates via `fetchDevices()`
- [ ] Manual "Discover Devices" button still works regardless of setting
- [ ] `settings.json` persists `"discovery_enabled": false` across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)