### PR TITLE
fix(install): on-device installer improvements + deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ See the [Survival Guide](https://gesellix.github.io/Bose-SoundTouch/guides/SURVI
 
 A local server that replaces the Bose cloud ("AfterTouch"). Once your speaker is redirected to it, you have full control without any Bose cloud dependency. The built-in web UI at `http://localhost:8000` handles all setup — no config files needed to get started.
 
-If you don't want to run a server for this - no problem. The service is small enough to run on the SoundTouch itself. See the [On-Device Installer](./scripts/on-device-install/README.md) for instructions.
+Not sure which approach fits your situation? See the [Deployment Overview](./docs/guides/DEPLOYMENT-OVERVIEW.md) — it compares running AfterTouch on a Raspberry Pi or other always-on host against running it directly on the SoundTouch speaker, with links to step-by-step walkthroughs for each path.
 
 **Two scenarios:**
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,7 +3,10 @@
 * [Introduction](README.md)
 
 ## User Guides
-* [Device-Local Install Journeys](DEVICE-LOCAL-INSTALL.md)
+* [Deployment Overview](guides/DEPLOYMENT-OVERVIEW.md)
+  * [Local Network Host Walkthrough](guides/EXTERNAL-HOST-WALKTHROUGH.md)
+  * [Cloud / VPS Walkthrough](guides/CLOUD-DEPLOY-WALKTHROUGH.md)
+  * [On-Device Install Walkthrough](guides/ON-DEVICE-INSTALL-WALKTHROUGH.md)
 * [Cloud Shutdown Survival Guide](guides/SURVIVAL-GUIDE.md)
 * [Self-Hosting AfterTouch](guides/SELF-HOSTING.md)
 * [Connecting Music Services](guides/MUSIC-SERVICES.md)
@@ -60,6 +63,9 @@
 * [Encrypted Export](concepts/ENCRYPTED-EXPORT.md)
 * [Diagnostic Export (Maintainer Setup)](DIAGNOSTIC-EXPORT.md)
 * [soundtouch-web Roadmap](soundtouch-web-roadmap.md)
+
+## Architecture
+* [Device-Local Install Journeys](architecture/DEVICE-LOCAL-INSTALL.md)
 
 ## Analysis & Research
 * [API Coverage Analysis](analysis/API-COVERAGE.md)

--- a/docs/architecture/DEVICE-LOCAL-INSTALL.md
+++ b/docs/architecture/DEVICE-LOCAL-INSTALL.md
@@ -1,5 +1,15 @@
 # Device-Local Install: Four User Journeys
 
+> **Looking for how to actually install AfterTouch?**
+> See the [Deployment Overview](../guides/DEPLOYMENT-OVERVIEW.md) for user-friendly
+> step-by-step guides for both deployment scenarios (external host and on-device).
+>
+> This document is an **architectural analysis** — user journeys, install patterns,
+> technology tradeoffs, and future directions. It is aimed at contributors and
+> project planning, not at end users.
+
+---
+
 A user-journey-shaped view of where AfterTouch sits today and where it could go. The same speaker, the same constraints, but four different audiences with non-overlapping needs:
 
 1. **Initial setup / install** — getting AfterTouch onto a fresh or freshly-orphaned speaker.

--- a/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
+++ b/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
@@ -7,7 +7,7 @@ This scenario is useful when you don't have an always-on machine at home but
 you already have a cloud server (Hetzner, DigitalOcean, Coolify, etc.).
 
 For local deployments (Raspberry Pi, NAS, home server) see
-[EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).  
+[EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).
 For a comparison of all deployment options see
 [DEPLOYMENT-OVERVIEW.md](DEPLOYMENT-OVERVIEW.md).
 
@@ -15,12 +15,12 @@ For a comparison of all deployment options see
 
 ## How cloud deployment differs from a local host
 
-| | Local host | Cloud host |
-|--|-----------|-----------|
-| Speaker discovery | Automatic (mDNS on the LAN) | **Disabled** — cloud can't reach your LAN |
-| Speaker migration | Via the AfterTouch web UI | **Via `soundtouch-cli` on your local machine** |
-| URL scheme | `http://` is fine on a LAN | **HTTPS required** — speakers validate the certificate |
-| Audio routing | Stays on the LAN (AfterTouch only proxies metadata) | Stays on the LAN — audio never transits the cloud server |
+|                   | Local host                                          | Cloud host                                               |
+|-------------------|-----------------------------------------------------|----------------------------------------------------------|
+| Speaker discovery | Automatic (mDNS on the LAN)                         | **Disabled** — cloud can't reach your LAN                |
+| Speaker migration | Via the AfterTouch web UI                           | **Via `soundtouch-cli` on your local machine**           |
+| URL scheme        | `http://` is fine on a LAN                          | **HTTPS required** — speakers validate the certificate   |
+| Audio routing     | Stays on the LAN (AfterTouch only proxies metadata) | Stays on the LAN — audio never transits the cloud server |
 
 > **Audio does not flow through AfterTouch.** The cloud server only handles
 > authentication tokens and URL discovery. Music data goes directly between
@@ -172,10 +172,10 @@ The speaker should appear in the list.
 2. Run or refresh the health checks.
 3. Apply any QuickFixes shown, especially:
 
-   | Warning | Action |
-   |---------|--------|
+   | Warning                                         | Action                                      |
+   |-------------------------------------------------|---------------------------------------------|
    | *Speaker reports an empty `<margeAccountUUID>`* | Click **Pair account** / **Apply QuickFix** |
-   | *INTERNET_RADIO source is a stale stub* | Click **Remove INTERNET_RADIO source** |
+   | *INTERNET_RADIO source is a stale stub*         | Click **Remove INTERNET_RADIO source**      |
 
 4. Reboot the speaker after any QuickFix that requires it, then re-run health checks.
 
@@ -260,14 +260,14 @@ To minimise downtime, use your cloud provider's restart policy
 
 ## Troubleshooting
 
-| Symptom | First check |
-|---------|------------|
-| Speaker shows certificate error | HTTPS certificate is not trusted — ensure your reverse proxy serves a valid Let's Encrypt cert |
-| Migration fails with "connection refused" | Speaker can't reach `soundtouch.example.com:443` — check your server's firewall |
-| Source TuneIn 1005 error | TuneIn not in speaker's source list — follow Step 6 |
-| AfterTouch logs "discovery timeout" every 5 min | Set `DISCOVERY_ENABLED=false` |
-| Devices tab empty after migration | Add the speaker manually by IP (Step 4) |
-| `margeAccountUUID` still empty after QuickFix | Re-run Health QuickFix and reboot again |
+| Symptom                                         | First check                                                                                    |
+|-------------------------------------------------|------------------------------------------------------------------------------------------------|
+| Speaker shows certificate error                 | HTTPS certificate is not trusted — ensure your reverse proxy serves a valid Let's Encrypt cert |
+| Migration fails with "connection refused"       | Speaker can't reach `soundtouch.example.com:443` — check your server's firewall                |
+| Source TuneIn 1005 error                        | TuneIn not in speaker's source list — follow Step 6                                            |
+| AfterTouch logs "discovery timeout" every 5 min | Set `DISCOVERY_ENABLED=false`                                                                  |
+| Devices tab empty after migration               | Add the speaker manually by IP (Step 4)                                                        |
+| `margeAccountUUID` still empty after QuickFix   | Re-run Health QuickFix and reboot again                                                        |
 
 For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and
 [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md).

--- a/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
+++ b/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
@@ -188,24 +188,94 @@ source list — you'll see error `1005` (UNKNOWN_SOURCE_ERROR) when trying to
 play a TuneIn station.
 
 **Why this happens:** The speaker materialises its source list from what
-AfterTouch serves via `/streaming/account/<id>/full`. If the device's
-`Sources.xml` on the server doesn't include a TUNEIN entry, the speaker
-never registers TuneIn as a source.
+AfterTouch serves via `/streaming/account/<id>/full`. If no `Sources.xml`
+exists yet for the device on the server (which happens when the device
+first checks in after service startup), AfterTouch never writes the default
+sources and TuneIn is never registered.
 
-**Check whether TuneIn is missing:**
+> **Note:** "Data Sync" from the AfterTouch web UI will not work here — it
+> requires AfterTouch to reach the speaker outbound, which is not possible
+> from a cloud server. The fix is entirely server-side.
+
+**Check whether TuneIn is missing** (run from your local machine):
 
 ```bash
 curl -s http://192.0.2.1:8090/sources
 ```
 
-If the XML does not contain `source="TUNEIN"`, run the Health QuickFix for
-missing sources (the health check reports it as a warning). If no QuickFix
-appears, trigger a data sync from the AfterTouch web UI:
+If the output does not contain `source="TUNEIN"`, fix it in three steps:
 
-1. Click your speaker → **Data Sync** tab (or **Migration** tab).
-2. Click **Sync** to push the default source set to the speaker.
-3. Reboot the speaker.
-4. Re-check `/sources` — `TUNEIN` should now be present.
+### 1. Create `Sources.xml` on the server
+
+Find the device's data directory on your server. With Docker it is inside
+the volume, e.g. `/app/data/accounts/<accountID>/devices/<deviceID>/`.
+Create `Sources.xml` there with the default source set:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sources>
+  <source id="10001" displayName="AUX IN" secret="" secretType="" type="Audio"
+          createdOn="2015-03-11T19:12:38.000+00:00"
+          updatedOn="2015-03-11T19:12:38.000+00:00">
+    <sourceKey type="AUX" account="AUX"/>
+  </source>
+  <source id="10003" secret="" secretType="token" type="Audio"
+          sourceproviderid="11"
+          createdOn="2019-01-24T08:18:37.000+00:00"
+          updatedOn="2019-02-03T18:35:45.000+00:00">
+    <sourceKey type="LOCAL_INTERNET_RADIO" account=""/>
+  </source>
+  <source id="10004" secret="" secretType="token" type="Audio"
+          sourceproviderid="25"
+          createdOn="2017-07-20T16:43:48.000+00:00"
+          updatedOn="2017-07-20T16:43:48.000+00:00">
+    <sourceKey type="TUNEIN" account=""/>
+  </source>
+  <source id="10005" secret="" secretType="token" type="Audio"
+          sourceproviderid="39"
+          createdOn="2026-02-16T01:01:01.000+00:00"
+          updatedOn="2026-02-16T01:01:01.000+00:00">
+    <sourceKey type="RADIO_BROWSER" account=""/>
+  </source>
+</sources>
+```
+
+The empty `secret=""` fields are intentional — AfterTouch generates TuneIn
+tokens on the fly from `pkg/service/marge/marge.go`.
+
+With Docker you can copy the file in:
+
+```bash
+docker cp Sources.xml aftertouch:/app/data/accounts/<accountID>/devices/<deviceID>/Sources.xml
+```
+
+### 2. Notify the speaker (from your local machine)
+
+Send a `sourcesUpdated` push to the speaker so it re-fetches `/full`:
+
+```bash
+curl -X POST http://192.0.2.1:8090/notification \
+  -H "Content-Type: application/xml" \
+  -d '<updates deviceID="<deviceID>"><sourcesUpdated/></updates>'
+```
+
+Replace `<deviceID>` with the speaker's device ID (visible in the AfterTouch
+Devices tab or in the `Sources.xml` path above).
+
+### 3. Power-cycle the speaker
+
+This is the load-bearing step. The firmware only activates new source *types*
+at boot — the runtime sync writes on-device state but does not complete
+activation. The CLI `setup reboot` command is not sufficient; physically
+unplug the speaker, wait 10 seconds, and plug it back in.
+
+After the reboot, re-check:
+
+```bash
+curl -s http://192.0.2.1:8090/sources
+```
+
+`TUNEIN` should now appear as `READY`.
 
 After TuneIn appears:
 

--- a/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
+++ b/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
@@ -1,0 +1,281 @@
+# Cloud Deployment Walkthrough
+
+A step-by-step guide to running AfterTouch on a VPS or cloud server and
+pointing your local Bose SoundTouch speakers at it.
+
+This scenario is useful when you don't have an always-on machine at home but
+you already have a cloud server (Hetzner, DigitalOcean, Coolify, etc.).
+
+For local deployments (Raspberry Pi, NAS, home server) see
+[EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).  
+For a comparison of all deployment options see
+[DEPLOYMENT-OVERVIEW.md](DEPLOYMENT-OVERVIEW.md).
+
+---
+
+## How cloud deployment differs from a local host
+
+| | Local host | Cloud host |
+|--|-----------|-----------|
+| Speaker discovery | Automatic (mDNS on the LAN) | **Disabled** — cloud can't reach your LAN |
+| Speaker migration | Via the AfterTouch web UI | **Via `soundtouch-cli` on your local machine** |
+| URL scheme | `http://` is fine on a LAN | **HTTPS required** — speakers validate the certificate |
+| Audio routing | Stays on the LAN (AfterTouch only proxies metadata) | Stays on the LAN — audio never transits the cloud server |
+
+> **Audio does not flow through AfterTouch.** The cloud server only handles
+> authentication tokens and URL discovery. Music data goes directly between
+> your LAN and the streaming provider.
+
+---
+
+## Security warning
+
+The Marge API (the Bose-protocol endpoints on `/streaming/*`) has no
+built-in authentication beyond account/device IDs. When AfterTouch is
+internet-facing, those endpoints are reachable by anyone who knows the URL.
+
+Minimum mitigations before going live:
+
+- Enable **HTTP Basic Auth** on the management UI (set via `MGMT_USERNAME` /
+  `MGMT_PASSWORD` or the `--mgmt-username` / `--mgmt-password` flags).
+- Run AfterTouch **behind a reverse proxy** (Nginx, Caddy, Coolify, Traefik)
+  and consider blocking the `/streaming/*` paths to all but your speaker's
+  IP address at the proxy level if your server/firewall allows it.
+- Do not expose the Docker socket or the data volume to untrusted processes.
+
+---
+
+## Step 1 — Deploy AfterTouch on your server
+
+### Docker / Docker Compose (any VPS)
+
+```yaml
+# docker-compose.yml
+services:
+  aftertouch:
+    image: ghcr.io/gesellix/bose-soundtouch:latest
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+      - "8443:8443"
+    environment:
+      SERVER_URL: "https://soundtouch.example.com"
+      HTTPS_SERVER_URL: "https://soundtouch.example.com"
+      DISCOVERY_ENABLED: "false"         # speakers aren't on the same network
+      MGMT_USERNAME: "admin"
+      MGMT_PASSWORD: "change_me!"        # change this
+    volumes:
+      - aftertouch-data:/app/data
+
+volumes:
+  aftertouch-data:
+```
+
+> **`DISCOVERY_ENABLED: "false"` is important.** Without it, AfterTouch
+> tries mDNS/UPnP discovery every 5 minutes and logs timeouts, since no
+> speakers are reachable from the cloud.
+
+Replace `soundtouch.example.com` with your own domain. Run:
+
+```bash
+docker compose up -d
+```
+
+### Coolify
+
+wimdeblauwe's working Coolify configuration (from
+[discussion #295](https://github.com/gesellix/Bose-SoundTouch/discussions/295)):
+
+- **Docker image:** `ghcr.io/gesellix/bose-soundtouch`
+- **Tag:** `latest`
+- **Custom docker options:** `--env SERVER_URL=https://soundtouch.example.com`
+- **Port exposes:** `8000,8443`
+- **Basic auth:** enabled in Coolify's settings
+- **Persistent storage volume:** source `/opt/coolifydata/soundtouchdata` →
+  destination `/app/data`
+
+Coolify handles HTTPS and certificate renewal automatically via Let's Encrypt.
+
+---
+
+## Step 2 — Verify the service is reachable
+
+```bash
+curl https://soundtouch.example.com/health
+```
+
+You should get a JSON response with `"status":"ok"` and a version string.
+If you get a certificate error, the HTTPS setup is not complete — fix that
+before proceeding, because the speaker will reject an untrusted certificate.
+
+---
+
+## Step 3 — Migrate the speaker from your local machine
+
+Because AfterTouch is in the cloud and cannot reach your speaker, the
+migration must be driven from `soundtouch-cli` **running on your own machine
+on the same LAN as the speaker**.
+
+Download `soundtouch-cli` for your OS from the
+[Releases page](https://github.com/gesellix/Bose-SoundTouch/releases).
+
+### Check the migration plan first
+
+```bash
+soundtouch-cli --host 192.0.2.1 setup plan \
+  --service-url="https://soundtouch.example.com"
+```
+
+Replace `192.0.2.1` with your speaker's LAN IP. The plan output shows what
+will change and which migration method will be used.
+
+### Run the migration
+
+```bash
+soundtouch-cli --host 192.0.2.1 setup migrate \
+  --service-url="https://soundtouch.example.com" \
+  --method=telnet
+```
+
+If `telnet` is not available on your speaker, omit `--method` to let the
+CLI pick the best available method.
+
+### Reboot the speaker
+
+```bash
+soundtouch-cli --host 192.0.2.1 setup reboot
+```
+
+Wait 2–3 minutes for the speaker to come back up. After the reboot, the
+speaker contacts `soundtouch.example.com` instead of the Bose cloud.
+
+---
+
+## Step 4 — Open the AfterTouch Admin UI
+
+Navigate to **`https://soundtouch.example.com`** in a browser. Because you
+set `DISCOVERY_ENABLED=false`, the Devices list may be empty — the speaker
+registered itself when it connected, but you need to add it manually first.
+
+Add your speaker:
+1. Go to the **Devices** tab.
+2. Click **Add device manually**.
+3. Enter your speaker's LAN IP (`192.0.2.1`) and click **Add**.
+
+The speaker should appear in the list.
+
+---
+
+## Step 5 — Run Health QuickFixes
+
+1. Click your speaker → **Health** tab.
+2. Run or refresh the health checks.
+3. Apply any QuickFixes shown, especially:
+
+   | Warning | Action |
+   |---------|--------|
+   | *Speaker reports an empty `<margeAccountUUID>`* | Click **Pair account** / **Apply QuickFix** |
+   | *INTERNET_RADIO source is a stale stub* | Click **Remove INTERNET_RADIO source** |
+
+4. Reboot the speaker after any QuickFix that requires it, then re-run health checks.
+
+---
+
+## Step 6 — TuneIn source registration (if TuneIn is missing)
+
+On a freshly factory-reset speaker, TuneIn may not appear in the speaker's
+source list — you'll see error `1005` (UNKNOWN_SOURCE_ERROR) when trying to
+play a TuneIn station.
+
+**Why this happens:** The speaker materialises its source list from what
+AfterTouch serves via `/streaming/account/<id>/full`. If the device's
+`Sources.xml` on the server doesn't include a TUNEIN entry, the speaker
+never registers TuneIn as a source.
+
+**Check whether TuneIn is missing:**
+
+```bash
+curl -s http://192.0.2.1:8090/sources
+```
+
+If the XML does not contain `source="TUNEIN"`, run the Health QuickFix for
+missing sources (the health check reports it as a warning). If no QuickFix
+appears, trigger a data sync from the AfterTouch web UI:
+
+1. Click your speaker → **Data Sync** tab (or **Migration** tab).
+2. Click **Sync** to push the default source set to the speaker.
+3. Reboot the speaker.
+4. Re-check `/sources` — `TUNEIN` should now be present.
+
+After TuneIn appears:
+
+```bash
+soundtouch-cli --host 192.0.2.1 source tunein --station s10861 \
+  --service-url="https://soundtouch.example.com"
+sleep 5
+soundtouch-cli --host 192.0.2.1 preset store-current --slot 1
+```
+
+---
+
+## Step 7 — Set up preset buttons
+
+### Via soundtouch-cli (from your local machine)
+
+```bash
+soundtouch-cli --host 192.0.2.1 source custom-radio \
+  --url "https://stream.laut.fm/country-nonstop" \
+  --name "Country Nonstop" \
+  --service-url "https://soundtouch.example.com"
+sleep 5
+soundtouch-cli --host 192.0.2.1 preset store-current --slot 1
+```
+
+See the [On-Device Install Walkthrough](ON-DEVICE-INSTALL-WALKTHROUGH.md#step-9--store-custom-radio-streams-to-preset-buttons)
+for six worked examples with public internet radio streams.
+
+### Via the AfterTouch web UI
+
+Use the **Radio Browser** or **TuneIn** tab in the Admin UI to find a
+station, play it, then store it to a preset slot.
+
+---
+
+## What happens if AfterTouch goes offline?
+
+The speaker caches its last-known source list and presets. If AfterTouch
+becomes unreachable:
+
+- **Preset buttons** that trigger locally-stored content (custom radio,
+  cached TuneIn stations) may still work for a short time.
+- **TuneIn / Spotify** require AfterTouch to resolve the token and URL —
+  these stop working when the server is unreachable.
+- **Audio does not route through AfterTouch** — once a stream URL is
+  resolved, the speaker fetches audio directly from the provider.
+
+To minimise downtime, use your cloud provider's restart policy
+(`restart: unless-stopped` in Docker Compose, or Coolify's auto-restart).
+
+---
+
+## Troubleshooting
+
+| Symptom | First check |
+|---------|------------|
+| Speaker shows certificate error | HTTPS certificate is not trusted — ensure your reverse proxy serves a valid Let's Encrypt cert |
+| Migration fails with "connection refused" | Speaker can't reach `soundtouch.example.com:443` — check your server's firewall |
+| Source TuneIn 1005 error | TuneIn not in speaker's source list — follow Step 6 |
+| AfterTouch logs "discovery timeout" every 5 min | Set `DISCOVERY_ENABLED=false` |
+| Devices tab empty after migration | Add the speaker manually by IP (Step 4) |
+| `margeAccountUUID` still empty after QuickFix | Re-run Health QuickFix and reboot again |
+
+For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and
+[MIGRATION-GUIDE.md](MIGRATION-GUIDE.md).
+
+---
+
+## References
+
+- [discussion #295](https://github.com/gesellix/Bose-SoundTouch/discussions/295) —
+  wimdeblauwe's field report deploying AfterTouch on a Hetzner VPS via Coolify;
+  covers the TuneIn source registration issue in detail.

--- a/docs/guides/DEPLOYMENT-OVERVIEW.md
+++ b/docs/guides/DEPLOYMENT-OVERVIEW.md
@@ -1,0 +1,66 @@
+# AfterTouch Deployment Overview
+
+AfterTouch replaces the Bose SoundTouch cloud, which shut down on 2026-05-06. There are two
+ways to run it — pick the one that fits your situation.
+
+---
+
+## Which deployment is right for me?
+
+|  | External host | On-device |
+|--|---------------|-----------|
+| **What it means** | AfterTouch runs on a separate computer (Raspberry Pi, NAS, PC) on your LAN. Speakers are pointed at that host. | AfterTouch runs directly on the SoundTouch speaker itself. No extra hardware. |
+| **Extra hardware needed** | Yes — a Raspberry Pi or any always-on machine | No |
+| **Multiple speakers** | Easy — one instance serves all speakers on the LAN | Each speaker needs its own install |
+| **Invasiveness** | Low — only the speaker's server-URL config changes | Slightly higher — writes to the speaker's persistent storage |
+| **Updates** | Update the host; speakers pick it up automatically | SSH into each speaker to update |
+| **Good for** | Households with several speakers; users who want a central dashboard | Single-speaker households; users who don't have an always-on computer |
+
+---
+
+## Option A — External host (Raspberry Pi, NAS, PC)
+
+The speaker stays unmodified. You run AfterTouch on a machine you already have
+on your home network, then tell the speaker to use it instead of the Bose cloud.
+
+| | Link |
+|--|------|
+| **User-friendly walkthrough** | [External Host Walkthrough](EXTERNAL-HOST-WALKTHROUGH.md) — step-by-step from install through preset setup |
+| **Raspberry Pi quick-install** | [Raspberry Pi Guide](RASPBERRY-PI.md) — one-command installer, systemd integration |
+| **Technical reference** | [Deployment Guide](DEPLOYMENT.md) — Docker, Kubernetes, systemd unit, configuration |
+
+---
+
+## Option B — On-device (AfterTouch on the speaker)
+
+AfterTouch runs on the SoundTouch speaker itself. Requires one SSH session to
+install; after that, the speaker self-hosts its own AfterTouch.
+
+| | Link |
+|--|------|
+| **User-friendly walkthrough** | [On-Device Install Walkthrough](ON-DEVICE-INSTALL-WALKTHROUGH.md) — SSH connection through verified radio preset playback |
+| **Installer reference** | [On-Device Installer README](../../scripts/on-device-install/README.md) — flags, paths, VERSION override, update/rollback |
+
+---
+
+## After choosing a deployment path
+
+Once AfterTouch is running and your speaker is migrated, the next steps are the
+same regardless of which deployment you chose:
+
+- **Health tab** — open the AfterTouch UI → Health, and run any QuickFixes shown
+  (especially *"empty margeAccountUUID"* if present).
+- **Music sources** — the Health tab also shows whether Internet Radio, TuneIn,
+  and Radio Browser are active.
+- **Presets** — use the AfterTouch web UI or `soundtouch-cli preset store-current`
+  to program the physical preset buttons.
+
+For troubleshooting either deployment see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+
+---
+
+## Architecture and planning documents
+
+If you're a contributor or interested in the technical design decisions
+(install patterns, user journeys, Gio/Wails tradeoffs, mini-build discussion),
+see [docs/architecture/DEVICE-LOCAL-INSTALL.md](../architecture/DEVICE-LOCAL-INSTALL.md).

--- a/docs/guides/DEPLOYMENT-OVERVIEW.md
+++ b/docs/guides/DEPLOYMENT-OVERVIEW.md
@@ -7,15 +7,15 @@ three ways to run it — pick the one that fits your situation.
 
 ## Which deployment is right for me?
 
-|                          | Local external host | Cloud / VPS | On-device |
-|--------------------------|---------------------|-------------|-----------|
-| **What it means**        | AfterTouch runs on a Raspberry Pi, NAS, or PC on your home LAN. | AfterTouch runs on a remote server you own (Hetzner, DigitalOcean, Coolify, …). | AfterTouch runs directly on the SoundTouch speaker itself. |
-| **Extra hardware**       | Yes — an always-on machine at home | No — uses a server you already have | No |
-| **Multiple speakers**    | Easy — one instance for all LAN speakers | Yes — one instance, managed remotely | Each speaker needs its own install |
-| **Speaker migration**    | Via the AfterTouch web UI | Via `soundtouch-cli` on your local machine | Via SSH into the speaker |
-| **HTTPS needed**         | No — HTTP on the LAN is fine | **Yes** — speakers require a valid certificate | No |
-| **Updates**              | Update the host once | Update the server once | SSH into each speaker |
-| **Good for**             | Most households; want a central dashboard | No always-on home machine; already have a VPS | Single-speaker; no extra hardware at all |
+|                       | Local external host                                             | Cloud / VPS                                                                     | On-device                                                                                                                         |
+|-----------------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| **What it means**     | AfterTouch runs on a Raspberry Pi, NAS, or PC on your home LAN. | AfterTouch runs on a remote server you own (Hetzner, DigitalOcean, Coolify, …). | AfterTouch runs directly on the SoundTouch speaker itself.                                                                        |
+| **Extra hardware**    | Yes — an always-on machine at home                              | No — uses a server you already have                                             | No                                                                                                                                |
+| **Multiple speakers** | Easy — one instance for all LAN speakers                        | Yes — one instance, managed remotely                                            | One install may serve multiple speakers if port 8000 is LAN-accessible (firmware-dependent; older devices may bind loopback only) |
+| **Speaker migration** | Via the AfterTouch web UI                                       | Via `soundtouch-cli` on your local machine                                      | Via SSH into the speaker                                                                                                          |
+| **HTTPS needed**      | No — HTTP on the LAN is fine                                    | **Yes** — speakers require a valid certificate                                  | No                                                                                                                                |
+| **Updates**           | Update the host once                                            | Update the server once                                                          | SSH into each speaker                                                                                                             |
+| **Good for**          | Most households; want a central dashboard                       | No always-on home machine; already have a VPS                                   | Single-speaker; no extra hardware at all                                                                                          |
 
 ---
 
@@ -24,11 +24,11 @@ three ways to run it — pick the one that fits your situation.
 Run AfterTouch on a machine already on your home network. The speaker is pointed at it
 via a simple URL change — nothing else on the speaker is modified.
 
-| | Link |
-|--|------|
-| **User-friendly walkthrough** | [External Host Walkthrough](EXTERNAL-HOST-WALKTHROUGH.md) — install → discover → migrate → presets |
-| **Raspberry Pi quick-install** | [Raspberry Pi Guide](RASPBERRY-PI.md) — one-command installer, systemd integration |
-| **Technical reference** | [Deployment Guide](DEPLOYMENT.md) — Docker, Kubernetes, systemd unit, configuration |
+|                                | Link                                                                                               |
+|--------------------------------|----------------------------------------------------------------------------------------------------|
+| **User-friendly walkthrough**  | [External Host Walkthrough](EXTERNAL-HOST-WALKTHROUGH.md) — install → discover → migrate → presets |
+| **Raspberry Pi quick-install** | [Raspberry Pi Guide](RASPBERRY-PI.md) — one-command installer, systemd integration                 |
+| **Technical reference**        | [Deployment Guide](DEPLOYMENT.md) — Docker, Kubernetes, systemd unit, configuration                |
 
 ---
 
@@ -39,11 +39,11 @@ speaker migration is done with `soundtouch-cli` from your local machine, and HTT
 a real certificate is required. Read the security notes in the walkthrough before
 exposing AfterTouch to the internet.
 
-| | Link |
-|--|------|
-| **User-friendly walkthrough** | [Cloud Deploy Walkthrough](CLOUD-DEPLOY-WALKTHROUGH.md) — VPS setup, CLI migration, TuneIn gotcha |
-| **Technical reference** | [Deployment Guide](DEPLOYMENT.md) — Docker Compose, environment variables, reverse proxy |
-| **Community field report** | [discussion #295](https://github.com/gesellix/Bose-SoundTouch/discussions/295) — Hetzner + Coolify setup by wimdeblauwe |
+|                               | Link                                                                                                                    |
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------|
+| **User-friendly walkthrough** | [Cloud Deploy Walkthrough](CLOUD-DEPLOY-WALKTHROUGH.md) — VPS setup, CLI migration, TuneIn gotcha                       |
+| **Technical reference**       | [Deployment Guide](DEPLOYMENT.md) — Docker Compose, environment variables, reverse proxy                                |
+| **Community field report**    | [discussion #295](https://github.com/gesellix/Bose-SoundTouch/discussions/295) — Hetzner + Coolify setup by wimdeblauwe |
 
 ---
 
@@ -53,10 +53,10 @@ AfterTouch runs on the SoundTouch speaker itself. Requires one SSH session to in
 after that, the speaker self-hosts its own AfterTouch. Delivers the **complete AfterTouch
 feature set** without any extra hardware.
 
-| | Link |
-|--|------|
+|                               | Link                                                                                                                      |
+|-------------------------------|---------------------------------------------------------------------------------------------------------------------------|
 | **User-friendly walkthrough** | [On-Device Install Walkthrough](ON-DEVICE-INSTALL-WALKTHROUGH.md) — SSH connection through verified radio preset playback |
-| **Installer reference** | [On-Device Installer README](../../scripts/on-device-install/README.md) — flags, paths, VERSION override, update/rollback |
+| **Installer reference**       | [On-Device Installer README](../../scripts/on-device-install/README.md) — flags, paths, VERSION override, update/rollback |
 
 ---
 

--- a/docs/guides/DEPLOYMENT-OVERVIEW.md
+++ b/docs/guides/DEPLOYMENT-OVERVIEW.md
@@ -7,7 +7,7 @@ three ways to run it — pick the one that fits your situation.
 
 ## Which deployment is right for me?
 
-|                       | Local external host                                             | Cloud / VPS                                                                     | On-device                                                                                                                         |
+|                       | Local network host                                              | Cloud / VPS                                                                     | On-device                                                                                                                         |
 |-----------------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | **What it means**     | AfterTouch runs on a Raspberry Pi, NAS, or PC on your home LAN. | AfterTouch runs on a remote server you own (Hetzner, DigitalOcean, Coolify, …). | AfterTouch runs directly on the SoundTouch speaker itself.                                                                        |
 | **Extra hardware**    | Yes — an always-on machine at home                              | No — uses a server you already have                                             | No                                                                                                                                |
@@ -19,7 +19,7 @@ three ways to run it — pick the one that fits your situation.
 
 ---
 
-## Option A — Local external host (Raspberry Pi, NAS, PC)
+## Option A — Local network host (Raspberry Pi, NAS, PC)
 
 Run AfterTouch on a machine already on your home network. The speaker is pointed at it
 via a simple URL change — nothing else on the speaker is modified.

--- a/docs/guides/DEPLOYMENT-OVERVIEW.md
+++ b/docs/guides/DEPLOYMENT-OVERVIEW.md
@@ -1,40 +1,57 @@
 # AfterTouch Deployment Overview
 
-AfterTouch replaces the Bose SoundTouch cloud, which shut down on 2026-05-06. There are two
-ways to run it — pick the one that fits your situation.
+AfterTouch replaces the Bose SoundTouch cloud, which shut down on 2026-05-06. There are
+three ways to run it — pick the one that fits your situation.
 
 ---
 
 ## Which deployment is right for me?
 
-|  | External host | On-device |
-|--|---------------|-----------|
-| **What it means** | AfterTouch runs on a separate computer (Raspberry Pi, NAS, PC) on your LAN. Speakers are pointed at that host. | AfterTouch runs directly on the SoundTouch speaker itself. No extra hardware. |
-| **Extra hardware needed** | Yes — a Raspberry Pi or any always-on machine | No |
-| **Multiple speakers** | Easy — one instance serves all speakers on the LAN | Each speaker needs its own install |
-| **Invasiveness** | Low — only the speaker's server-URL config changes | Slightly higher — writes to the speaker's persistent storage |
-| **Updates** | Update the host; speakers pick it up automatically | SSH into each speaker to update |
-| **Good for** | Households with several speakers; users who want a central dashboard | Single-speaker households; users who don't have an always-on computer |
+|                          | Local external host | Cloud / VPS | On-device |
+|--------------------------|---------------------|-------------|-----------|
+| **What it means**        | AfterTouch runs on a Raspberry Pi, NAS, or PC on your home LAN. | AfterTouch runs on a remote server you own (Hetzner, DigitalOcean, Coolify, …). | AfterTouch runs directly on the SoundTouch speaker itself. |
+| **Extra hardware**       | Yes — an always-on machine at home | No — uses a server you already have | No |
+| **Multiple speakers**    | Easy — one instance for all LAN speakers | Yes — one instance, managed remotely | Each speaker needs its own install |
+| **Speaker migration**    | Via the AfterTouch web UI | Via `soundtouch-cli` on your local machine | Via SSH into the speaker |
+| **HTTPS needed**         | No — HTTP on the LAN is fine | **Yes** — speakers require a valid certificate | No |
+| **Updates**              | Update the host once | Update the server once | SSH into each speaker |
+| **Good for**             | Most households; want a central dashboard | No always-on home machine; already have a VPS | Single-speaker; no extra hardware at all |
 
 ---
 
-## Option A — External host (Raspberry Pi, NAS, PC)
+## Option A — Local external host (Raspberry Pi, NAS, PC)
 
-The speaker stays unmodified. You run AfterTouch on a machine you already have
-on your home network, then tell the speaker to use it instead of the Bose cloud.
+Run AfterTouch on a machine already on your home network. The speaker is pointed at it
+via a simple URL change — nothing else on the speaker is modified.
 
 | | Link |
 |--|------|
-| **User-friendly walkthrough** | [External Host Walkthrough](EXTERNAL-HOST-WALKTHROUGH.md) — step-by-step from install through preset setup |
+| **User-friendly walkthrough** | [External Host Walkthrough](EXTERNAL-HOST-WALKTHROUGH.md) — install → discover → migrate → presets |
 | **Raspberry Pi quick-install** | [Raspberry Pi Guide](RASPBERRY-PI.md) — one-command installer, systemd integration |
 | **Technical reference** | [Deployment Guide](DEPLOYMENT.md) — Docker, Kubernetes, systemd unit, configuration |
 
 ---
 
-## Option B — On-device (AfterTouch on the speaker)
+## Option B — Cloud / VPS
 
-AfterTouch runs on the SoundTouch speaker itself. Requires one SSH session to
-install; after that, the speaker self-hosts its own AfterTouch.
+Run AfterTouch on a public server. Because the server can't reach your LAN via mDNS,
+speaker migration is done with `soundtouch-cli` from your local machine, and HTTPS with
+a real certificate is required. Read the security notes in the walkthrough before
+exposing AfterTouch to the internet.
+
+| | Link |
+|--|------|
+| **User-friendly walkthrough** | [Cloud Deploy Walkthrough](CLOUD-DEPLOY-WALKTHROUGH.md) — VPS setup, CLI migration, TuneIn gotcha |
+| **Technical reference** | [Deployment Guide](DEPLOYMENT.md) — Docker Compose, environment variables, reverse proxy |
+| **Community field report** | [discussion #295](https://github.com/gesellix/Bose-SoundTouch/discussions/295) — Hetzner + Coolify setup by wimdeblauwe |
+
+---
+
+## Option C — On-device (AfterTouch on the speaker)
+
+AfterTouch runs on the SoundTouch speaker itself. Requires one SSH session to install;
+after that, the speaker self-hosts its own AfterTouch. Delivers the **complete AfterTouch
+feature set** without any extra hardware.
 
 | | Link |
 |--|------|
@@ -55,7 +72,7 @@ same regardless of which deployment you chose:
 - **Presets** — use the AfterTouch web UI or `soundtouch-cli preset store-current`
   to program the physical preset buttons.
 
-For troubleshooting either deployment see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+For troubleshooting any deployment see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
 ---
 

--- a/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -1,0 +1,245 @@
+# External Host Walkthrough
+
+A step-by-step guide to running AfterTouch on a Raspberry Pi (or any always-on
+computer) and migrating your Bose SoundTouch speakers to use it.
+
+By the end you'll have AfterTouch running on your host, your speaker(s) pointed
+at it, and your radio presets working again.
+
+For a comparison with the on-device install option see
+[DEPLOYMENT-OVERVIEW.md](DEPLOYMENT-OVERVIEW.md).
+
+---
+
+## What you need
+
+- A **Raspberry Pi** (Zero 2W, 3, or 4), a NAS, or any always-on Linux/macOS/Windows
+  machine on your home network.
+- Your **Bose SoundTouch speaker** on the same network. It doesn't need SSH enabled.
+- A **browser** on any device on the same network.
+- The **speaker's LAN IP address** — find it in your router's device list, or run
+  `arp -a` on your computer. Replace `192.0.2.1` throughout with the real IP.
+
+---
+
+## Step 1 — Install AfterTouch on your host
+
+### Raspberry Pi (recommended for always-on use)
+
+```bash
+curl -fsSL -o install.sh \
+  https://raw.githubusercontent.com/gesellix/bose-soundtouch/main/scripts/raspberry-pi/install.sh
+sudo bash install.sh
+```
+
+The installer detects your Pi's architecture (armv7, arm64, or amd64), downloads
+the binary, creates a `soundtouch` system user, and registers a systemd unit that
+starts on boot.
+
+To install a specific version:
+
+```bash
+sudo bash install.sh v0.92.0
+```
+
+Check that the service is running:
+
+```bash
+systemctl status soundtouch-service
+```
+
+The Admin UI is now at **`http://<pi-ip>:8000`** — open it in a browser.
+
+### Other Linux hosts (systemd)
+
+Download the binary for your architecture from the
+[Releases page](https://github.com/gesellix/Bose-SoundTouch/releases), then
+install it as a systemd service — see [DEPLOYMENT.md](DEPLOYMENT.md) for the
+unit file template.
+
+### Docker
+
+```bash
+docker run -d \
+  --name aftertouch \
+  --network host \
+  -e SERVER_URL=http://192.0.2.10:8000 \
+  -v aftertouch-data:/data \
+  ghcr.io/gesellix/bose-soundtouch:latest
+```
+
+Replace `192.0.2.10` with the host machine's LAN IP. The `--network host` flag
+is required so AfterTouch can reach the speakers and respond to mDNS discovery.
+
+---
+
+## Step 2 — Note your host's LAN IP and open the Admin UI
+
+Your host's LAN IP is the address your speakers will use to reach AfterTouch.
+Find it with:
+
+```bash
+# Linux / macOS
+ip addr show     # or: hostname -I
+# Windows
+ipconfig
+```
+
+Open **`http://<host-ip>:8000`** in a browser. You should see the AfterTouch
+Admin UI. If it's not reachable, check that port 8000 is not blocked by a
+firewall on the host.
+
+---
+
+## Step 3 — Discover your speaker
+
+In the Admin UI:
+
+1. Go to the **Devices** tab. AfterTouch runs mDNS discovery automatically —
+   your speaker should appear within a minute or two.
+2. If it doesn't appear, click **Trigger Discovery**. If it still doesn't appear,
+   add it manually: enter `192.0.2.1` (your speaker's IP) and click **Add**.
+
+You should now see your speaker listed with its name and model.
+
+---
+
+## Step 4 — Migrate the speaker
+
+This step tells the speaker to use your AfterTouch instance instead of the
+defunct Bose cloud. **The speaker gets a new server URL written to it; this is
+reversible via the "Revert" button.**
+
+1. Click your speaker in the Devices list.
+2. Click **Migrate** (or open the Migration wizard from the speaker's detail page).
+3. The wizard shows a summary of what will change. Review it and click **Confirm**.
+4. AfterTouch rewrites the speaker's server-URL config and reboots it.
+5. Wait 2–3 minutes for the speaker to come back up.
+
+After the reboot the speaker reconnects to AfterTouch. You should see its status
+turn green in the Devices tab.
+
+> **If the migration wizard asks for your AfterTouch URL**, enter
+> `http://<host-ip>:8000` (the same URL you used to open the Admin UI).
+
+---
+
+## Step 5 — Check the Health tab and run QuickFixes
+
+1. Click your speaker in the Devices list, then open the **Health** tab.
+2. Click **Run health checks** (or wait for them to run automatically).
+3. Look for any warnings. The most common after a fresh migration:
+
+   | Warning | QuickFix action |
+   |---------|----------------|
+   | *Speaker reports an empty `<margeAccountUUID>`* | Click **Pair account** / **Apply QuickFix** and confirm. The speaker will reboot. |
+   | *INTERNET_RADIO source is a stale stub* | Click **Remove INTERNET_RADIO source**. |
+   | *TuneIn / Radio Browser missing from sources* | These appear automatically once the speaker has paired; if still missing after a QuickFix reboot, trigger discovery again. |
+
+4. After any QuickFix that reboots the speaker, re-run the health checks to
+   confirm the warning is gone.
+
+---
+
+## Step 6 — Verify pairing and sources
+
+After the health checks are green, confirm from your browser:
+
+- In the **Devices** tab, click the speaker. Its **Account** field should show
+  a non-empty UUID, not `default`.
+- In the **Sources** tab (if present), or via the health checks, confirm
+  `LOCAL_INTERNET_RADIO`, `TUNEIN`, and `RADIO_BROWSER` are listed.
+
+You can also check directly from any machine on the LAN:
+
+```bash
+# Replace 192.0.2.1 with your speaker's IP
+curl -s http://192.0.2.1:8090/info | grep -i marge
+curl -s http://192.0.2.1:8090/sources
+```
+
+`margeAccountUUID` must not be empty. Sources should include
+`LOCAL_INTERNET_RADIO`, `TUNEIN`, and `RADIO_BROWSER`.
+
+---
+
+## Step 7 — Set up preset buttons (optional)
+
+### Via the AfterTouch web UI
+
+1. Open **`http://<host-ip>:8000`** and navigate to your speaker.
+2. Use the **Radio Browser** or **TuneIn** tab to find a station.
+3. Click the station to play it.
+4. Click **Store as preset → slot 1** (or whichever slot you want).
+5. Repeat for slots 2–6.
+
+### Via soundtouch-cli (any machine on the LAN)
+
+Download the CLI for your machine from the
+[Releases page](https://github.com/gesellix/Bose-SoundTouch/releases), then:
+
+```bash
+# Play a custom radio stream on the speaker
+soundtouch-cli --host 192.0.2.1 source custom-radio \
+  --url "https://stream.laut.fm/country-nonstop" \
+  --name "Country Nonstop" \
+  --service-url "http://<host-ip>:8000"
+sleep 5
+
+# Store it to preset slot 1
+soundtouch-cli --host 192.0.2.1 preset store-current --slot 1
+```
+
+Repeat for each slot. See the
+[On-Device Install Walkthrough](ON-DEVICE-INSTALL-WALKTHROUGH.md#step-9--store-custom-radio-streams-to-preset-buttons)
+for six worked examples with Austrian internet radio stations.
+
+---
+
+## Step 8 — Verify and enjoy
+
+Press a preset button on the speaker briefly (a long press overwrites the preset).
+Each slot should play the corresponding stream.
+
+To check what's stored:
+
+```bash
+curl -s http://192.0.2.1:8090/presets
+```
+
+---
+
+## Updating AfterTouch
+
+### Raspberry Pi
+
+```bash
+sudo bash install.sh              # updates to latest release
+sudo bash install.sh v0.93.0     # updates to a specific version
+```
+
+The installer stops the service, downloads the new binary, and restarts
+automatically.
+
+### Checking current version
+
+```bash
+systemctl status soundtouch-service   # shows the running version in the log
+curl -s http://<host-ip>:8000/health | grep version
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | First check |
+|---------|------------|
+| Speaker not appearing in Devices | Click **Trigger Discovery**; try adding the IP manually |
+| Migration fails | Confirm the speaker can reach `http://<host-ip>:8000` — try `curl http://<host-ip>:8000` from the speaker's SSH shell |
+| `margeAccountUUID` still empty after QuickFix + reboot | Re-run Health QuickFix, reboot again |
+| Radio source error 1005 | `margeAccountUUID` is empty — complete Step 5 first |
+| Speaker reverts to Bose cloud after router restart | Your router's DNS is overriding AfterTouch's server URL — see [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md) for DNS-interception setup |
+| Admin UI not reachable | Check `systemctl status soundtouch-service` and firewall rules for port 8000 |
+
+For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and
+[MIGRATION-GUIDE.md](MIGRATION-GUIDE.md).

--- a/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -130,11 +130,11 @@ turn green in the Devices tab.
 2. Click **Run health checks** (or wait for them to run automatically).
 3. Look for any warnings. The most common after a fresh migration:
 
-   | Warning | QuickFix action |
-   |---------|----------------|
-   | *Speaker reports an empty `<margeAccountUUID>`* | Click **Pair account** / **Apply QuickFix** and confirm. The speaker will reboot. |
-   | *INTERNET_RADIO source is a stale stub* | Click **Remove INTERNET_RADIO source**. |
-   | *TuneIn / Radio Browser missing from sources* | These appear automatically once the speaker has paired; if still missing after a QuickFix reboot, trigger discovery again. |
+   | Warning                                         | QuickFix action                                                                                                            |
+   |-------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+   | *Speaker reports an empty `<margeAccountUUID>`* | Click **Pair account** / **Apply QuickFix** and confirm. The speaker will reboot.                                          |
+   | *INTERNET_RADIO source is a stale stub*         | Click **Remove INTERNET_RADIO source**.                                                                                    |
+   | *TuneIn / Radio Browser missing from sources*   | These appear automatically once the speaker has paired; if still missing after a QuickFix reboot, trigger discovery again. |
 
 4. After any QuickFix that reboots the speaker, re-run the health checks to
    confirm the warning is gone.
@@ -232,14 +232,14 @@ curl -s http://<host-ip>:8000/health | grep version
 
 ## Troubleshooting
 
-| Symptom | First check |
-|---------|------------|
-| Speaker not appearing in Devices | Click **Trigger Discovery**; try adding the IP manually |
-| Migration fails | Confirm the speaker can reach `http://<host-ip>:8000` — try `curl http://<host-ip>:8000` from the speaker's SSH shell |
-| `margeAccountUUID` still empty after QuickFix + reboot | Re-run Health QuickFix, reboot again |
-| Radio source error 1005 | `margeAccountUUID` is empty — complete Step 5 first |
-| Speaker reverts to Bose cloud after router restart | Your router's DNS is overriding AfterTouch's server URL — see [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md) for DNS-interception setup |
-| Admin UI not reachable | Check `systemctl status soundtouch-service` and firewall rules for port 8000 |
+| Symptom                                                | First check                                                                                                                       |
+|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| Speaker not appearing in Devices                       | Click **Trigger Discovery**; try adding the IP manually                                                                           |
+| Migration fails                                        | Confirm the speaker can reach `http://<host-ip>:8000` — try `curl http://<host-ip>:8000` from the speaker's SSH shell             |
+| `margeAccountUUID` still empty after QuickFix + reboot | Re-run Health QuickFix, reboot again                                                                                              |
+| Radio source error 1005                                | `margeAccountUUID` is empty — complete Step 5 first                                                                               |
+| Speaker reverts to Bose cloud after router restart     | Your router's DNS is overriding AfterTouch's server URL — see [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md) for DNS-interception setup |
+| Admin UI not reachable                                 | Check `systemctl status soundtouch-service` and firewall rules for port 8000                                                      |
 
 For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and
 [MIGRATION-GUIDE.md](MIGRATION-GUIDE.md).

--- a/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -282,14 +282,14 @@ should start playing the corresponding stream.
 
 ## Troubleshooting
 
-| Symptom | First check |
-|---------|------------|
-| SSH "no matching host key type" | Add `-oHostKeyAlgorithms=+ssh-rsa` |
-| Port 8000 not reachable from LAN | Use the SSH tunnel (Step 5) |
-| `margeAccountUUID` still empty after reboot | Re-run Health QuickFix, reboot again |
-| Radio source error 1005 | `margeAccountUUID` is empty — complete Step 6 first |
-| `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20` |
-| No space left on device during install | Run the cleanup in Step 2; check `df -h /mnt/nv` |
+| Symptom                                              | First check                                         |
+|------------------------------------------------------|-----------------------------------------------------|
+| SSH "no matching host key type"                      | Add `-oHostKeyAlgorithms=+ssh-rsa`                  |
+| Port 8000 not reachable from LAN                     | Use the SSH tunnel (Step 5)                         |
+| `margeAccountUUID` still empty after reboot          | Re-run Health QuickFix, reboot again                |
+| Radio source error 1005                              | `margeAccountUUID` is empty — complete Step 6 first |
+| `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20`            |
+| No space left on device during install               | Run the cleanup in Step 2; check `df -h /mnt/nv`    |
 
 For more detail on any of these, see
 [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) and the

--- a/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -1,0 +1,296 @@
+# On-Device Install Walkthrough
+
+A complete end-to-end runbook for installing AfterTouch directly on a
+Bose SoundTouch speaker — from first SSH connection through verified
+radio preset playback.
+
+**Credit:** This guide is based on a step-by-step walkthrough contributed
+by [weissigera](https://github.com/weissigera) in
+[issue #329](https://github.com/gesellix/Bose-SoundTouch/issues/329#issuecomment-4521280831),
+documenting a successful fresh installation on a SoundTouch 20 Series I.
+
+For the installer reference and troubleshooting tips see
+[scripts/on-device-install/README.md](../../scripts/on-device-install/README.md).
+
+---
+
+## Prerequisites
+
+- SSH enabled on the speaker (the usual "Stick with remote_services" procedure).
+- Your machine can reach the speaker on the LAN.
+- The speaker's LAN IP address — replace `192.0.2.1` throughout with the
+  actual address shown in your router or `arp -a`.
+
+> **Note on SSH host-key negotiation:** SoundTouch speakers only advertise
+> legacy host-key algorithms (`ssh-rsa`, `ssh-dss`). Modern OpenSSH clients
+> reject these by default. The `-oHostKeyAlgorithms=+ssh-rsa` flag below
+> opts them back in. Without it you'll see
+> `no matching host key type found`.
+
+---
+
+## Step 1 — Connect to the speaker via SSH
+
+```bash
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
+```
+
+You should see a prompt such as `root@soundtouch-device:~#`.
+
+---
+
+## Step 2 — Check free space (and clean up if needed)
+
+The persistent `/mnt/nv` partition typically has 20–40 MB free — enough for
+the AfterTouch binary (~12 MB) plus one backup. Check first:
+
+```bash
+rw            # remount rootfs read-write
+df -h /mnt/nv
+```
+
+If you have an older installation with multiple backup or artefact files left
+behind by earlier upgrades, remove them:
+
+```bash
+# List what's there
+ls -lh /mnt/nv/aftertouch/
+
+# Remove specific stale files (adjust version numbers to what you see)
+rm -f /mnt/nv/aftertouch/aftertouch-service.v0.80.1.backup
+rm -f /mnt/nv/aftertouch/aftertouch-service.v0.86.0.backup
+rm -f /mnt/nv/aftertouch/aftertouch-service.v0.86.0.old
+rm -f /mnt/nv/aftertouch/aftertouch-service.new
+rm -f /mnt/nv/soundtouch-cli        # cli binary if left there by hand
+rm -f /mnt/nv/aftertouch/soundtouch-cli
+
+df -h /mnt/nv   # confirm space recovered
+```
+
+> **From v0.89.0 onwards the installer prunes stale artefacts automatically**
+> during every upgrade — manual cleanup should no longer be necessary on
+> fresh installs.
+
+---
+
+## Step 3 — Install (or upgrade) AfterTouch
+
+Run the canonical one-liner. It downloads the binary and init script,
+creates `/mnt/nv/aftertouch/`, symlinks `/opt/aftertouch`, backs up the
+currently running binary, and starts the service:
+
+```bash
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+```
+
+To target a specific version instead of the default:
+
+```bash
+# Via environment variable (works with pipe-to-sh)
+VERSION=0.92.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+
+# Via command-line flag (pass args after sh -s --)
+curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.92.0
+```
+
+Verify the installed version:
+
+```bash
+wget -qO- http://localhost:8000/health
+```
+
+The JSON response should include `"version":"v0.92.0"` (or whichever
+version you installed).
+
+---
+
+## Step 4 — Reboot the speaker
+
+```bash
+sync
+reboot
+```
+
+Wait 2–3 minutes for the speaker to come back up, then reconnect:
+
+```bash
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
+```
+
+---
+
+## Step 5 — Open an SSH tunnel and access the Admin UI
+
+**Open a new terminal on your machine** (not inside the speaker's SSH
+session — see [issue #250](https://github.com/gesellix/Bose-SoundTouch/issues/250)
+for the port-forward-from-inside trap) and run:
+
+```bash
+ssh -oHostKeyAlgorithms=+ssh-rsa -L 8000:localhost:8000 root@192.0.2.1
+```
+
+Keep this terminal open. Navigate to **http://localhost:8000** in your
+browser.
+
+> Skip this step if your speaker's firmware exposes port 8000 on the LAN
+> directly — you can reach `http://192.0.2.1:8000` without a tunnel in that
+> case.
+
+---
+
+## Step 6 — Run the Health QuickFix for empty `margeAccountUUID`
+
+In the AfterTouch UI:
+
+1. Open the **Health** tab.
+2. Run or refresh the health checks.
+3. Look for the warning:
+   > *Speaker reports an empty `<margeAccountUUID>`*
+4. Click the **QuickFix** button (labelled "Fix", "Pair account", or
+   "Apply QuickFix" depending on the version) and confirm.
+
+Then reboot again to let the pairing take effect:
+
+```bash
+sync
+reboot
+```
+
+---
+
+## Step 7 — Verify pairing and sources
+
+After the reboot reconnect via SSH and check:
+
+```bash
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
+
+# margeAccountUUID must NOT be empty after the QuickFix
+wget -qO- http://localhost:8090/info | grep margeAccountUUID
+
+# Sources must include LOCAL_INTERNET_RADIO, TUNEIN, and RADIO_BROWSER
+wget -qO- http://localhost:8090/sources
+```
+
+If `margeAccountUUID` is still empty, re-run the Health QuickFix (Step 6)
+and reboot again.
+
+---
+
+## Step 8 — Download soundtouch-cli (optional, for preset setup)
+
+If you want to program preset buttons from the command line, download the
+CLI binary to the speaker's `/tmp` (tmpfs, so it survives only until the
+next reboot — which is fine for a one-time setup run):
+
+```bash
+cd /tmp
+
+curl -L --fail -o soundtouch-cli \
+  https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.92.0/soundtouch-cli-v0.92.0-linux-armv7
+chmod +x soundtouch-cli
+
+/tmp/soundtouch-cli --version
+```
+
+Replace `v0.92.0` with the version you installed.
+
+---
+
+## Step 9 — Store custom radio streams to preset buttons
+
+Each station must be playing before it can be saved. The `sleep 5` gives
+the speaker time to buffer and confirm the stream before storing.
+
+> **Press preset buttons briefly.** A long press on the physical hardware
+> overwrites the stored preset.
+
+```bash
+# Preset 1 — Hitradio OE3
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "http://orf-live.ors-shoutcast.at/oe3-q2a" \
+  --name "Hitradio OE3" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 1
+
+# Preset 2 — Lounge FM
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "http://188.138.9.183/digital.mp3" \
+  --name "Lounge FM" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 2
+
+# Preset 3 — Country Nonstop
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "https://stream.laut.fm/country-nonstop" \
+  --name "Country Nonstop" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 3
+
+# Preset 4 — Radio Piterpan
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "https://klasse1.fluidstream.eu/piterpan.mp3?FLID=8" \
+  --name "Radio Piterpan" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 4
+
+# Preset 5 — kronehit
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "https://secureonair.krone.at/kronehit-hp.mp3" \
+  --name "kronehit" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 5
+
+# Preset 6 — Radio Niederösterreich
+/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+  --url "http://orf-live.ors-shoutcast.at/noe-q2a" \
+  --name "Radio Niederoesterreich" \
+  --service-url "http://localhost:8000"
+sleep 5
+/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 6
+```
+
+These are the stations from weissigera's setup (Austrian public and
+internet radio). Replace any or all of them with your own streams — the
+pattern is the same regardless of station.
+
+---
+
+## Step 10 — Verify presets and final reboot
+
+```bash
+wget -qO- http://localhost:8090/presets
+```
+
+You should see all six preset slots populated. Then do a final reboot and
+test the physical buttons:
+
+```bash
+sync
+reboot
+```
+
+After the speaker comes back up, press preset buttons 1–6 briefly — each
+should start playing the corresponding stream.
+
+---
+
+## Troubleshooting
+
+| Symptom | First check |
+|---------|------------|
+| SSH "no matching host key type" | Add `-oHostKeyAlgorithms=+ssh-rsa` |
+| Port 8000 not reachable from LAN | Use the SSH tunnel (Step 5) |
+| `margeAccountUUID` still empty after reboot | Re-run Health QuickFix, reboot again |
+| Radio source error 1005 | `margeAccountUUID` is empty — complete Step 6 first |
+| `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20` |
+| No space left on device during install | Run the cleanup in Step 2; check `df -h /mnt/nv` |
+
+For more detail on any of these, see
+[TROUBLESHOOTING.md](./TROUBLESHOOTING.md) and the
+[on-device installer README](../../scripts/on-device-install/README.md).

--- a/docs/guides/RASPBERRY-PI.md
+++ b/docs/guides/RASPBERRY-PI.md
@@ -2,6 +2,11 @@
 
 This guide explains how to install the `soundtouch-service` as a persistent systemd service on a Raspberry Pi (tested on Raspberry Pi Zero 2W, 3, and 4).
 
+For a complete walkthrough — from install through speaker migration and preset setup — see
+[EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).
+Not sure whether to use a Pi or run AfterTouch on the speaker itself? See
+[DEPLOYMENT-OVERVIEW.md](DEPLOYMENT-OVERVIEW.md).
+
 ## Automated Installer
 
 We provide a specialized installer script located in the `scripts/raspberry-pi/` directory of the repository.
@@ -30,7 +35,7 @@ You can customize the installation using environment variables:
 
 ```bash
 sudo \
-  VERSION=v0.17.0 \
+  VERSION=v0.92.0 \
   HOSTNAME_FQDN=soundtouch.local \
   HTTP_PORT=80 \
   HTTPS_PORT=443 \
@@ -42,7 +47,7 @@ sudo \
 To update the service to a specific version, run the installer with the version as an argument:
 
 ```bash
-sudo bash install.sh v0.18.1
+sudo bash install.sh v0.92.0
 ```
 
 The installer will automatically fetch the latest version of itself for that release and then update the service binary and restart it.

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -2,6 +2,9 @@
 
 Allows to run AfterTouch on SoundTouch devices directly, eliminating the need to run and maintain a separate server on the local network.
 
+For a complete step-by-step walkthrough — from first SSH connection through verified radio preset playback — see
+[docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md](../../docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md).
+
 ## Disclaimer
 
 ### Invasiveness
@@ -82,7 +85,31 @@ The init script's `status` now distinguishes "running with listener up" from "PI
 
 ## Updating AfterTouch
 
-To update AfterTouch, simply run the installation command again. The installer will check if there's a new version available and update it if necessary.
+Run the installer again with the version you want to install. The script backs up the currently-running binary (named after its version), installs the new one, and prunes older leftover artefacts to keep `/mnt/nv` free.
+
+**Install (or upgrade to) a specific version** — three equivalent ways:
+
+```bash
+# 1. Environment variable (works when piping into sh)
+VERSION=0.92.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+
+# 2. Command-line flag (pass args after `sh -s --`)
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.92.0
+
+# 3. Download first, then run with a flag
+curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh
+sh install.sh --version 0.92.0
+```
+
+Running **without** a version override installs the version hard-coded in the script (the latest release at the time the script was published). That default is updated with each release; if you're running from `main`, it reflects the most recent tagged version.
+
+> **Tip — rollback:** if the new binary misbehaves, the installer left a `.backup` file alongside it:
+> ```bash
+> ls /mnt/nv/aftertouch/aftertouch-service*.backup
+> cp /mnt/nv/aftertouch/aftertouch-service.<old-version>.backup \
+>    /mnt/nv/aftertouch/aftertouch-service
+> /etc/init.d/aftertouch restart
+> ```
 
 ## Uninstallation
 

--- a/scripts/on-device-install/aftertouch
+++ b/scripts/on-device-install/aftertouch
@@ -81,10 +81,24 @@ case "$1" in
   stop)
     echo "Stopping $DESC..."
     if [ -f "$PIDFILE" ]; then
+      PID=$(cat "$PIDFILE")
       start-stop-daemon --stop \
         --quiet \
         --oknodo \
         --pidfile "$PIDFILE"
+      # Wait up to 15 s for SIGTERM to take effect before escalating.
+      # The Go HTTP server exits promptly on SIGTERM in normal conditions;
+      # the loop handles the rare case where it is stuck in a blocking syscall.
+      tries=0
+      while [ $tries -lt 15 ] && kill -0 "$PID" 2>/dev/null; do
+        sleep 1
+        tries=$((tries + 1))
+      done
+      if kill -0 "$PID" 2>/dev/null; then
+        echo "Warning: $NAME (PID $PID) still alive after ${tries}s; sending SIGKILL..." >&2
+        kill -9 "$PID" 2>/dev/null || true
+        sleep 1
+      fi
       rm -f "$PIDFILE"
     else
       echo "No $NAME running (no PID file)." >&2

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -44,8 +44,39 @@ curl \
   --fail \
   "$BINARY_URL"
 
+# Back up the current binary before overwriting so a one-step rollback
+# is always available.  The version string comes from the binary itself;
+# if it is absent (very old build or corrupted) we fall back to a timestamp.
+BACKUP_FILE=""
+if [ -f "$INSTALL_DIR/aftertouch-service" ]; then
+  current_version=$("$INSTALL_DIR/aftertouch-service" --version 2>/dev/null \
+    | awk '{print $NF}') || true
+  if [ -z "$current_version" ] || [ "$current_version" = "dev" ]; then
+    current_version=$(date +%Y%m%d-%H%M%S)
+  fi
+  BACKUP_FILE="$INSTALL_DIR/aftertouch-service.${current_version}.backup"
+  cp -p "$INSTALL_DIR/aftertouch-service" "$BACKUP_FILE"
+  echo "Backed up current binary ($current_version) → $BACKUP_FILE"
+fi
+
 mv "$UPDATE_TMP_DIR/binary" "$INSTALL_DIR/aftertouch-service"
 chmod +x "$INSTALL_DIR/aftertouch-service"
+
+# Keep only the backup we just created; prune all older *.backup, *.old, and
+# *.new artefacts left by earlier installs.  /mnt/nv is small (tens of MB),
+# so accumulation quickly causes "no space left on device" during downloads.
+if [ -n "$BACKUP_FILE" ]; then
+  echo "Disk usage before GC:"; df -h "$INSTALL_DIR"
+  for f in "$INSTALL_DIR/aftertouch-service".*.backup \
+            "$INSTALL_DIR/aftertouch-service".*.old \
+            "$INSTALL_DIR/aftertouch-service.new"; do
+    [ -f "$f" ] || continue
+    [ "$f" = "$BACKUP_FILE" ] && continue
+    rm -f "$f"
+    echo "Removed stale artefact: $f"
+  done
+  echo "Disk usage after GC:"; df -h "$INSTALL_DIR"
+fi
 
 echo "Creating init script..."
 curl \

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 set -eo pipefail
 
+# Default version installed when no override is provided.  Update this value
+# each time a new release is cut so that running the canonical one-liner
+#   curl -sSL .../install.sh | sh
+# picks up the latest binary without extra arguments.
+#
+# Override via environment variable or the --version/-v flag:
+#   VERSION=0.92.0 curl -sSL .../install.sh | sh
+#   curl -sSL .../install.sh | sh -s -- --version 0.92.0
 VERSION=${VERSION:-0.91.0}
+
+# Parse optional command-line arguments so the script can be invoked as:
+#   install.sh --version 0.92.0
+#   install.sh -v 0.92.0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version|-v)
+      if [ -z "$2" ]; then
+        echo "ERROR: --version requires an argument." >&2; exit 1
+      fi
+      VERSION="$2"; shift 2;;
+    --) shift; break;;
+    *) echo "Unknown argument: $1" >&2; exit 1;;
+  esac
+done
+
 GH_REPO=${GH_REPO:-gesellix/Bose-SoundTouch}
 BINARY_URL=${BINARY_URL:-https://github.com/$GH_REPO/releases/download/v$VERSION/soundtouch-service-v$VERSION-linux-armv7}
 INIT_SCRIPT_URL=${INIT_SCRIPT_URL:-https://raw.githubusercontent.com/$GH_REPO/v$VERSION/scripts/on-device-install/aftertouch}


### PR DESCRIPTION
Closes #329.

## Installer fixes

- **Backup + GC on upgrade**: `install.sh` now backs up the running binary (named after its version) before replacing it, then prunes all older `.backup`/`.old`/`.new` artefacts. Keeps `/mnt/nv` free.
- **`--version` flag**: `install.sh` accepts `--version`/`-v` in addition to the `VERSION` env var. Both forms documented in the installer README with rollback tip.
- **Reliable `stop)`**: the init script now waits up to 15 s for SIGTERM to take effect, then escalates to SIGKILL. Addresses the workaround weissigera needed (`killall aftertouch-service`).

## Docs

- `docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md`: 10-step field-tested runbook from weissigera (SSH, storage check, install, pairing, presets). Credited to the contributor.
- `docs/guides/DEPLOYMENT-OVERVIEW.md`: navigation page comparing all three deployment options (local host, cloud/VPS, on-device) with links to walkthroughs.
- `docs/guides/EXTERNAL-HOST-WALKTHROUGH.md`: install to preset setup for Raspberry Pi / NAS / PC.
- `docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md`: VPS/Coolify setup, CLI-driven migration, TuneIn source gotcha, security notes. Based on discussion #295.
- `docs/architecture/DEVICE-LOCAL-INSTALL.md`: moved planning doc out of the user-visible guides root.
- README: replaced the one-liner on-device footnote with a link to the deployment overview.