### PR TITLE
ci: fix Hugo setup action — use peaceiris/actions-hugo@v3.2.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2a84ef14cf28a37009d2a8f1d0d6e67eb56e8 # v3.0.0
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3.2.1
         with:
           hugo-version: 'latest'
           extended: true


### PR DESCRIPTION
The previous SHA 75d2a84... did not correspond to any real commit in peaceiris/actions-hugo (there is no v3.0.0 release). Update to the correct v3.2.1 SHA.
