### PR TITLE
fix(handlers): clean up stale device entries on cross-account migration

### DIFF
--- a/cmd/soundtouch-cli/cmd_cloud.go
+++ b/cmd/soundtouch-cli/cmd_cloud.go
@@ -65,6 +65,7 @@ func cloudSourceRemoveCmd() *cli.Command {
 
 // canonicalSourceID maps well-known SourceKeyType values to their canonical IDs.
 // Used to resolve --type to an ID without requiring a round-trip GET.
+// TODO We need to ensure that ids here are consistent with the ones used in the AfterTouch service.
 var canonicalSourceID = map[string]string{
 	"AUX":                  "10001",
 	"INTERNET_RADIO":       "10002",

--- a/pkg/service/handlers/mac_discovery_integration_test.go
+++ b/pkg/service/handlers/mac_discovery_integration_test.go
@@ -362,6 +362,107 @@ func TestMACBasedDeviceDiscovery_MigrationScenario(t *testing.T) {
 	t.Logf("\n✅ MAC-based device migration test completed!")
 }
 
+// TestHandleDiscoveredDevice_CrossAccountMigration verifies the branch in
+// handleDiscoveredDevice that fires when a device's live MargeAccountUUID
+// differs from its stored account. The device directory must be moved to the
+// new account and the old entry must not appear in ListAllDevices.
+func TestHandleDiscoveredDevice_CrossAccountMigration(t *testing.T) {
+	tempDir := t.TempDir()
+	ds := datastore.NewDataStore(tempDir)
+
+	const (
+		deviceID   = "F4E11E930BEB"
+		oldAccount = "default"
+		newAccount = "8637922"
+	)
+
+	// 1. Seed device under the old account with presets so we can verify
+	//    they survive the move.
+	oldInfo := &models.ServiceDeviceInfo{
+		DeviceID:  deviceID,
+		AccountID: oldAccount,
+		Name:      "Stale Name",
+		IPAddress: "192.0.2.42",
+	}
+	if err := ds.SaveDeviceInfo(oldAccount, deviceID, oldInfo); err != nil {
+		t.Fatalf("SaveDeviceInfo under %s: %v", oldAccount, err)
+	}
+	presets := []models.ServicePreset{
+		{ID: "1", ServiceContentItem: models.ServiceContentItem{Name: "My Station", ContentItemType: "stationurl"}},
+	}
+	if err := ds.SavePresets(oldAccount, deviceID, presets); err != nil {
+		t.Fatalf("SavePresets under %s: %v", oldAccount, err)
+	}
+
+	// 2. Mock the speaker's /info endpoint — reports the new margeAccountUUID.
+	deviceInfoXML := fmt.Sprintf(`<info deviceID="%s">
+<name>Updated Name</name>
+<type>SoundTouch 10</type>
+<margeAccountUUID>%s</margeAccountUUID>
+<networkInfo type="SCM">
+<macAddress>%s</macAddress>
+<ipAddress>192.0.2.42</ipAddress>
+</networkInfo>
+<moduleType>sm2</moduleType>
+</info>`, deviceID, newAccount, deviceID)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, deviceInfoXML)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	deviceIP := server.URL[len("http://"):]
+	sm := setup.NewManager(server.URL, ds, nil)
+	srv := NewServer(ds, sm, "http://localhost", false, false, false)
+
+	// 3. Trigger discovery — the live MargeAccountUUID differs from storedAccount.
+	srv.handleDiscoveredDevice(models.DiscoveredDevice{
+		Host:            deviceIP,
+		Name:            "Discovery Name",
+		DiscoveryMethod: "mDNS",
+	})
+
+	// 4. Device must now be stored under the new account with the live name.
+	info, err := ds.GetDeviceInfo(newAccount, deviceID)
+	if err != nil {
+		t.Fatalf("GetDeviceInfo under new account %s: %v", newAccount, err)
+	}
+	if info.AccountID != newAccount {
+		t.Errorf("AccountID: want %s, got %s", newAccount, info.AccountID)
+	}
+	if info.Name != "Updated Name" {
+		t.Errorf("Name: want %q, got %q", "Updated Name", info.Name)
+	}
+
+	// 5. Old account entry must be gone.
+	if _, err := ds.GetDeviceInfo(oldAccount, deviceID); err == nil {
+		t.Errorf("stale entry still present under old account %s after MoveDevice", oldAccount)
+	}
+
+	// 6. Presets must have survived the move.
+	moved, err := ds.GetPresets(newAccount, deviceID)
+	if err != nil {
+		t.Fatalf("GetPresets under new account %s: %v", newAccount, err)
+	}
+	if len(moved) != 1 || moved[0].Name != "My Station" {
+		t.Errorf("presets not preserved after move: got %+v", moved)
+	}
+
+	// 7. ListAllDevices must return exactly one entry — no duplicates.
+	all, err := ds.ListAllDevices()
+	if err != nil {
+		t.Fatalf("ListAllDevices: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("ListAllDevices: want 1 device, got %d: %+v", len(all), all)
+	}
+}
+
 func TestMACBasedDeviceDiscovery_FallbackScenario(t *testing.T) {
 	// Test scenario where /info endpoint is not available
 	tempDir, err := os.MkdirTemp("", "mac-fallback-test-*")

--- a/pkg/service/handlers/mac_discovery_integration_test.go
+++ b/pkg/service/handlers/mac_discovery_integration_test.go
@@ -463,6 +463,107 @@ func TestHandleDiscoveredDevice_CrossAccountMigration(t *testing.T) {
 	}
 }
 
+// TestHandleDiscoveredDevice_CrossAccountMigration_TargetExists covers the case
+// where both the old and the new account directories already have data for the
+// device before discovery fires. os.Rename fails because the target dir exists,
+// so MoveDevice cannot atomically relocate the directory. The stale source entry
+// must still be removed via the unconditional RemoveDevice fallback, and
+// ListAllDevices must return exactly one entry after the cycle.
+func TestHandleDiscoveredDevice_CrossAccountMigration_TargetExists(t *testing.T) {
+	tempDir := t.TempDir()
+	ds := datastore.NewDataStore(tempDir)
+
+	const (
+		deviceID = "F4E11E930BEB"
+		// oldAccount sorts alphabetically BEFORE newAccount so that
+		// ListAllDevices (which sorts accounts alphabetically, pushing "default"
+		// to the back) picks it first. That means findExistingDeviceInfoByDeviceID
+		// returns oldAccount as storedAccount, the MargeAccountUUID mismatch
+		// condition fires, MoveDevice fails because newAccount already has a
+		// device dir, and the RemoveDevice fallback must clean up the stale entry.
+		oldAccount = "account-aaa-stale"
+		newAccount = "account-zzz-live"
+	)
+
+	// Seed the device under both accounts (simulates a pre-existing duplicate).
+	for _, acc := range []string{oldAccount, newAccount} {
+		info := &models.ServiceDeviceInfo{
+			DeviceID:  deviceID,
+			AccountID: acc,
+			Name:      "Stale Name",
+			IPAddress: "192.0.2.42",
+		}
+		if err := ds.SaveDeviceInfo(acc, deviceID, info); err != nil {
+			t.Fatalf("SaveDeviceInfo under %s: %v", acc, err)
+		}
+	}
+
+	// Confirm both exist before discovery.
+	all, err := ds.ListAllDevices()
+	if err != nil {
+		t.Fatalf("ListAllDevices (before): %v", err)
+	}
+	// ListAllDevices deduplicates; both real accounts → alphabetically-first wins.
+	if len(all) != 1 {
+		t.Logf("ListAllDevices before discovery: %d entries (expected 1 due to dedup): %+v", len(all), all)
+	}
+
+	// Mock /info — reports newAccount as the canonical MargeAccountUUID.
+	deviceInfoXML := fmt.Sprintf(`<info deviceID="%s">
+<name>Updated Name</name>
+<type>SoundTouch 10</type>
+<margeAccountUUID>%s</margeAccountUUID>
+<networkInfo type="SCM">
+<macAddress>%s</macAddress>
+<ipAddress>192.0.2.42</ipAddress>
+</networkInfo>
+<moduleType>sm2</moduleType>
+</info>`, deviceID, newAccount, deviceID)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/info" {
+			w.Header().Set("Content-Type", "application/xml")
+			fmt.Fprint(w, deviceInfoXML)
+		} else {
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	deviceIP := server.URL[len("http://"):]
+	sm := setup.NewManager(server.URL, ds, nil)
+	srv := NewServer(ds, sm, "http://localhost", false, false, false)
+
+	srv.handleDiscoveredDevice(models.DiscoveredDevice{
+		Host:            deviceIP,
+		Name:            "Discovery Name",
+		DiscoveryMethod: "mDNS",
+	})
+
+	// New account must have fresh data.
+	info, err := ds.GetDeviceInfo(newAccount, deviceID)
+	if err != nil {
+		t.Fatalf("GetDeviceInfo under %s: %v", newAccount, err)
+	}
+	if info.Name != "Updated Name" {
+		t.Errorf("Name: want %q, got %q", "Updated Name", info.Name)
+	}
+
+	// Old account stale entry must be gone.
+	if _, err := ds.GetDeviceInfo(oldAccount, deviceID); err == nil {
+		t.Errorf("stale entry still present under old account %s", oldAccount)
+	}
+
+	// No duplicates in ListAllDevices.
+	all, err = ds.ListAllDevices()
+	if err != nil {
+		t.Fatalf("ListAllDevices (after): %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("ListAllDevices: want 1 device, got %d: %+v", len(all), all)
+	}
+}
+
 func TestMACBasedDeviceDiscovery_FallbackScenario(t *testing.T) {
 	// Test scenario where /info endpoint is not available
 	tempDir, err := os.MkdirTemp("", "mac-fallback-test-*")

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -1099,6 +1099,19 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 		return
 	}
 
+	// If the device was (or needed to be) relocated to a different account, ensure the
+	// stale source entry is gone. MoveDevice's rename is a no-op if the target already
+	// existed (e.g. partial duplicate state), leaving the source dir behind; removing it
+	// here is safe because SaveDeviceInfo above has already written fresh data to
+	// accountID. RemoveDevice returns nil when the path does not exist, so this is also
+	// a harmless no-op when MoveDevice already renamed the directory successfully.
+	if storedAccount != "" && storedAccount != accountID {
+		if err := s.ds.RemoveDevice(storedAccount, deviceID); err != nil {
+			log.Printf("Failed to remove stale device entry for %s in %s: %v",
+				deviceID, storedAccount, err)
+		}
+	}
+
 	// 8. Create default Sources.xml only when no sources file exists yet
 	if !s.ds.HasConfiguredSources(accountID, deviceID) {
 		if sources, err := s.ds.GetConfiguredSources(accountID, deviceID); err == nil {


### PR DESCRIPTION
Closes #346 (follow-up to #348).

## What this adds

PR #348 introduced `DataStore.MoveDevice` to atomically relocate a device directory when the speaker's live `MargeAccountUUID` differs from where AfterTouch has it stored. This PR covers two gaps identified during review:

1. **Server-level integration test** for the `handleDiscoveredDevice` cross-account migration path (the datastore layer was tested in #348; the trigger condition in the server was not).

2. **Fallback cleanup when the rename target already exists.** `os.Rename` fails — `ENOTEMPTY` on Linux, `EEXIST` on macOS — when the destination device directory is already present (pre-existing duplicate state). Without a fallback, the stale source entry persisted on disk. The fix: after `SaveDeviceInfo` writes fresh data to the canonical account, `RemoveDevice` is called unconditionally on the old account. It is a safe no-op (`RemoveAll` returns nil for non-existent paths) when `MoveDevice` already renamed the directory; it removes the stale entry when the rename failed.

## Scenario reference

| Scenario | Rename | Fallback | Outcome |
|---|---|---|---|
| Device only in wrong/default account | ✅ succeeds | no-op | Stale entry gone, canonical has current name |
| Device in two real accounts, stale sorts first | ❌ ENOTEMPTY | removes stale | Stale entry gone, canonical has current name |
| Device in two real accounts, canonical sorts first | not called | not called | Stale persists (invisible via ListAllDevices dedup); health check flags it |
| Device in `default` **and** a real account simultaneously | not called | not called | Stale `default` dir persists (ListAllDevices dedup hides it); health check flags it |
| Correct account already (steady state) | not called | not called | SaveDeviceInfo updates name/IP/firmware in place |

Note: a device stored *only* in `default` with a real `MargeAccountUUID` is the normal single-wrong-account case (first row) — rename succeeds and it is cleaned up on the first discovery cycle.

## Noteworthy (release notes)

**Stale device entries are now cleaned up automatically on discovery.** When a speaker reports a `MargeAccountUUID` that differs from where AfterTouch has it stored, the device directory is atomically moved to the correct account using `rename(2)` (all files — presets, recents, sources — move in one operation). If the target directory already exists (pre-existing duplicate state from an earlier version), the rename is skipped and the stale source entry is removed instead. Either way, `ListAllDevices` and the web UI dropdowns reflect the correct account and current device name after the next discovery scan or a manual Rescan. Orphan entries that escape both paths are surfaced by the health tab consistency check with an Evict QuickFix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)