### PR TITLE
sec5a: sanitize log-injection in pkg/service/handlers

### DIFF
--- a/pkg/service/handlers/handlers_account_mgmt.go
+++ b/pkg/service/handlers/handlers_account_mgmt.go
@@ -41,7 +41,7 @@ func (s *Server) HandleMgmtAccountDetails(w http.ResponseWriter, r *http.Request
 	// 1. Get account info
 	accountInfo, err := s.ds.GetAccountInfo(accountID)
 	if err != nil {
-		log.Printf("[Mgmt] Failed to get account info for %s: %v", accountID, err)
+		log.Printf("[Mgmt] Failed to get account info for %s: %v", sanitizeLog(accountID), err)
 		accountInfo = &models.ServiceAccountInfo{AccountID: accountID}
 	}
 
@@ -227,7 +227,7 @@ func (s *Server) getDeviceDetail(accountID string, d *models.ServiceDeviceInfo) 
 		for j := range sources {
 			fs := mapToFullResponseSource(&sources[j])
 			if fs.Type == "" && fs.Name == "" && fs.DisplayName == "" {
-				log.Printf("[Mgmt] Skipping empty source for device %s", d.DeviceID)
+				log.Printf("[Mgmt] Skipping empty source for device %s", sanitizeLog(d.DeviceID))
 				continue
 			}
 

--- a/pkg/service/handlers/handlers_alexa.go
+++ b/pkg/service/handlers/handlers_alexa.go
@@ -34,7 +34,7 @@ func (s *Server) HandleAlexaCertificate(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	log.Printf("[alexa] certificate provisioning not implemented (device=%s); Alexa voice control requires AWS IoT integration", device)
+	log.Printf("[alexa] certificate provisioning not implemented (device=%s); Alexa voice control requires AWS IoT integration", sanitizeLog(device))
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusNotImplemented)

--- a/pkg/service/handlers/handlers_bmx_orion.go
+++ b/pkg/service/handlers/handlers_bmx_orion.go
@@ -58,7 +58,7 @@ func (s *Server) HandleOrionPlayback(w http.ResponseWriter, r *http.Request) {
 	// callers that would have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	data := r.URL.Query().Get("data")

--- a/pkg/service/handlers/handlers_bmx_siriusxm.go
+++ b/pkg/service/handlers/handlers_bmx_siriusxm.go
@@ -28,8 +28,8 @@ import (
 // go/clear-text-logging caught the original `auth=%q` shape.
 func (s *Server) HandleSiriusXMLiveAdapter(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[BMX SiriusXM] %s %s ua=%q authPresent=%t query=%q",
-		r.Method, r.URL.Path, r.UserAgent(),
-		r.Header.Get("Authorization") != "", r.URL.RawQuery)
+		r.Method, sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()),
+		r.Header.Get("Authorization") != "", sanitizeLog(r.URL.RawQuery))
 
 	svc, err := extractBMXService(bmxServicesJSON, "SIRIUSXM_EVEREST")
 	if err != nil {
@@ -51,8 +51,8 @@ func (s *Server) HandleSiriusXMLiveAdapter(w http.ResponseWriter, r *http.Reques
 // /navigate, /logout; playback URLs come dynamically from navigate.
 func (s *Server) HandleSiriusXMLiveAdapterSubpath(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[BMX SiriusXM] UNIMPLEMENTED %s %s ua=%q authPresent=%t query=%q",
-		r.Method, r.URL.Path, r.UserAgent(),
-		r.Header.Get("Authorization") != "", r.URL.RawQuery)
+		r.Method, sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()),
+		r.Header.Get("Authorization") != "", sanitizeLog(r.URL.RawQuery))
 
 	http.Error(w, "not implemented", http.StatusNotFound)
 }

--- a/pkg/service/handlers/handlers_bmx_tunein.go
+++ b/pkg/service/handlers/handlers_bmx_tunein.go
@@ -44,7 +44,7 @@ func (s *Server) HandleTuneInPlayback(w http.ResponseWriter, r *http.Request) {
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	stationID := chi.URLParam(r, "stationID")
@@ -71,7 +71,7 @@ func (s *Server) HandleTuneInPodcastInfo(w http.ResponseWriter, r *http.Request)
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	podcastID := chi.URLParam(r, "podcastID")
@@ -99,7 +99,7 @@ func (s *Server) HandleTuneInPlaybackPodcast(w http.ResponseWriter, r *http.Requ
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	podcastID := chi.URLParam(r, "podcastID")
@@ -153,7 +153,7 @@ func (s *Server) HandleTuneInReport(w http.ResponseWriter, r *http.Request) {
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	var req struct {
@@ -201,7 +201,7 @@ func (s *Server) HandleTuneInNavigate(w http.ResponseWriter, r *http.Request) {
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	wildcard := chi.URLParam(r, "*")
@@ -268,7 +268,7 @@ func (s *Server) HandleTuneInSearch(w http.ResponseWriter, r *http.Request) {
 	// have been rejected; do NOT 401.
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	query := r.URL.Query().Get("q")
@@ -295,7 +295,7 @@ func (s *Server) HandleTuneInSearch(w http.ResponseWriter, r *http.Request) {
 func (s *Server) HandleTuneInSearchNext(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Authorization") == "" {
 		log.Printf("[BMX] Authorization missing (gate temporarily disabled, see handlers_bmx.go); path=%q ua=%q",
-			r.URL.Path, r.UserAgent())
+			sanitizeLog(r.URL.Path), sanitizeLog(r.UserAgent()))
 	}
 
 	cursor := r.URL.Query().Get("cursor")
@@ -321,7 +321,7 @@ func (s *Server) HandleTuneInSearchNext(w http.ResponseWriter, r *http.Request) 
 func (s *Server) HandleTuneInFavorite(w http.ResponseWriter, r *http.Request) {
 	stationID := chi.URLParam(r, "stationID")
 	if err := s.ds.SaveTuneInFavorite(stationID); err != nil {
-		log.Printf("Failed to persist TuneIn favorite %s: %v", stationID, err)
+		log.Printf("Failed to persist TuneIn favorite %s: %v", sanitizeLog(stationID), err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -333,7 +333,7 @@ func (s *Server) HandleTuneInFavorite(w http.ResponseWriter, r *http.Request) {
 func (s *Server) HandleTuneInDeleteFavorite(w http.ResponseWriter, r *http.Request) {
 	stationID := chi.URLParam(r, "stationID")
 	if err := s.ds.DeleteTuneInFavorite(stationID); err != nil {
-		log.Printf("Failed to delete TuneIn favorite %s: %v", stationID, err)
+		log.Printf("Failed to delete TuneIn favorite %s: %v", sanitizeLog(stationID), err)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/service/handlers/handlers_catchall.go
+++ b/pkg/service/handlers/handlers_catchall.go
@@ -23,9 +23,9 @@ func (s *Server) HandleNotFound(w http.ResponseWriter, r *http.Request) {
 			truncated = "…"
 		}
 
-		log.Printf("[UNHANDLED] %s %s body(%d bytes): %s%s", r.Method, r.URL.Path, len(body), preview, truncated)
+		log.Printf("[UNHANDLED] %s %s body(%d bytes): %s%s", r.Method, sanitizeLog(r.URL.Path), len(body), sanitizeLog(string(preview)), truncated)
 	} else {
-		log.Printf("[UNHANDLED] %s %s", r.Method, r.URL.Path)
+		log.Printf("[UNHANDLED] %s %s", r.Method, sanitizeLog(r.URL.Path))
 	}
 
 	http.NotFound(w, r)

--- a/pkg/service/handlers/handlers_export.go
+++ b/pkg/service/handlers/handlers_export.go
@@ -130,7 +130,7 @@ func (s *Server) buildDiagnosticArchive() ([]byte, error) {
 
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			log.Printf("[Export] read dir %s: %v", dir, err)
+			log.Printf("[Export] read dir %s: %v", sanitizeLog(dir), err)
 
 			continue
 		}
@@ -142,14 +142,14 @@ func (s *Server) buildDiagnosticArchive() ([]byte, error) {
 
 			data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
 			if err != nil {
-				log.Printf("[Export] read %s: %v", entry.Name(), err)
+				log.Printf("[Export] read %s: %v", sanitizeLog(entry.Name()), err)
 
 				continue
 			}
 
 			archivePath := "datastore/accounts/" + dev.AccountID + "/devices/" + dev.DeviceID + "/" + entry.Name()
 			if err := addTarBytes(tw, archivePath, data); err != nil {
-				log.Printf("[Export] add %s: %v", archivePath, err)
+				log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), err)
 			}
 		}
 	}
@@ -205,13 +205,13 @@ func (s *Server) addServiceHTTP(tw *tar.Writer, client *http.Client, devices []m
 	tryAdd := func(archivePath, url string) {
 		data, err := diagFetch(client, url)
 		if err != nil {
-			log.Printf("[Export] fetch %s: %v", url, err)
+			log.Printf("[Export] fetch %s: %v", sanitizeLog(url), err)
 
 			return
 		}
 
 		if err := addTarBytes(tw, archivePath, data); err != nil {
-			log.Printf("[Export] add %s: %v", archivePath, err)
+			log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), err)
 		}
 	}
 
@@ -265,14 +265,14 @@ func (s *Server) addSpeakerHTTP(tw *tar.Writer, client *http.Client, devices []m
 		for _, ep := range endpoints {
 			data, err := diagFetch(client, speakerBase+"/"+ep)
 			if err != nil {
-				log.Printf("[Export] speaker %s /%s: %v", id, ep, err)
+				log.Printf("[Export] speaker %s /%s: %v", sanitizeLog(id), ep, err)
 
 				continue
 			}
 
 			archivePath := "http/speaker/" + id + "/" + ep + ".xml"
 			if err := addTarBytes(tw, archivePath, data); err != nil {
-				log.Printf("[Export] add %s: %v", archivePath, err)
+				log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), err)
 			}
 		}
 	}
@@ -372,14 +372,14 @@ func addSpeakerSSH(tw *tar.Writer, devices []models.ServiceDeviceInfo) {
 		for _, remotePath := range speakerSSHPaths {
 			data, err := sc.ReadFile(remotePath)
 			if err != nil {
-				log.Printf("[Export] SSH %s %s: %v", id, remotePath, err)
+				log.Printf("[Export] SSH %s %s: %v", sanitizeLog(id), remotePath, err)
 
 				continue
 			}
 
 			archivePath := "ssh/speaker/" + id + remotePath
 			if err := addTarBytes(tw, archivePath, data); err != nil {
-				log.Printf("[Export] add %s: %v", archivePath, err)
+				log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), err)
 			}
 		}
 
@@ -387,27 +387,27 @@ func addSpeakerSSH(tw *tar.Writer, devices []models.ServiceDeviceInfo) {
 		for filename, cmd := range map[string]string{"dmesg.txt": "dmesg"} {
 			out, err := sc.Run(cmd)
 			if err != nil && strings.TrimSpace(out) == "" {
-				log.Printf("[Export] SSH %s %q: %v", id, cmd, err)
+				log.Printf("[Export] SSH %s %q: %v", sanitizeLog(id), cmd, err)
 
 				continue
 			}
 
 			archivePath := "ssh/speaker/" + id + "/" + filename
 			if err := addTarBytes(tw, archivePath, []byte(out)); err != nil {
-				log.Printf("[Export] add %s: %v", archivePath, err)
+				log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), err)
 			}
 		}
 
 		// Syslog: fetch raw, strip 127.0.0.1 noise, then keep only the last speakerLogWindow.
 		rawLog, logErr := sc.Run("logread 2>/dev/null | grep -v '127.0.0.1'")
 		if logErr != nil && strings.TrimSpace(rawLog) == "" {
-			log.Printf("[Export] SSH %s logread: %v", id, logErr)
+			log.Printf("[Export] SSH %s logread: %v", sanitizeLog(id), logErr)
 		} else {
 			filtered := filterSpeakerLog(rawLog, speakerLogWindow)
 			archivePath := "ssh/speaker/" + id + "/logread.txt"
 
 			if addErr := addTarBytes(tw, archivePath, []byte(filtered)); addErr != nil {
-				log.Printf("[Export] add %s: %v", archivePath, addErr)
+				log.Printf("[Export] add %s: %v", sanitizeLog(archivePath), addErr)
 			}
 		}
 	}

--- a/pkg/service/handlers/handlers_marge.go
+++ b/pkg/service/handlers/handlers_marge.go
@@ -256,7 +256,7 @@ func (s *Server) HandleMargePowerOn(w http.ResponseWriter, r *http.Request) {
 	deviceID := req.Device.ID
 	deviceIP := req.DiagnosticData.DeviceLandscape.IPAddress
 
-	log.Printf("[Marge] Device %s powered on (IP: %s)", deviceID, deviceIP)
+	log.Printf("[Marge] Device %s powered on (IP: %s)", sanitizeLog(deviceID), sanitizeLog(deviceIP))
 
 	// Persist device details provided in the power_on request
 	if deviceID != "" && s.ds != nil {
@@ -285,7 +285,7 @@ func (s *Server) HandleMargePowerOn(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if err := s.ds.SaveDeviceInfo(accountID, deviceID, info); err != nil {
-			log.Printf("[Marge] Failed to save device info for %s: %v", deviceID, err)
+			log.Printf("[Marge] Failed to save device info for %s: %v", sanitizeLog(deviceID), err)
 		}
 	}
 
@@ -303,7 +303,7 @@ func (s *Server) HandleMargePowerOn(w http.ResponseWriter, r *http.Request) {
 
 	if deviceIP != "" && remoteHost != "" && deviceIP != remoteHost {
 		log.Printf("[Marge] power_on body IP %q differs from TCP source %q for device %s — using TCP source for credential push",
-			deviceIP, remoteHost, deviceID)
+			sanitizeLog(deviceIP), sanitizeLog(remoteHost), sanitizeLog(deviceID))
 	}
 
 	target := remoteHost
@@ -491,7 +491,7 @@ func (s *Server) HandleMargeUpdatePreset(w http.ResponseWriter, r *http.Request)
 
 	presetNumber, err := strconv.Atoi(presetNumberStr)
 	if err != nil {
-		log.Printf("[Marge] Invalid preset number: %s", presetNumberStr)
+		log.Printf("[Marge] Invalid preset number: %s", sanitizeLog(presetNumberStr))
 		http.Error(w, "Invalid preset number", http.StatusBadRequest)
 
 		return
@@ -507,7 +507,7 @@ func (s *Server) HandleMargeUpdatePreset(w http.ResponseWriter, r *http.Request)
 
 	data, err := marge.UpdatePreset(s.ds, account, device, presetNumber, body)
 	if err != nil {
-		log.Printf("[Marge] UpdatePreset failed for account=%s, device=%s, preset=%d: %v", account, device, presetNumber, err)
+		log.Printf("[Marge] UpdatePreset failed for account=%s, device=%s, preset=%d: %v", sanitizeLog(account), sanitizeLog(device), presetNumber, err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 
 		return

--- a/pkg/service/handlers/handlers_mgmt.go
+++ b/pkg/service/handlers/handlers_mgmt.go
@@ -242,7 +242,7 @@ func (s *Server) bridgeSpotifyToMarge(accountID string) {
 	// For now, we use the first account found or match by ID if possible.
 	// In this bridge, we'll ensure all linked Spotify accounts are registered in Marge.
 	for _, acc := range accounts {
-		log.Printf("[Spotify Bridge] Registering Spotify user %s in Marge for account %s", acc.UserID, accountID)
+		log.Printf("[Spotify Bridge] Registering Spotify user %s in Marge for account %s", sanitizeLog(acc.UserID), sanitizeLog(accountID))
 
 		// 1. Register in Marge (updates configuredsources.xml for all devices in the account)
 		// We use the BoseSecret as the credential instead of the AccessToken
@@ -276,13 +276,13 @@ func (s *Server) bridgeSpotifyToMarge(accountID string) {
 			}
 
 			go func(d models.ServiceDeviceInfo) {
-				log.Printf("[Spotify Bridge] Notifying speaker %s (%s) about new Spotify account", d.Name, d.IPAddress)
+				log.Printf("[Spotify Bridge] Notifying speaker %s (%s) about new Spotify account", sanitizeLog(d.Name), sanitizeLog(d.IPAddress))
 
 				c := client.NewClientFromHost(d.IPAddress)
 				creds := models.NewSpotifyOAuthCredentials(acc.UserID, credential, acc.DisplayName)
 
 				if err := c.SetMusicServiceOAuthAccount(creds); err != nil {
-					log.Printf("[Spotify Bridge] Failed to notify speaker %s via OAuth: %v", d.Name, err)
+					log.Printf("[Spotify Bridge] Failed to notify speaker %s via OAuth: %v", sanitizeLog(d.Name), err)
 
 					// Fallback if OAuth is not supported (Error 1029)
 					errs := &models.ErrorsResponse{}
@@ -297,31 +297,31 @@ func (s *Server) bridgeSpotifyToMarge(accountID string) {
 						}
 
 						if isUnsupported {
-							log.Printf("[Spotify Bridge] Speaker %s doesn't support OAuth, falling back to Marge sync notification", d.Name)
+							log.Printf("[Spotify Bridge] Speaker %s doesn't support OAuth, falling back to Marge sync notification", sanitizeLog(d.Name))
 
 							// Some speakers (especially Stockholm-based) don't support /setMusicServiceOAuthAccount
 							// via LISA but will pick up the new source from Marge if notified.
 							if err := c.NotifySourcesUpdated(d.DeviceID); err != nil {
-								log.Printf("[Spotify Bridge] Sync notification failed for speaker %s: %v", d.Name, err)
+								log.Printf("[Spotify Bridge] Sync notification failed for speaker %s: %v", sanitizeLog(d.Name), err)
 
 								// Final fallback to legacy account creation
-								log.Printf("[Spotify Bridge] Falling back to legacy account creation for speaker %s", d.Name)
+								log.Printf("[Spotify Bridge] Falling back to legacy account creation for speaker %s", sanitizeLog(d.Name))
 
 								legacyCreds := models.NewSpotifyCredentials(acc.UserID, credential)
 								if err := c.SetMusicServiceAccount(legacyCreds); err != nil {
-									log.Printf("[Spotify Bridge] Legacy fallback failed for speaker %s: %v", d.Name, err)
+									log.Printf("[Spotify Bridge] Legacy fallback failed for speaker %s: %v", sanitizeLog(d.Name), err)
 								} else {
-									log.Printf("[Spotify Bridge] Legacy fallback successful for speaker %s", d.Name)
+									log.Printf("[Spotify Bridge] Legacy fallback successful for speaker %s", sanitizeLog(d.Name))
 								}
 							} else {
-								log.Printf("[Spotify Bridge] Sync notification successful for speaker %s", d.Name)
+								log.Printf("[Spotify Bridge] Sync notification successful for speaker %s", sanitizeLog(d.Name))
 							}
 
 							return
 						}
 					}
 				} else {
-					log.Printf("[Spotify Bridge] Successfully notified speaker %s", d.Name)
+					log.Printf("[Spotify Bridge] Successfully notified speaker %s", sanitizeLog(d.Name))
 				}
 			}(*dev)
 		}
@@ -583,7 +583,7 @@ func (s *Server) bridgeAmazonToMarge(accountID string) {
 	}
 
 	for _, acc := range accounts {
-		log.Printf("[Amazon Bridge] Registering Amazon user %s in Marge for account %s", acc.Email, accountID)
+		log.Printf("[Amazon Bridge] Registering Amazon user %s in Marge for account %s", sanitizeLog(acc.Email), sanitizeLog(accountID))
 
 		// Build the AmazonSecret credential envelope expected by the speaker firmware.
 		credMap := map[string]interface{}{
@@ -622,7 +622,7 @@ func (s *Server) bridgeAmazonToMarge(accountID string) {
 			}
 
 			go func(d models.ServiceDeviceInfo) {
-				log.Printf("[Amazon Bridge] Notifying speaker %s (%s) about new Amazon account", d.Name, d.IPAddress)
+				log.Printf("[Amazon Bridge] Notifying speaker %s (%s) about new Amazon account", sanitizeLog(d.Name), sanitizeLog(d.IPAddress))
 
 				cfg := client.DefaultConfig()
 				cfg.Host = d.IPAddress
@@ -631,24 +631,24 @@ func (s *Server) bridgeAmazonToMarge(accountID string) {
 				creds := models.NewAmazonOAuthCredentials(acc.Email, string(credJSON), acc.DisplayName)
 
 				if err := c.SetMusicServiceOAuthAccount(creds); err != nil {
-					log.Printf("[Amazon Bridge] Failed to notify speaker %s via OAuth: %v", d.Name, err)
-					log.Printf("[Amazon Bridge] Speaker %s doesn't support OAuth or is unreachable, falling back to Marge sync notification", d.Name)
+					log.Printf("[Amazon Bridge] Failed to notify speaker %s via OAuth: %v", sanitizeLog(d.Name), err)
+					log.Printf("[Amazon Bridge] Speaker %s doesn't support OAuth or is unreachable, falling back to Marge sync notification", sanitizeLog(d.Name))
 
 					if err := c.NotifySourcesUpdated(d.DeviceID); err != nil {
-						log.Printf("[Amazon Bridge] Sync notification failed for speaker %s: %v", d.Name, err)
-						log.Printf("[Amazon Bridge] Falling back to legacy account creation for speaker %s", d.Name)
+						log.Printf("[Amazon Bridge] Sync notification failed for speaker %s: %v", sanitizeLog(d.Name), err)
+						log.Printf("[Amazon Bridge] Falling back to legacy account creation for speaker %s", sanitizeLog(d.Name))
 
 						legacyCreds := models.NewAmazonMusicCredentials(acc.Email, string(credJSON))
 						if err := c.SetMusicServiceAccount(legacyCreds); err != nil {
-							log.Printf("[Amazon Bridge] Legacy fallback failed for speaker %s: %v", d.Name, err)
+							log.Printf("[Amazon Bridge] Legacy fallback failed for speaker %s: %v", sanitizeLog(d.Name), err)
 						} else {
-							log.Printf("[Amazon Bridge] Legacy fallback successful for speaker %s", d.Name)
+							log.Printf("[Amazon Bridge] Legacy fallback successful for speaker %s", sanitizeLog(d.Name))
 						}
 					} else {
-						log.Printf("[Amazon Bridge] Sync notification successful for speaker %s", d.Name)
+						log.Printf("[Amazon Bridge] Sync notification successful for speaker %s", sanitizeLog(d.Name))
 					}
 				} else {
-					log.Printf("[Amazon Bridge] Successfully notified speaker %s", d.Name)
+					log.Printf("[Amazon Bridge] Successfully notified speaker %s", sanitizeLog(d.Name))
 				}
 			}(*dev)
 		}

--- a/pkg/service/handlers/handlers_oauth.go
+++ b/pkg/service/handlers/handlers_oauth.go
@@ -35,7 +35,7 @@ func (s *Server) HandleBoseToken(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	log.Printf("[OAuth] Unknown music provider: %s", sourceID)
+	log.Printf("[OAuth] Unknown music provider: %s", sanitizeLog(sourceID))
 	http.Error(w, "Unknown music provider", http.StatusNotFound)
 }
 
@@ -105,7 +105,7 @@ func (s *Server) HandleBoseAccountToken(w http.ResponseWriter, r *http.Request) 
 // The speaker sends the bare refresh token extracted from the stored AmazonSecret JSON.
 func (s *Server) HandleBoseAmazonToken(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "deviceID")
-	log.Printf("[Amazon] Token request for device %s", deviceID)
+	log.Printf("[Amazon] Token request for device %s", sanitizeLog(deviceID))
 
 	s.mu.RLock()
 	svc := s.amazonService
@@ -152,13 +152,13 @@ func (s *Server) HandleBoseAmazonToken(w http.ResponseWriter, r *http.Request) {
 	if secret != "" {
 		if acc, ok := svc.GetAccountByRefreshToken(secret); ok {
 			account = acc
-			log.Printf("[Amazon] Found account for refresh token: %s", acc.UserID)
+			log.Printf("[Amazon] Found account for refresh token: %s", sanitizeLog(acc.UserID))
 		}
 	}
 
 	if account != nil {
 		if err := svc.RefreshAccessToken(account); err != nil {
-			log.Printf("[Amazon] Failed to refresh token for %s: %v. Returning 502", account.UserID, err)
+			log.Printf("[Amazon] Failed to refresh token for %s: %v. Returning 502", sanitizeLog(account.UserID), err)
 			http.Error(w, "Token refresh failed", http.StatusBadGateway)
 
 			return
@@ -176,7 +176,7 @@ func (s *Server) HandleBoseAmazonToken(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		log.Printf("[Amazon] Using default account %s", userID)
+		log.Printf("[Amazon] Using default account %s", sanitizeLog(userID))
 	}
 
 	// Omit "scope" — Amazon Music scopes are undocumented; sending invented values
@@ -200,7 +200,7 @@ func (s *Server) HandleBoseAmazonToken(w http.ResponseWriter, r *http.Request) {
 // POST /oauth/device/{deviceID}/music/musicprovider/15/token/cs3
 func (s *Server) HandleBoseSpotifyToken(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "deviceID")
-	log.Printf("[Spotify Proxy] Intercepted token request for device %s", deviceID)
+	log.Printf("[Spotify Proxy] Intercepted token request for device %s", sanitizeLog(deviceID))
 
 	s.mu.RLock()
 	svc := s.spotifyService
@@ -251,13 +251,13 @@ func (s *Server) HandleBoseSpotifyToken(w http.ResponseWriter, r *http.Request) 
 	if secret != "" {
 		if acc, ok := svc.GetAccountBySecret(secret); ok {
 			account = acc
-			log.Printf("[Spotify Proxy] Found account for secret %s: %s", secret, acc.UserID)
+			log.Printf("[Spotify Proxy] Found account for secret %s: %s", sanitizeLog(secret), sanitizeLog(acc.UserID))
 		}
 	}
 
 	if account != nil {
 		if err := svc.RefreshAccessToken(account); err != nil {
-			log.Printf("[Spotify Proxy] Failed to refresh token for %s: %v. Returning 502", account.UserID, err)
+			log.Printf("[Spotify Proxy] Failed to refresh token for %s: %v. Returning 502", sanitizeLog(account.UserID), err)
 			http.Error(w, "Token refresh failed", http.StatusBadGateway)
 
 			return
@@ -276,7 +276,7 @@ func (s *Server) HandleBoseSpotifyToken(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 
-		log.Printf("[Spotify Proxy] Using default account %s", userID)
+		log.Printf("[Spotify Proxy] Using default account %s", sanitizeLog(userID))
 	}
 
 	// Format response as expected by Bose firmware.

--- a/pkg/service/handlers/logutil.go
+++ b/pkg/service/handlers/logutil.go
@@ -1,0 +1,12 @@
+package handlers
+
+import "strings"
+
+// sanitizeLog strips newline characters from s to prevent log-injection
+// (CodeQL go/log-injection). Values from speakers, HTTP requests, and
+// external APIs may contain attacker-controlled newlines.
+func sanitizeLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	return s
+}

--- a/pkg/service/handlers/origin_middleware.go
+++ b/pkg/service/handlers/origin_middleware.go
@@ -22,6 +22,6 @@ func (s *Server) OriginMiddleware(next http.Handler) http.Handler {
 			origin = "upstream"
 		}
 
-		log.Printf("[LOG] %s %s | %d | %s | %v", r.Method, r.URL.Path, ww.Status(), origin, time.Since(start))
+		log.Printf("[LOG] %s %s | %d | %s | %v", r.Method, sanitizeLog(r.URL.Path), ww.Status(), origin, time.Since(start))
 	})
 }

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -841,11 +841,11 @@ func (s *Server) PrimeDeviceWithSpotify(deviceIP string) {
 	// pick or map accounts to speakers, but for now, we follow the "One linked account" model.
 	accessToken, username, err := svc.GetFreshToken()
 	if err != nil {
-		log.Printf("[Spotify Watchdog] Failed to get fresh token for %s: %v", deviceIP, err)
+		log.Printf("[Spotify Watchdog] Failed to get fresh token for %s: %v", sanitizeLog(deviceIP), err)
 		return
 	}
 
-	log.Printf("[Spotify Watchdog] Proactively priming %s with Spotify user %s", deviceIP, username)
+	log.Printf("[Spotify Watchdog] Proactively priming %s with Spotify user %s", sanitizeLog(deviceIP), sanitizeLog(username))
 
 	// Register the SPOTIFY source in our marge datastore before pushing credentials.
 	// Without this, storePreset later fails with "AddPreset - failed due to invalid SourceID"
@@ -858,12 +858,12 @@ func (s *Server) PrimeDeviceWithSpotify(deviceIP string) {
 		// recorded the specifics; here we just upgrade the watchdog's view to
 		// "primed" since marge holds the authoritative SPOTIFY source.
 		if errors.Is(err, spotify.ErrAddUserNoOp) {
-			log.Printf("[Spotify Watchdog] Successfully primed %s (ZeroConf addUser was an expected no-op)", deviceIP)
+			log.Printf("[Spotify Watchdog] Successfully primed %s (ZeroConf addUser was an expected no-op)", sanitizeLog(deviceIP))
 		} else {
-			log.Printf("[Spotify Watchdog] Failed to prime %s: %v", deviceIP, err)
+			log.Printf("[Spotify Watchdog] Failed to prime %s: %v", sanitizeLog(deviceIP), err)
 		}
 	} else {
-		log.Printf("[Spotify Watchdog] Successfully primed %s", deviceIP)
+		log.Printf("[Spotify Watchdog] Successfully primed %s", sanitizeLog(deviceIP))
 	}
 }
 
@@ -880,7 +880,7 @@ func (s *Server) registerSpotifySourceForDevice(deviceIP string, accounts []spot
 
 	accountID, deviceID := s.resolvePairedAccount(deviceIP, host)
 	if accountID == "" {
-		log.Printf("[Spotify Watchdog] No paired account for %s yet — skipping marge source registration", deviceIP)
+		log.Printf("[Spotify Watchdog] No paired account for %s yet — skipping marge source registration", sanitizeLog(deviceIP))
 		return
 	}
 
@@ -893,11 +893,11 @@ func (s *Server) registerSpotifySourceForDevice(deviceIP string, accounts []spot
 		}
 
 		if _, err := marge.AddSource(s.ds, accountID, acc.UserID, strconv.Itoa(constants.SpotifyProviderID), credential, "token_version_3", acc.DisplayName); err != nil {
-			log.Printf("[Spotify Watchdog] Failed to register Spotify source for account %s: %v", accountID, err)
+			log.Printf("[Spotify Watchdog] Failed to register Spotify source for account %s: %v", sanitizeLog(accountID), err)
 			continue
 		}
 
-		log.Printf("[Spotify Watchdog] Registered Spotify source %s for account %s (device %s)", acc.UserID, accountID, deviceID)
+		log.Printf("[Spotify Watchdog] Registered Spotify source %s for account %s (device %s)", sanitizeLog(acc.UserID), sanitizeLog(accountID), sanitizeLog(deviceID))
 
 		registered = true
 	}
@@ -910,9 +910,9 @@ func (s *Server) registerSpotifySourceForDevice(deviceIP string, accounts []spot
 	if registered && deviceID != "" {
 		c := client.NewClientFromHost(deviceIP)
 		if err := c.NotifySourcesUpdated(deviceID); err != nil {
-			log.Printf("[Spotify Watchdog] sourcesUpdated notification for %s failed: %v", deviceIP, err)
+			log.Printf("[Spotify Watchdog] sourcesUpdated notification for %s failed: %v", sanitizeLog(deviceIP), err)
 		} else {
-			log.Printf("[Spotify Watchdog] Notified %s to re-sync sources (deviceID=%s)", deviceIP, deviceID)
+			log.Printf("[Spotify Watchdog] Notified %s to re-sync sources (deviceID=%s)", sanitizeLog(deviceIP), sanitizeLog(deviceID))
 		}
 	}
 }
@@ -941,7 +941,7 @@ func (s *Server) resolvePairedAccount(deviceIP, host string) (accountID, deviceI
 				deviceID = info.DeviceID
 			}
 		} else {
-			log.Printf("[Spotify Watchdog] live /info lookup for %s failed: %v (falling back to datastore account=%q)", deviceIP, err, accountID)
+			log.Printf("[Spotify Watchdog] live /info lookup for %s failed: %v (falling back to datastore account=%q)", sanitizeLog(deviceIP), err, sanitizeLog(accountID))
 		}
 	}
 
@@ -992,20 +992,20 @@ func (s *Server) PrimeDeviceWithAmazon(deviceIP string) {
 
 	accessToken, username, err := svc.GetFreshToken()
 	if err != nil {
-		log.Printf("[Amazon Watchdog] Failed to get fresh token for %s: %v", deviceIP, err)
+		log.Printf("[Amazon Watchdog] Failed to get fresh token for %s: %v", sanitizeLog(deviceIP), err)
 		return
 	}
 
-	log.Printf("[Amazon Watchdog] Proactively priming %s with Amazon user %s", deviceIP, username)
+	log.Printf("[Amazon Watchdog] Proactively priming %s with Amazon user %s", sanitizeLog(deviceIP), sanitizeLog(username))
 
 	if err := s.pushAmazonTokenToDevice(deviceIP, username, accessToken); err != nil {
 		if errors.Is(err, amazon.ErrAddUserNoOp) {
-			log.Printf("[Amazon Watchdog] Successfully primed %s (ZeroConf addUser was an expected no-op)", deviceIP)
+			log.Printf("[Amazon Watchdog] Successfully primed %s (ZeroConf addUser was an expected no-op)", sanitizeLog(deviceIP))
 		} else {
-			log.Printf("[Amazon Watchdog] Failed to prime %s: %v", deviceIP, err)
+			log.Printf("[Amazon Watchdog] Failed to prime %s: %v", sanitizeLog(deviceIP), err)
 		}
 	} else {
-		log.Printf("[Amazon Watchdog] Successfully primed %s", deviceIP)
+		log.Printf("[Amazon Watchdog] Successfully primed %s", sanitizeLog(deviceIP))
 	}
 }
 
@@ -1021,12 +1021,12 @@ func (s *Server) pushAmazonTokenToDevice(deviceIP, username, accessToken string)
 }
 
 func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
-	log.Printf("Discovered Bose device: %s at %s (Serial: %s)", d.Name, d.Host, d.SerialNo)
+	log.Printf("Discovered Bose device: %s at %s (Serial: %s)", sanitizeLog(d.Name), sanitizeLog(d.Host), sanitizeLog(d.SerialNo))
 
 	// 1. Always fetch live device info from /info endpoint as the authoritative source
 	liveInfo, err := s.sm.GetLiveDeviceInfo(d.Host)
 	if err != nil {
-		log.Printf("Failed to fetch live device info for %s at %s: %v", d.Name, d.Host, err)
+		log.Printf("Failed to fetch live device info for %s at %s: %v", sanitizeLog(d.Name), sanitizeLog(d.Host), err)
 		// Fallback to discovery info if /info is not available
 		s.handleDiscoveredDeviceFallback(d)
 
@@ -1036,13 +1036,13 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	// 2. Use deviceID from /info as the canonical device identifier
 	deviceID := liveInfo.DeviceID
 	if deviceID == "" {
-		log.Printf("No deviceID found in /info response for %s at %s, using fallback", d.Name, d.Host)
+		log.Printf("No deviceID found in /info response for %s at %s, using fallback", sanitizeLog(d.Name), sanitizeLog(d.Host))
 		s.handleDiscoveredDeviceFallback(d)
 
 		return
 	}
 
-	log.Printf("Using deviceID '%s' from /info for device %s at %s", deviceID, d.Name, d.Host)
+	log.Printf("Using deviceID '%s' from /info for device %s at %s", sanitizeLog(deviceID), sanitizeLog(d.Name), sanitizeLog(d.Host))
 
 	// 3. Get account ID from live info or fallback to existing/default
 	storedAccount := ""
@@ -1064,7 +1064,7 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	if liveInfo.MargeAccountUUID != "" && storedAccount != "" && liveInfo.MargeAccountUUID != storedAccount {
 		if err := s.ds.MoveDevice(storedAccount, accountID, deviceID); err != nil {
 			log.Printf("Failed to migrate device %s from %s to %s: %v",
-				deviceID, storedAccount, accountID, err)
+				sanitizeLog(deviceID), sanitizeLog(storedAccount), sanitizeLog(accountID), err)
 		}
 	}
 
@@ -1095,7 +1095,7 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 
 	// 7. Save the updated device info
 	if err := s.ds.SaveDeviceInfo(accountID, deviceID, info); err != nil {
-		log.Printf("Failed to save device info for %s: %v", deviceID, err)
+		log.Printf("Failed to save device info for %s: %v", sanitizeLog(deviceID), err)
 		return
 	}
 
@@ -1108,27 +1108,27 @@ func (s *Server) handleDiscoveredDevice(d models.DiscoveredDevice) {
 	if storedAccount != "" && storedAccount != accountID {
 		if err := s.ds.RemoveDevice(storedAccount, deviceID); err != nil {
 			log.Printf("Failed to remove stale device entry for %s in %s: %v",
-				deviceID, storedAccount, err)
+				sanitizeLog(deviceID), sanitizeLog(storedAccount), err)
 		}
 	}
 
 	// 8. Create default Sources.xml only when no sources file exists yet
 	if !s.ds.HasConfiguredSources(accountID, deviceID) {
 		if sources, err := s.ds.GetConfiguredSources(accountID, deviceID); err == nil {
-			log.Printf("Creating default Sources.xml for device %s", deviceID)
+			log.Printf("Creating default Sources.xml for device %s", sanitizeLog(deviceID))
 
 			if err := s.ds.SaveConfiguredSources(accountID, deviceID, sources); err != nil {
-				log.Printf("Failed to save default sources for %s: %v", deviceID, err)
+				log.Printf("Failed to save default sources for %s: %v", sanitizeLog(deviceID), err)
 			}
 		}
 	}
 
-	log.Printf("Successfully saved device %s (%s) with MAC-based deviceID: %s", info.Name, d.Host, deviceID)
+	log.Printf("Successfully saved device %s (%s) with MAC-based deviceID: %s", sanitizeLog(info.Name), sanitizeLog(d.Host), sanitizeLog(deviceID))
 }
 
 // handleDiscoveredDeviceFallback handles device discovery when /info endpoint is not available
 func (s *Server) handleDiscoveredDeviceFallback(d models.DiscoveredDevice) {
-	log.Printf("Using fallback discovery method for device: %s at %s", d.Name, d.Host)
+	log.Printf("Using fallback discovery method for device: %s at %s", sanitizeLog(d.Name), sanitizeLog(d.Host))
 
 	// Use discovery data as-is with the old logic
 	existingID := s.findExistingDeviceID(d)
@@ -1156,27 +1156,27 @@ func (s *Server) handleDiscoveredDeviceFallback(d models.DiscoveredDevice) {
 
 	// If we had an IP-based entry and now have a Serial, clean up the IP-based entry
 	if d.SerialNo != "" && existingID != "" && existingID != d.SerialNo {
-		log.Printf("Device %s previously known as %s, migrating to serial-based ID %s", d.Name, existingID, d.SerialNo)
+		log.Printf("Device %s previously known as %s, migrating to serial-based ID %s", sanitizeLog(d.Name), sanitizeLog(existingID), sanitizeLog(d.SerialNo))
 		_ = s.ds.RemoveDevice(accountID, existingID)
 	}
 
 	if err := s.ds.SaveDeviceInfo(accountID, deviceID, info); err != nil {
-		log.Printf("Failed to save device info for %s: %v", deviceID, err)
+		log.Printf("Failed to save device info for %s: %v", sanitizeLog(deviceID), err)
 		return
 	}
 
 	// Create default Sources.xml only when no sources file exists yet
 	if !s.ds.HasConfiguredSources(accountID, deviceID) {
 		if sources, err := s.ds.GetConfiguredSources(accountID, deviceID); err == nil {
-			log.Printf("Creating default Sources.xml for device %s (fallback)", deviceID)
+			log.Printf("Creating default Sources.xml for device %s (fallback)", sanitizeLog(deviceID))
 
 			if err := s.ds.SaveConfiguredSources(accountID, deviceID, sources); err != nil {
-				log.Printf("Failed to save default sources for %s: %v", deviceID, err)
+				log.Printf("Failed to save default sources for %s: %v", sanitizeLog(deviceID), err)
 			}
 		}
 	}
 
-	log.Printf("Successfully saved device %s (%s) with fallback deviceID: %s", info.Name, d.Host, deviceID)
+	log.Printf("Successfully saved device %s (%s) with fallback deviceID: %s", sanitizeLog(info.Name), sanitizeLog(d.Host), sanitizeLog(deviceID))
 }
 
 func (s *Server) mergeOverlappingDevices() {
@@ -1240,7 +1240,7 @@ func (s *Server) mergeOverlappingDevices() {
 			}
 
 			if devID != masterID && dev.IPAddress == ip {
-				log.Printf("Merging overlapping device entry %s into %s (IP: %s)", devID, masterID, ip)
+				log.Printf("Merging overlapping device entry %s into %s (IP: %s)", sanitizeLog(devID), sanitizeLog(masterID), sanitizeLog(ip))
 				_ = s.ds.RemoveDevice(dev.AccountID, devID)
 			}
 		}


### PR DESCRIPTION
Fixes CodeQL go/log-injection alerts in the handlers package.

Adds pkg/service/handlers/logutil.go with a package-private sanitizeLog helper that strips \n and \r from strings before they reach log call sites. Values from speakers, HTTP requests, and external APIs (device IDs, account IDs, IP addresses, speaker names, OAuth user IDs/emails, station IDs, URL paths, user-agent strings) may contain attacker-controlled newlines.

Wraps all external-data string arguments across 12 files: handlers_account_mgmt.go, handlers_alexa.go, handlers_bmx_orion.go, handlers_bmx_siriusxm.go, handlers_bmx_tunein.go, handlers_catchall.go, handlers_export.go, handlers_marge.go, handlers_mgmt.go, handlers_oauth.go, origin_middleware.go, server.go.

No behaviour change — purely a logging concern. make check passes.
