### PR TITLE
fix(ci): remove nancy from Vulnerability Scan job

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,31 +29,14 @@ jobs:
       - name: Install libpcap
         run: sudo apt-get install -y libpcap-dev
 
-      - name: Install security scanning tools
-        run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          go install github.com/sonatypecommunity/nancy@latest
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
       - name: Run govulncheck (Official Go vulnerability scanner)
         run: |
           echo "::group::Running govulncheck"
           govulncheck ./...
           echo "::endgroup::"
-
-      - name: Run Nancy vulnerability scanner
-        run: |
-          echo "::group::Running Nancy dependency scanner"
-          go list -json -deps ./... | nancy sleuth
-          echo "::endgroup::"
-
-      - name: Upload vulnerability scan results
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: vulnerability-scan-results
-          path: |
-            vulnerability-report.json
-            nancy-report.json
 
   static-analysis:
     name: Static Security Analysis


### PR DESCRIPTION
nancy was installed from github.com/sonatypecommunity/nancy which is a non-existent package (correct org is
sonatype-nexus-community). nancy v2.0.0 also has replace- directive issues that break go install.

govulncheck already covers Go CVE scanning via the official Go vulnerability database, making nancy redundant here. The nancy-report.json artifact referenced in the upload step was never actually produced by the pipeline anyway.
