### PR TITLE
docs: update cloud-shutdown messaging to past tense

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 > by, or otherwise connected to Bose Corporation.** See
 > [Disclaimer](#disclaimer) for the full statement.
 
-## Context: Cloud Shutdown
+## The Bose Cloud Has Shut Down
 
-Bose is shutting down SoundTouch cloud services on **May 6, 2026**. After that, music service browsing, preset sync, and the official SoundTouch app stop working. This toolkit lets you keep your speakers fully functional.
+Bose shut down SoundTouch cloud services on **May 6, 2026**. Presets, music service browsing, and stereo pairing no longer work through Bose's infrastructure. AfterTouch restores all of these — no Bose infrastructure required.
 
 See the [Survival Guide](https://gesellix.github.io/Bose-SoundTouch/guides/SURVIVAL-GUIDE.html) for the full picture.
 
@@ -25,13 +25,11 @@ A local server that replaces the Bose cloud ("AfterTouch"). Once your speaker is
 
 Not sure which approach fits your situation? See the [Deployment Overview](./docs/guides/DEPLOYMENT-OVERVIEW.md) — it compares running AfterTouch on a Raspberry Pi or other always-on host against running it directly on the SoundTouch speaker, with links to step-by-step walkthroughs for each path.
 
-**Two scenarios:**
+**Getting started:**
 
-**Before shutdown — migrate your existing setup**
-While the Bose cloud is still running, use `soundtouch-backup` to save your account data. The local service web UI then helps with the migration so your speaker keeps its presets and credentials.
+**Already migrated before May 6** — your presets and credentials are preserved. AfterTouch picks up where the Bose cloud left off.
 
-**After shutdown or factory reset — start fresh**
-Create a local account, configure your speakers, and start using them immediately. No Bose infrastructure required.
+**Starting fresh (or after a factory reset)** — create a local account, configure your speakers, and start using them immediately.
 
 **Redirecting your speaker**
 

--- a/docs/guides/MIGRATION-GUIDE.md
+++ b/docs/guides/MIGRATION-GUIDE.md
@@ -128,7 +128,7 @@ Once the speaker appears, click **Sync Data**. This connects to the speaker and 
 
 ![Data Sync tab showing a successful sync](../images/ui-sync.png)
 
-If the Bose cloud is still running, Sync also fetches your account data from Bose's servers. This is your preservation step — do it before the cloud shuts down.
+Sync pulls the speaker's local state into AfterTouch's datastore, creating an off-device backup of its configuration. If you ran this before May 6, 2026, your account data from Bose's servers was also captured at that time.
 
 ---
 
@@ -297,4 +297,4 @@ If you need to undo a migration:
 
 Once all speakers are migrated, the `data/` directory is the source of truth for your presets, recents, and device state. Back it up periodically. The web UI at `http://<server>:8000` is your management interface from this point on.
 
-For the Bose cloud backup you created in Step 4, keep the `.tar.gz` archive in case you need to restore credentials or presets later.
+If you ran `soundtouch-backup` before the cloud shutdown, keep that archive in case you need to restore credentials or presets later.

--- a/docs/guides/SURVIVAL-GUIDE.md
+++ b/docs/guides/SURVIVAL-GUIDE.md
@@ -1,18 +1,26 @@
-# Bose Cloud Shutdown: Survival Guide
+# Keeping Your Speakers Alive After the Bose Cloud Shutdown
 
-Bose is shutting down SoundTouch cloud services on **May 6, 2026**. After that date, the following stop working:
+Bose shut down SoundTouch cloud services on **May 6, 2026**. Per the [official end-of-life page](https://www.bose.com/soundtouch-end-of-life), the following no longer work:
 
-- Music service browsing (TuneIn, Spotify connect via app, etc.)
-- Preset and recently-played sync
-- The official SoundTouch app
+- **Presets** — preset buttons on the product and in the app
+- **Music service browsing and playback** from the SoundTouch app (TuneIn, Spotify, etc.)
+- **Stereo pairing** for SoundTouch 10
+- **Alexa voice commands**
 - Software update checks
 
 What **continues to work** regardless:
+- The official SoundTouch app for local control (play/pause/volume/source selection)
 - Local playback controls via `soundtouch-cli`, `soundtouch-web`, or any app that uses the local Web API
 - Bluetooth, AUX, and AirPlay inputs
 - Multiroom zones (local, peer-to-peer)
 
-**AfterTouch** — the `soundtouch-service` — restores everything in the first list by running a replacement for the Bose cloud on your own network.
+**AfterTouch** — the `soundtouch-service` — restores the first three:
+
+- **Presets** — full preset management including long-press assignment and recently-played sync; music service presets (Spotify, TuneIn, etc.) work once the service is linked (see [Connecting Music Services](MUSIC-SERVICES.md))
+- **Music browsing and playback** — TuneIn, Internet Radio, and RadioBrowser via `soundtouch-web`; direct station/URL playback via `soundtouch-cli`; Spotify via Spotify Connect (speaker-native) or AfterTouch's OAuth integration; Amazon Music OAuth infrastructure is in place but streaming is not yet verified
+- **Stereo pairing** — via `soundtouch-cli`
+
+Alexa voice commands are not currently supported.
 
 ---
 
@@ -42,35 +50,22 @@ You can leave SSH enabled for future maintenance, or disable it once migration i
 
 ---
 
-## Scenario A: Migrate before the shutdown
+## Scenario A: You migrated before May 6 (or have a backup)
 
-Do this while the Bose cloud is still running. Your existing presets and listening history are preserved.
+If you ran `soundtouch-backup` and pointed your speakers at AfterTouch before the shutdown, your presets and listening history are already preserved in AfterTouch's datastore. You're done — just keep AfterTouch running.
 
-**Step 1 — Back up your data.**
-Run `soundtouch-backup all` to save your Bose account data (presets, paired devices, music sources) and each speaker's local state. See the [soundtouch-backup README](../../cmd/soundtouch-backup/README.md) for usage.
+If you have a backup but haven't migrated yet, start AfterTouch and restore the backup before following the steps below.
 
-**Step 2 — Start the service and open the web UI** at `http://<server>:8000`.
+**Step 1 — Start the service and open the web UI** at `http://<server>:8000`.
 
-**Step 3 — Configure the server URL.**
+**Step 2 — Configure the server URL.**
 In the Settings tab, set the server URL to the address your speakers can reach (e.g. `http://soundtouch.fritz.box:8000`). If you plan to use DNS/DHCP redirect, also configure the HTTPS server URL.
 
-**Step 4 — Add your speaker.**
+**Step 3 — Add your speaker.**
 The service discovers devices on your network automatically. If a speaker doesn't appear, add it manually by IP address.
 
-**Step 5 — Sync device data.**
-Click "Sync" on the device to pull its current presets, recents, and sources from the Bose cloud into the local service's datastore.
-
-**Step 6 — Migrate.**
-The web UI offers two redirect methods and walks you through each step:
-
-| Method       | How it works                                           | When to use                                              |
-|--------------|--------------------------------------------------------|----------------------------------------------------------|
-| XML redirect | Uploads a config file to the speaker via the Web API   | Testing; simpler setup; covers only registered endpoints |
-| DNS/DHCP     | Custom DNS resolves Bose hostnames to the local server | All devices at once; full coverage                       |
-
-Both methods require TLS when the speaker uses HTTPS to contact the service. The web UI guides you through installing the service's CA certificate on the speaker (requires SSH).
-
-**Step 7 — Reboot the speaker.**
+**Step 4 — Migrate.**
+**Step 5 — Reboot the speaker.**
 Power-cycle the speaker to apply the changes. After reboot it contacts the local service instead of Bose's cloud.
 
 ---


### PR DESCRIPTION
Bose shut down SoundTouch cloud services on 2026-05-06. Update the three main user-facing docs to reflect that the shutdown has happened:

- README.md: rename section, rewrite opening paragraph, reframe the two getting-started scenarios as 'already migrated' vs 'starting fresh'.
- SURVIVAL-GUIDE.md: past-tense title and opening; remove duplicate Scenario B heading (copy-paste leftover from earlier edit); remove the table of redirect methods and TLS note that belonged to the deleted pre-shutdown Scenario B stub.
- MIGRATION-GUIDE.md: remove the 'cloud is still running' note from the Sync step; fix the post-migration backup blurb to reference soundtouch-backup rather than a non-existent Step 4 tar.gz.
