### PR TITLE
sec4: fix unhandled writable file close; ignore CODE-SCANNING-NOTES.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,10 @@ stockholm_zip/*.zip
 NEXT.md
 DONE.md
 
+# Code-scanning working notes — snapshot + remediation plan; not committed
+# until the sweep is complete and the notes are stable.
+CODE-SCANNING-NOTES.md
+
 # Plan/tracking note for the Health-tab debug-utility programme.
 # Living document; commit history of the checks themselves is the
 # source of truth for what shipped.

--- a/pkg/service/certmanager/certmanager.go
+++ b/pkg/service/certmanager/certmanager.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"fmt"
 	"math/big"
 	"net"
 	"os"
@@ -180,22 +181,32 @@ func (cm *CertificateManager) GenerateCA() error {
 		return err
 	}
 
-	if encodeErr := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes}); encodeErr != nil {
-		return encodeErr
+	certEncodeErr := pem.Encode(certOut, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	certCloseErr := certOut.Close()
+
+	if certEncodeErr != nil {
+		return certEncodeErr
 	}
 
-	certOut.Close()
+	if certCloseErr != nil {
+		return fmt.Errorf("close certificate file: %w", certCloseErr)
+	}
 
 	keyOut, err := os.OpenFile(cm.GetCAKeyPath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
 
-	if err := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)}); err != nil {
-		return err
+	keyEncodeErr := pem.Encode(keyOut, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(priv)})
+	keyCloseErr := keyOut.Close()
+
+	if keyEncodeErr != nil {
+		return keyEncodeErr
 	}
 
-	keyOut.Close()
+	if keyCloseErr != nil {
+		return fmt.Errorf("close key file: %w", keyCloseErr)
+	}
 
 	return nil
 }

--- a/scripts/extract-ws/main.go
+++ b/scripts/extract-ws/main.go
@@ -97,7 +97,7 @@ func extractSSDP(packet gopacket.Packet, udp *layers.UDP, ssdpFilename string) {
 	if err != nil {
 		return
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	srcIP := packet.NetworkLayer().NetworkFlow().Src().String()
 	dstIP := packet.NetworkLayer().NetworkFlow().Dst().String()


### PR DESCRIPTION
Closes CodeQL alerts [#280](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/280) and [#281](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/281) (go/unhandled-writable-file-close).

scripts/extract-ws/main.go: change bare 'defer f.Close()' to 'defer func() { _ = f.Close() }()' — function returns void, silent discard is the correct pattern (matches existing '_, _ = w.Write()' usage elsewhere).

pkg/service/certmanager/certmanager.go: sequence encode + close for both the cert file and the key file, checking both errors. This also fixes resource leaks on the pem.Encode error path (file was previously left open when encode failed). Matches the established pattern in handlers_export.go (tw.Close / gz.Close).

.gitignore: exclude CODE-SCANNING-NOTES.md (local working notes; will be added to VCS once the scanning sweep is complete and the notes are stable).
