### PR TITLE
fix(docs): use relative links in homepage shortcodes

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -22,8 +22,8 @@ layout: hextra-home
 </div>
 
 <div class="hx-mb-6">
-{{< hextra/hero-button text="Get Started" link="/docs/guides/GETTING-STARTED" >}}
-{{< hextra/hero-button text="Survival Guide" link="/docs/guides/SURVIVAL-GUIDE" style="outline" >}}
+{{< hextra/hero-button text="Get Started" link="docs/guides/GETTING-STARTED" >}}
+{{< hextra/hero-button text="Survival Guide" link="docs/guides/SURVIVAL-GUIDE" style="outline" >}}
 </div>
 
 <div class="hx-mt-6">
@@ -47,13 +47,13 @@ layout: hextra-home
     title="Three Deployment Options"
     subtitle="Run on a Raspberry Pi, a VPS, or directly on the speaker itself."
     icon="server"
-    link="/docs/guides/DEPLOYMENT-OVERVIEW"
+    link="docs/guides/DEPLOYMENT-OVERVIEW"
   >}}
   {{< hextra/feature-card
     title="CLI Control"
     subtitle="soundtouch-cli for scripting, home automation, and direct device control."
     icon="terminal"
-    link="/docs/guides/CLI-REFERENCE"
+    link="docs/guides/CLI-REFERENCE"
   >}}
   {{< hextra/feature-card
     title="Open Source"


### PR DESCRIPTION
The hextra/hero-button and hextra/feature-card shortcodes call Hugo's relURL on any link starting with '/'. relURL prepends the baseURL sub-path — but the deployed site was producing /docs/... instead of /Bose-SoundTouch/docs/..., meaning relURL was seeing a baseURL with no sub-path (likely just the domain).

Rather than depend on relURL working correctly at build time, remove the leading slash from all four internal links. Bare paths are emitted verbatim by the shortcode and are resolved by the browser relative to the page's own URL (/Bose-SoundTouch/ on GitHub Pages, / on local dev) — correct in both environments.
