### PR TITLE
refactor: drop INTERNET_RADIO stub from initial sources + removal tooling

### DIFF
--- a/cmd/soundtouch-cli/cmd_cloud.go
+++ b/cmd/soundtouch-cli/cmd_cloud.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/urfave/cli/v2"
+)
+
+// cloudCommand assembles the `soundtouch-cli cloud …` command group.
+// All subcommands talk to the AfterTouch service (not the speaker directly)
+// and require --service-url.
+func cloudCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "cloud",
+		Usage: "Manage AfterTouch service data (sources, accounts, devices)",
+		Subcommands: []*cli.Command{
+			cloudSourceCmd(),
+		},
+	}
+}
+
+func cloudSourceCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "source",
+		Usage: "Manage sources stored in AfterTouch",
+		Subcommands: []*cli.Command{
+			cloudSourceRemoveCmd(),
+		},
+	}
+}
+
+func cloudSourceRemoveCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "remove",
+		Usage: "Remove a source from AfterTouch's datastore for a specific device",
+		Flags: append(CloudCommonFlags,
+			&cli.StringFlag{
+				Name:     "account",
+				Aliases:  []string{"a"},
+				Usage:    "Account ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "device",
+				Aliases:  []string{"d"},
+				Usage:    "Device ID",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:  "id",
+				Usage: "Source ID to remove (e.g. 10002)",
+			},
+			&cli.StringFlag{
+				Name:    "type",
+				Aliases: []string{"t"},
+				Usage:   "Source type to remove (e.g. INTERNET_RADIO). Resolved to a canonical ID; fails if multiple sources share the type.",
+			},
+		),
+		Action: cloudSourceRemove,
+	}
+}
+
+// canonicalSourceID maps well-known SourceKeyType values to their canonical IDs.
+// Used to resolve --type to an ID without requiring a round-trip GET.
+var canonicalSourceID = map[string]string{
+	"AUX":                  "10001",
+	"INTERNET_RADIO":       "10002",
+	"LOCAL_INTERNET_RADIO": "10003",
+	"TUNEIN":               "10004",
+	"RADIO_BROWSER":        "10005",
+}
+
+func cloudSourceRemove(c *cli.Context) error {
+	serviceURL := strings.TrimRight(c.String("service-url"), "/")
+	account := c.String("account")
+	device := c.String("device")
+	sourceID := c.String("id")
+	sourceType := strings.ToUpper(c.String("type"))
+
+	if sourceID == "" && sourceType == "" {
+		return fmt.Errorf("one of --id or --type is required")
+	}
+
+	if sourceID != "" && sourceType != "" {
+		return fmt.Errorf("only one of --id or --type may be given")
+	}
+
+	if sourceType != "" {
+		id, ok := canonicalSourceID[sourceType]
+		if !ok {
+			return fmt.Errorf("unknown source type %q; use --id for non-canonical sources", sourceType)
+		}
+
+		sourceID = id
+	}
+
+	url := fmt.Sprintf("%s/setup/sources/%s/%s/%s", serviceURL, account, device, sourceID)
+
+	req, err := http.NewRequest(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNoContent {
+		PrintSuccess(fmt.Sprintf("Removed source %s from device %s (account %s)", sourceID, device, account))
+
+		if sourceType != "" {
+			fmt.Printf("  Type: %s\n", sourceType)
+		}
+
+		return nil
+	}
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+
+	return fmt.Errorf("service returned %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+}

--- a/cmd/soundtouch-cli/cmd_source.go
+++ b/cmd/soundtouch-cli/cmd_source.go
@@ -3,6 +3,8 @@ package main
 import (
 	"encoding/base64"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -684,4 +686,52 @@ func boolToStatus(b bool) string {
 	}
 
 	return "❌ No"
+}
+
+// notifySourcesUpdated POSTs a sourcesUpdated notification directly to the
+// speaker's :8090/notification endpoint. The speaker re-fetches its source
+// list from AfterTouch immediately. Requires network access to the speaker.
+func notifySourcesUpdated(c *cli.Context) error {
+	if err := RequireHost(c); err != nil {
+		return err
+	}
+
+	clientConfig := GetClientConfig(c)
+
+	client, err := CreateSoundTouchClient(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	info, err := client.GetDeviceInfo()
+	if err != nil {
+		return fmt.Errorf("failed to get device info from %s: %w", clientConfig.Host, err)
+	}
+
+	body := fmt.Sprintf(`<updates deviceID="%s"><sourcesUpdated/></updates>`, info.DeviceID)
+	notifyURL := fmt.Sprintf("http://%s:8090/notification", clientConfig.Host)
+
+	req, err := http.NewRequest(http.MethodPost, notifyURL, strings.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/xml")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("post to speaker: %w", err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<10))
+
+		return fmt.Errorf("speaker returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+
+	PrintSuccess(fmt.Sprintf("Sent sourcesUpdated to %s (%s)", info.DeviceID, clientConfig.Host))
+
+	return nil
 }

--- a/cmd/soundtouch-cli/common.go
+++ b/cmd/soundtouch-cli/common.go
@@ -22,10 +22,10 @@ import (
 // CloudCommonFlags defines flags for commands that talk to the AfterTouch service.
 var CloudCommonFlags = []cli.Flag{
 	&cli.StringFlag{
-		Name:    "service-url",
-		Usage:   "AfterTouch service URL",
-		Value:   "http://aftertouch.local:8000",
-		EnvVars: []string{"AFTERTOUCH_URL"},
+		Name:     "service-url",
+		Usage:    "AfterTouch service URL",
+		Required: true,
+		EnvVars:  []string{"AFTERTOUCH_URL"},
 	},
 }
 

--- a/cmd/soundtouch-cli/common.go
+++ b/cmd/soundtouch-cli/common.go
@@ -19,6 +19,16 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+// CloudCommonFlags defines flags for commands that talk to the AfterTouch service.
+var CloudCommonFlags = []cli.Flag{
+	&cli.StringFlag{
+		Name:    "service-url",
+		Usage:   "AfterTouch service URL",
+		Value:   "http://aftertouch.local:8000",
+		EnvVars: []string{"AFTERTOUCH_URL"},
+	},
+}
+
 // CommonFlags defines flags that are shared across multiple commands
 var CommonFlags = []cli.Flag{
 	&cli.StringFlag{

--- a/cmd/soundtouch-cli/main.go
+++ b/cmd/soundtouch-cli/main.go
@@ -1146,6 +1146,12 @@ func main() {
 						Action: introspectAllServices,
 						Before: RequireHost,
 					},
+					{
+						Name:   "notify-updated",
+						Usage:  "Tell the speaker to re-fetch its source list from AfterTouch",
+						Action: notifySourcesUpdated,
+						Before: RequireHost,
+					},
 				},
 			},
 			// Bass commands
@@ -2237,6 +2243,10 @@ func main() {
 	// Speaker provisioning (factory-reset, Wi-Fi, URL rewrite, pairing).
 	// Defined in cmd_setup.go to keep the top-level command list readable.
 	app.Commands = append(app.Commands, setupCommand())
+
+	// AfterTouch service management (sources, accounts, devices).
+	// Defined in cmd_cloud.go.
+	app.Commands = append(app.Commands, cloudCommand())
 
 	// Sort commands alphabetically (including subcommands and flags recursively)
 	sortCommands(app.Commands)

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1244,6 +1244,7 @@ func setupRouter(server *handlers.Server, stockholmHandler *stockholm.Handler) *
 		r.Get("/dns-discoveries", server.HandleGetDNSDiscoveries)
 		r.Get("/dns-discoveries/download", server.HandleDownloadDNSDiscoveries)
 		r.Delete("/dns-discoveries", server.HandleClearDNSDiscoveries)
+		r.Delete("/sources/{account}/{device}/{sourceID}", server.HandleDeleteSource)
 
 		r.Get("/devices/{deviceId}/events", server.HandleGetDeviceEvents)
 		r.Get("/device-summary/{deviceId}", server.HandleDeviceSummary)

--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -9,6 +9,7 @@ DELETE   /setup/devices/{deviceId}                                    handlers.(
 DELETE   /setup/dns-discoveries                                       handlers.(*Server).HandleClearDNSDiscoveries-fm
 DELETE   /setup/interactions/sessions                                 handlers.(*Server).HandleCleanupSessions-fm
 DELETE   /setup/interactions/sessions/{session}                       handlers.(*Server).HandleDeleteSession-fm
+DELETE   /setup/sources/{account}/{device}/{sourceID}                 handlers.(*Server).HandleDeleteSource-fm
 DELETE   /streaming/account/{account}/device/{device}                 handlers.(*Server).HandleMargeRemoveDevice-fm
 DELETE   /streaming/account/{account}/device/{device}/preset/{presetNumber} handlers.(*Server).HandleMargeRemovePreset-fm
 DELETE   /streaming/account/{account}/group/{groupId}                 handlers.(*Server).HandleMargeDeleteGroup-fm

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -1779,7 +1779,7 @@ func (ds *DataStore) GetConfiguredSources(account, device string) ([]models.Conf
 	data, err := ds.rootReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
-			sources := ds.getDefaultSources()
+			sources := ds.getInitialSources()
 			ds.DeduceSourceIDs(account, device, sources)
 
 			return sources, nil
@@ -2187,6 +2187,27 @@ func (ds *DataStore) getDefaultSources() []models.ConfiguredSource {
 	}
 
 	return sources
+}
+
+// getInitialSources returns the default sources for a brand-new device.
+// INTERNET_RADIO (ID 10002) is excluded — it is a legacy provider no longer
+// actively served by AfterTouch; omitting it prevents speakers from
+// receiving a stale entry in their initial Sources.xml. The full list
+// (including 10002) is kept in getDefaultSources() for canonicalisation
+// of existing devices that already reference INTERNET_RADIO.
+func (ds *DataStore) getInitialSources() []models.ConfiguredSource {
+	all := ds.getDefaultSources()
+
+	out := make([]models.ConfiguredSource, 0, len(all))
+	for i := range all {
+		if all[i].SourceKeyType == constants.ProviderInternetRadio {
+			continue
+		}
+
+		out = append(out, all[i])
+	}
+
+	return out
 }
 
 // isMACAddressFormat checks if a string looks like a MAC address

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -2032,6 +2032,65 @@ func (ds *DataStore) SaveConfiguredSources(account, device string, sources []mod
 	return ds.atomicWriteFile(path, append(header, data...))
 }
 
+// DeleteSourceByID removes the source with the given ID from the device's
+// Sources.xml. It is a no-op if the source is not present.
+func (ds *DataStore) DeleteSourceByID(account, device, sourceID string) error {
+	sources, err := ds.GetConfiguredSources(account, device)
+	if err != nil {
+		return err
+	}
+
+	filtered := make([]models.ConfiguredSource, 0, len(sources))
+
+	for i := range sources {
+		if sources[i].ID != sourceID {
+			filtered = append(filtered, sources[i])
+		}
+	}
+
+	if len(filtered) == len(sources) {
+		return nil
+	}
+
+	return ds.SaveConfiguredSources(account, device, filtered)
+}
+
+// DeleteSourceByType removes the source with the given SourceKeyType from
+// the device's Sources.xml. Returns an error if more than one source matches
+// (to prevent accidental bulk deletion). No-op if no match is found.
+func (ds *DataStore) DeleteSourceByType(account, device, sourceKeyType string) error {
+	sources, err := ds.GetConfiguredSources(account, device)
+	if err != nil {
+		return err
+	}
+
+	var matches int
+
+	for i := range sources {
+		if sources[i].SourceKeyType == sourceKeyType {
+			matches++
+		}
+	}
+
+	if matches > 1 {
+		return fmt.Errorf("found %d sources with type %q; use an ID-based deletion for precision", matches, sourceKeyType)
+	}
+
+	if matches == 0 {
+		return nil
+	}
+
+	filtered := make([]models.ConfiguredSource, 0, len(sources))
+
+	for i := range sources {
+		if sources[i].SourceKeyType != sourceKeyType {
+			filtered = append(filtered, sources[i])
+		}
+	}
+
+	return ds.SaveConfiguredSources(account, device, filtered)
+}
+
 // updateDeviceMappings creates bidirectional mappings for device resolution
 func (ds *DataStore) updateDeviceMappings(info models.ServiceDeviceInfo) {
 	ds.idMutex.Lock()

--- a/pkg/service/datastore/sources_deduction_test.go
+++ b/pkg/service/datastore/sources_deduction_test.go
@@ -24,6 +24,7 @@ func TestGetConfiguredSources_DeduceIDs(t *testing.T) {
 		t.Fatalf("Failed to create device dir: %v", err)
 	}
 
+	// Provider 11 = LOCAL_INTERNET_RADIO (active, present in initial sources)
 	recentsXML := `<?xml version="1.0" encoding="UTF-8" ?>
 <recents>
     <recent id="2184615630">
@@ -33,13 +34,13 @@ func TestGetConfiguredSources_DeduceIDs(t *testing.T) {
         <location>52349</location>
         <name>Lounge FM Digital</name>
         <source id="9330201" type="Audio">
-            <createdOn>2015-03-11T19:12:38.000+00:00</createdOn>
+            <createdOn>2019-01-24T08:18:37.000+00:00</createdOn>
             <credential type="token"></credential>
             <name>9330201</name>
-            <sourceproviderid>2</sourceproviderid>
+            <sourceproviderid>11</sourceproviderid>
             <sourcename></sourcename>
             <sourceSettings/>
-            <updatedOn>2015-03-11T19:12:38.000+00:00</updatedOn>
+            <updatedOn>2019-02-03T18:35:45.000+00:00</updatedOn>
             <username></username>
         </source>
         <sourceid>9330201</sourceid>
@@ -52,7 +53,7 @@ func TestGetConfiguredSources_DeduceIDs(t *testing.T) {
 		t.Fatalf("Failed to write Recents.xml: %v", err)
 	}
 
-	// Now call GetConfiguredSources and expect it to have "9330201" for provider ID "2"
+	// Now call GetConfiguredSources and expect it to have "9330201" for provider ID "11"
 	sources, err := ds.GetConfiguredSources(account, device)
 	if err != nil {
 		t.Fatalf("GetConfiguredSources failed: %v", err)
@@ -60,17 +61,17 @@ func TestGetConfiguredSources_DeduceIDs(t *testing.T) {
 
 	foundDeducted := false
 	for _, s := range sources {
-		if s.SourceProviderID == "2" {
+		if s.SourceProviderID == "11" {
 			if s.ID == "9330201" {
 				foundDeducted = true
 			} else {
-				t.Errorf("Expected source ID 9330201 for provider 2, got %s", s.ID)
+				t.Errorf("Expected source ID 9330201 for provider 11, got %s", s.ID)
 			}
 		}
 	}
 
 	if !foundDeducted {
-		t.Errorf("Did not find source with provider ID 2 and deducted ID 9330201")
+		t.Errorf("Did not find source with provider ID 11 and deducted ID 9330201")
 	}
 }
 
@@ -90,34 +91,28 @@ func TestGetConfiguredSources_DeduceIDs_AllProviders(t *testing.T) {
 		t.Fatalf("Failed to create device dir: %v", err)
 	}
 
-	// 2: INTERNET_RADIO
 	// 9: AUX
 	// 11: LOCAL_INTERNET_RADIO
 	// 25: TUNEIN
+	// INTERNET_RADIO (provider 2) is intentionally excluded from initial sources
+	// and therefore not expected in the deduction result.
 	presetsXML := `<?xml version="1.0" encoding="UTF-8" ?>
 <presets>
     <preset id="1">
-        <contentItem source="INTERNET_RADIO" sourceAccount="" isPresetable="true" type="station" itemName="Station 2">
-            <containerArt>http://example.com/art2.png</containerArt>
-        </contentItem>
-        <source id="ID2" type="Audio" sourceproviderid="2" />
-        <sourceid>ID2</sourceid>
-    </preset>
-    <preset id="2">
         <contentItem source="AUX" sourceAccount="AUX" isPresetable="true" type="station" itemName="Station 9">
             <containerArt>http://example.com/art9.png</containerArt>
         </contentItem>
         <source id="ID9" type="Audio" sourceproviderid="9" />
         <sourceid>ID9</sourceid>
     </preset>
-    <preset id="3">
+    <preset id="2">
         <contentItem source="LOCAL_INTERNET_RADIO" sourceAccount="" isPresetable="true" type="station" itemName="Station 11">
             <containerArt>http://example.com/art11.png</containerArt>
         </contentItem>
         <source id="ID11" type="Audio" sourceproviderid="11" />
         <sourceid>ID11</sourceid>
     </preset>
-    <preset id="4">
+    <preset id="3">
         <contentItem source="TUNEIN" sourceAccount="" isPresetable="true" type="station" itemName="Station 25">
             <containerArt>http://example.com/art25.png</containerArt>
         </contentItem>
@@ -136,7 +131,6 @@ func TestGetConfiguredSources_DeduceIDs_AllProviders(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		"2":  "ID2",
 		"9":  "ID9",
 		"11": "ID11",
 		"25": "ID25",

--- a/pkg/service/handlers/handlers_setup.go
+++ b/pkg/service/handlers/handlers_setup.go
@@ -1348,3 +1348,25 @@ func (s *Server) HandleDownloadSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 }
+
+// HandleDeleteSource removes a source from a device's Sources.xml.
+// DELETE /setup/sources/{account}/{device}/{sourceID}
+func (s *Server) HandleDeleteSource(w http.ResponseWriter, r *http.Request) {
+	account := chi.URLParam(r, "account")
+	device := chi.URLParam(r, "device")
+	sourceID := chi.URLParam(r, "sourceID")
+
+	if account == "" || device == "" || sourceID == "" {
+		http.Error(w, "account, device, and sourceID are required", http.StatusBadRequest)
+
+		return
+	}
+
+	if err := s.ds.DeleteSourceByID(account, device, sourceID); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -133,6 +133,7 @@ func NewServer(ds *datastore.DataStore, sm *setup.Manager, serverURL string, red
 	health.RegisterPresetsCountCheck(s.healthRegistry, ds)
 	health.RegisterPresetsConsistencyCheck(s.healthRegistry, ds)
 	health.RegisterRefreshSourcesCheck(s.healthRegistry, ds)
+	health.RegisterStaleInternetRadioCheck(s.healthRegistry, ds)
 	health.RegisterDefaultAccountNonBoseDevicesCheck(s.healthRegistry, ds)
 	health.RegisterOAuthTargetReachableCheck(
 		s.healthRegistry,

--- a/pkg/service/health/checks_stale_internet_radio.go
+++ b/pkg/service/health/checks_stale_internet_radio.go
@@ -1,0 +1,126 @@
+package health
+
+import (
+	"fmt"
+
+	"github.com/gesellix/bose-soundtouch/pkg/service/constants"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// CheckIDStaleInternetRadio is the registry id of the stale INTERNET_RADIO
+// stub source check.
+const CheckIDStaleInternetRadio = "stale_internet_radio"
+
+// FixIDRemoveInternetRadio is the registry id of the quick-fix that removes
+// the stub INTERNET_RADIO source.
+const FixIDRemoveInternetRadio = "remove_internet_radio"
+
+// RegisterStaleInternetRadioCheck registers a check that detects the legacy
+// INTERNET_RADIO stub source (empty credentials) left over from devices
+// initialised before AfterTouch removed it from the default source list.
+func RegisterStaleInternetRadioCheck(r *Registry, ds *datastore.DataStore) {
+	r.Register(Check{
+		ID:    CheckIDStaleInternetRadio,
+		Title: "Stale INTERNET_RADIO stub source",
+		Run: func() []Finding {
+			return runStaleInternetRadioCheck(ds)
+		},
+	})
+
+	r.RegisterFix(CheckIDStaleInternetRadio, FixIDRemoveInternetRadio, func(target Target) (string, error) {
+		return fixRemoveInternetRadio(ds, target)
+	})
+}
+
+func runStaleInternetRadioCheck(ds *datastore.DataStore) []Finding {
+	if ds == nil {
+		return nil
+	}
+
+	devices, err := ds.ListAllDevices()
+	if err != nil {
+		return []Finding{{
+			Severity: SeverityError,
+			Message:  "Could not enumerate devices: " + err.Error(),
+		}}
+	}
+
+	var findings []Finding
+
+	for i := range devices {
+		dev := &devices[i]
+		if dev.AccountID == "" || dev.DeviceID == "" {
+			continue
+		}
+
+		sources, err := ds.GetConfiguredSources(dev.AccountID, dev.DeviceID)
+		if err != nil {
+			continue
+		}
+
+		for j := range sources {
+			s := &sources[j]
+
+			if s.SourceKeyType != constants.ProviderInternetRadio {
+				continue
+			}
+
+			if s.Secret != "" || s.Credential.Value != "" {
+				// Real user-configured INTERNET_RADIO source — don't touch it.
+				continue
+			}
+
+			findings = append(findings, Finding{
+				Severity: SeverityInfo,
+				Target:   Target{Account: dev.AccountID, Device: dev.DeviceID},
+				Message: fmt.Sprintf(
+					"Device %s has a stub %s source (ID %s) with no credentials.",
+					displayName(dev.Name, dev.DeviceID),
+					constants.ProviderInternetRadio,
+					s.ID,
+				),
+				Details: "AfterTouch no longer adds INTERNET_RADIO to new devices. " +
+					"This entry is a leftover from an earlier version and can be safely removed. " +
+					"The speaker will re-sync its source list on the next reconnect.",
+				QuickFixes: []QuickFix{{
+					ID:    FixIDRemoveInternetRadio,
+					Label: fmt.Sprintf("Remove %s source (ID %s)", constants.ProviderInternetRadio, s.ID),
+				}},
+			})
+		}
+	}
+
+	return findings
+}
+
+func fixRemoveInternetRadio(ds *datastore.DataStore, target Target) (string, error) {
+	if target.Device == "" {
+		return "", fmt.Errorf("device is required")
+	}
+
+	sources, err := ds.GetConfiguredSources(target.Account, target.Device)
+	if err != nil {
+		return "", fmt.Errorf("could not read sources: %w", err)
+	}
+
+	irID := ""
+
+	for i := range sources {
+		if sources[i].SourceKeyType == constants.ProviderInternetRadio &&
+			sources[i].Secret == "" && sources[i].Credential.Value == "" {
+			irID = sources[i].ID
+
+			break
+		}
+	}
+
+	if irID == "" {
+		return "No stub INTERNET_RADIO source found — nothing to remove.", nil
+	}
+
+	if err := ds.DeleteSourceByID(target.Account, target.Device, irID); err != nil {
+		return "", fmt.Errorf("delete source: %w", err)
+	}
+
+	return fmt.Sprintf("Removed stub %s source (ID %s) from device %s. The speaker will receive the updated source list on its next reconnect.", constants.ProviderInternetRadio, irID, target.Device), nil
+}

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -1259,25 +1259,48 @@ func getAccountSources(ds *datastore.DataStore, account, lastDeviceID string) []
 	return fullSources
 }
 
-// mergeDefaultSources adds any default sources missing from stored that are not already present
-// (matched by SourceKeyType). It does not persist — initializeDefaultSources handles persistence at startup.
+// mergeDefaultSources returns sources in canonical order: defaults first (using
+// the stored entry's credentials when a match is found), followed by any stored
+// sources that have no matching default (e.g. Spotify, Amazon). This ensures
+// that default sources always appear in a predictable order regardless of what
+// is present in the device's on-disk Sources.xml.
+// It does not persist — initializeDefaultSources handles persistence at startup.
 func mergeDefaultSources(stored, defaults []models.ConfiguredSource) []models.ConfiguredSource {
+	result := make([]models.ConfiguredSource, 0, len(stored)+len(defaults))
+
 	for i := range defaults {
-		found := false
+		found := -1
 
 		for j := range stored {
 			if stored[j].SourceKeyType == defaults[i].SourceKeyType {
-				found = true
+				found = j
 				break
 			}
 		}
 
-		if !found {
-			stored = append(stored, defaults[i])
+		if found >= 0 {
+			result = append(result, stored[found])
+		} else {
+			result = append(result, defaults[i])
 		}
 	}
 
-	return stored
+	for i := range stored {
+		isDefault := false
+
+		for j := range defaults {
+			if stored[i].SourceKeyType == defaults[j].SourceKeyType {
+				isDefault = true
+				break
+			}
+		}
+
+		if !isDefault {
+			result = append(result, stored[i])
+		}
+	}
+
+	return result
 }
 
 // AccountSourcesToXML generates the account sources XML.
@@ -1415,11 +1438,7 @@ func RemovePreset(ds *datastore.DataStore, account, device string, presetNumber 
 // (since auto-add appends). Returns (nil, sources) when no match could be
 // resolved — UpdatePreset turns that into a 500 with a diagnostic log line.
 func resolvePresetSource(ds *datastore.DataStore, account, device string, sources []models.ConfiguredSource, sourceID string, presetNumber int) (*models.ConfiguredSource, []models.ConfiguredSource) {
-	log.Printf("[Marge] Searching for source matching ID=%s in %d sources", sourceID, len(sources))
-
 	for i := range sources {
-		log.Printf("[Marge]   Source[%d]: ID=%s, Type=%s, SourceKeyType=%s, SourceKeyAccount=%s", i, sources[i].ID, sources[i].Type, sources[i].SourceKeyType, sources[i].SourceKeyAccount)
-
 		if sources[i].ID == sourceID {
 			return &sources[i], sources
 		}

--- a/pkg/service/marge/marge_test.go
+++ b/pkg/service/marge/marge_test.go
@@ -638,7 +638,11 @@ func TestDefaultSources(t *testing.T) {
 		t.Fatalf("Failed to get sources: %v", err)
 	}
 
-	expectedCount := 5
+	// INTERNET_RADIO (ID 10002) is excluded from initial sources — it is a legacy
+	// provider no longer served by AfterTouch. The cloud-level account sources
+	// (getAccountSources via GetDefaultSources) still include it for backward
+	// compatibility with existing speaker firmware.
+	expectedCount := 4
 	if len(sources) != expectedCount {
 		t.Errorf("Expected %d sources, got %d", expectedCount, len(sources))
 	}
@@ -664,10 +668,7 @@ func TestDefaultSources(t *testing.T) {
 				t.Error("LOCAL_INTERNET_RADIO should have a secret")
 			}
 		case "INTERNET_RADIO":
-			foundIR = true
-			if s.SecretType != "token" {
-				t.Errorf("Expected INTERNET_RADIO secretType token, got %s", s.SecretType)
-			}
+			t.Errorf("INTERNET_RADIO must not appear in initial sources — it is excluded from getInitialSources()")
 		case "RADIO_BROWSER":
 			foundIR = true
 			if s.SecretType != "token" {
@@ -695,7 +696,7 @@ func TestDefaultSources(t *testing.T) {
 	}
 
 	if !foundTuneIn || !foundLocalIR || !foundIR || !foundAux {
-		t.Errorf("Missing expected sources: TuneIn=%v, LocalIR=%v, IR=%v, Aux=%v", foundTuneIn, foundLocalIR, foundIR, foundAux)
+		t.Errorf("Missing expected sources: TuneIn=%v, LocalIR=%v, RadioBrowser=%v, Aux=%v", foundTuneIn, foundLocalIR, foundIR, foundAux)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `getInitialSources()` excludes the legacy INTERNET_RADIO stub (ID 10002) from new device `Sources.xml` files. `getDefaultSources()` retains it for canonicalisation and cloud account responses.
- `mergeDefaultSources` rebuilt in canonical ID order so INTERNET_RADIO stays at position 0 in cloud responses even when absent from the device file.
- `DeleteSourceByID` / `DeleteSourceByType` (uniqueness-guarded) added to datastore.
- `DELETE /setup/sources/{account}/{device}/{sourceID}` endpoint.
- Health check `stale_internet_radio`: finds stub INTERNET_RADIO entries (empty credentials) and offers a one-click **Remove INTERNET_RADIO source (ID 10002)** fix. Skips sources with real credentials.
- `soundtouch-cli cloud source remove --service-url <url> --account <id> --device <id> [--id 10002 | --type INTERNET_RADIO]` — removes from AfterTouch datastore.
- `soundtouch-cli --host <ip> source notify-updated` — POSTs `sourcesUpdated` directly to the speaker to trigger an immediate re-fetch.
- `CloudCommonFlags` (`--service-url` / `AFTERTOUCH_URL`, required) as the AfterTouch-side counterpart to `CommonFlags`.

## Test plan

- [ ] `make test` passes
- [ ] `make lint` clean
- [ ] Integration suite: 49 requests, 0 failures
- [ ] Health tab shows finding on a device with old stub; fix button removes it
- [ ] `soundtouch-cli cloud source remove --service-url … --account … --device … --type INTERNET_RADIO` returns 204
- [ ] `soundtouch-cli --host <ip> source notify-updated` triggers immediate re-fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)