### PR TITLE
fix(lint): add staticcheck-native suppressions for known-good warnings

### DIFF
--- a/pkg/service/handlers/handlers_bmx.go
+++ b/pkg/service/handlers/handlers_bmx.go
@@ -105,7 +105,7 @@ func (s *Server) applyBMXTemplate(content string) string {
 // disabled (log-only); kept as the future-restore point — when we re-add
 // the gate, callers will use this helper.
 //
-//nolint:unused // intentional: future-restore point for the disabled auth gate.
+//lint:ignore U1000 intentional: future-restore point for the disabled BMX auth gate
 func (s *Server) writeBMXUnauthorized(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.WriteHeader(http.StatusUnauthorized)

--- a/pkg/service/handlers/handlers_etag_test.go
+++ b/pkg/service/handlers/handlers_etag_test.go
@@ -225,6 +225,7 @@ func TestMargeETags(t *testing.T) {
 		_ = pyProxy.ModifyResponse(resp)
 
 		//nolint:canonicalheader
+		//lint:ignore SA1008 ETag header key is intentionally non-canonical; Bose speakers reject the canonicalized form
 		if _, ok := resp.Header[caseSensitiveETag]; !ok {
 			t.Errorf("ModifyResponse did not normalize ETag casing. Headers: %v", resp.Header)
 		}
@@ -267,6 +268,7 @@ func TestMargeETags(t *testing.T) {
 		}
 
 		//nolint:canonicalheader
+		//lint:ignore SA1008 ETag header key is intentionally non-canonical; Bose speakers reject the canonicalized form
 		if _, ok := h[caseSensitiveETag]; ok {
 			// In Go's map, "ETag" and "Etag" are different keys.
 			// Set() uses CanonicalHeaderKey which produces "Etag" (lowercase 't').

--- a/pkg/service/handlers/mac_mapping_integration_test.go
+++ b/pkg/service/handlers/mac_mapping_integration_test.go
@@ -223,6 +223,7 @@ func TestMacMappingIntegration_HTTPHandler(t *testing.T) {
 		// Extract ETag from response headers (direct access needed for httptest.ResponseRecorder)
 		etag := ""
 		//nolint:staticcheck // SA1008: ETag header name must be case-sensitive for test
+		//lint:ignore SA1008 ETag header key is intentionally non-canonical; Bose speakers reject the canonicalized form
 		if vals, ok := rr1.Header()["ETag"]; ok && len(vals) > 0 {
 			etag = vals[0]
 		}


### PR DESCRIPTION
The static-analysis CI job runs 'staticcheck ./...' directly. Standalone staticcheck uses //lint:ignore directives, not the //nolint comments that golangci-lint reads.

SA1008 (non-canonical header key) on three ETag lines:
  handlers_etag_test.go:228, :270
  mac_mapping_integration_test.go:226
ETag must stay non-canonical — Bose speakers reject 'Etag'. Existing //nolint:canonicalheader / //nolint:staticcheck comments remain for golangci-lint; //lint:ignore SA1008 is added for the standalone staticcheck invocation.

U1000 (unused function) on writeBMXUnauthorized in handlers_bmx.go: The auth gate is temporarily disabled; the helper is kept as a restore point. //lint:ignore U1000 replaces //nolint:unused because golangci-lint's staticcheck runner also honours //lint:ignore, making //nolint:unused redundant (nolintlint would complain).
