### PR TITLE
sec5b: sanitize log-injection in pkg/service/datastore and pkg/service/marge

### DIFF
--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -934,10 +934,10 @@ func (ds *DataStore) GetPresets(account, device string) ([]models.ServicePreset,
 	}
 
 	if needsRewrite {
-		log.Printf("[Datastore] Presets.xml for device %s used legacy <ContentItem> format; rewriting in canonical form", device)
+		log.Printf("[Datastore] Presets.xml for device %s used legacy <ContentItem> format; rewriting in canonical form", sanitizeLog(device))
 
 		if werr := ds.SavePresets(account, device, presets); werr != nil {
-			log.Printf("[Datastore] failed to rewrite normalised Presets.xml for device %s: %v", device, werr)
+			log.Printf("[Datastore] failed to rewrite normalised Presets.xml for device %s: %v", sanitizeLog(device), werr)
 		}
 	}
 
@@ -1049,7 +1049,7 @@ func repairLeakedSource(account, device, label, persistedSource, sourceID string
 	for i := range sources {
 		if sources[i].ID == sourceID && sources[i].SourceKeyType != "" {
 			log.Printf("[Datastore] %s: repaired leaked source %q -> %q via sourceid=%s (account=%s device=%s) — likely written by the pre-fix marge.syncPresets/syncRecents path; speaker's perspective is now restored on read",
-				label, persistedSource, sources[i].SourceKeyType, sourceID, account, device)
+				sanitizeLog(label), sanitizeLog(persistedSource), sanitizeLog(sources[i].SourceKeyType), sanitizeLog(sourceID), sanitizeLog(account), sanitizeLog(device))
 
 			return sources[i].SourceKeyType
 		}
@@ -1179,7 +1179,7 @@ func (ds *DataStore) SavePresets(account, device string, presets []models.Servic
 
 		if pxml.ContentItem.IsPresetable == "false" {
 			log.Printf("[Datastore] SavePresets: storing preset %s as isPresetable=false (account=%s device=%s source=%s) — speaker firmware marked this content non-recallable; preset will appear on the speaker but pressing it will not play",
-				pxml.ID, account, device, p.Source)
+				sanitizeLog(pxml.ID), sanitizeLog(account), sanitizeLog(device), sanitizeLog(p.Source))
 		}
 
 		pxml.ContentItem.ItemName = p.Name

--- a/pkg/service/datastore/logutil.go
+++ b/pkg/service/datastore/logutil.go
@@ -1,4 +1,4 @@
-package handlers
+package datastore
 
 import "strings"
 

--- a/pkg/service/marge/logutil.go
+++ b/pkg/service/marge/logutil.go
@@ -1,4 +1,4 @@
-package handlers
+package marge
 
 import "strings"
 

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -898,7 +898,7 @@ func mapPresetsToFullResponse(presets []models.ServicePreset, sources []models.C
 
 				if sources[j].ID == p.SourceID && !sourceTypeCompatible(p.Source, sources[j].SourceKeyType) {
 					log.Printf("[Marge] /full: refusing cross-type bind for preset %s — preset.Source=%q but configured source id=%s has type %q; falling through to type-based match",
-						p.ButtonNumber, p.Source, sources[j].ID, sources[j].SourceKeyType)
+						sanitizeLog(p.ButtonNumber), sanitizeLog(p.Source), sanitizeLog(sources[j].ID), sanitizeLog(sources[j].SourceKeyType))
 				}
 			}
 		}
@@ -958,7 +958,7 @@ func mapPresetsToFullResponse(presets []models.ServicePreset, sources []models.C
 		// repopulated, which is recoverable; a wiped /presets is not.
 		if synth, ok := synthesiseDefaultSourceForPreset(p); ok {
 			log.Printf("[Marge] /full: synthesising canonical %s source (id=%s, providerid=%s) for preset %s — original source %q not in configured sources; preset will appear on the speaker but play-time may fail until the source is repopulated",
-				p.Source, synth.ID, synth.SourceProviderID, p.ButtonNumber, p.SourceID)
+				sanitizeLog(p.Source), sanitizeLog(synth.ID), sanitizeLog(synth.SourceProviderID), sanitizeLog(p.ButtonNumber), sanitizeLog(p.SourceID))
 			fullPreset.Source = synth
 			fullPresets = append(fullPresets, fullPreset)
 
@@ -966,7 +966,7 @@ func mapPresetsToFullResponse(presets []models.ServicePreset, sources []models.C
 		}
 
 		log.Printf("[Marge] /full: skipping preset %s — source %q (id=%q, account=%q) not in configured sources and not synthesisable; the speaker's preset slot will revert to empty until the source is repopulated",
-			p.ButtonNumber, p.Source, p.SourceID, p.SourceAccount)
+			sanitizeLog(p.ButtonNumber), sanitizeLog(p.Source), sanitizeLog(p.SourceID), sanitizeLog(p.SourceAccount))
 	}
 
 	return fullPresets
@@ -1027,7 +1027,7 @@ func findMatchingSourceForRecent(r *models.ServiceRecent, sources []models.Confi
 
 			if sources[j].ID == r.SourceID && !sourceTypeCompatible(r.Source, sources[j].SourceKeyType) {
 				log.Printf("[Marge] /full: refusing cross-type bind for recent id=%s — recent.Source=%q but configured source id=%s has type %q; falling through to type-based match",
-					r.ID, r.Source, sources[j].ID, sources[j].SourceKeyType)
+					sanitizeLog(r.ID), sanitizeLog(r.Source), sanitizeLog(sources[j].ID), sanitizeLog(sources[j].SourceKeyType))
 			}
 		}
 	}
@@ -1118,7 +1118,7 @@ func mapRecentsToFullResponse(recents []models.ServiceRecent, sources []models.C
 		// still take the sync down.
 		if synth, ok := synthesiseDefaultSourceForRecent(r); ok {
 			log.Printf("[Marge] /full: synthesising canonical %s source (id=%s, providerid=%s) for recent id=%s — original source %q not in configured sources",
-				r.Source, synth.ID, synth.SourceProviderID, r.ID, r.SourceID)
+				sanitizeLog(r.Source), sanitizeLog(synth.ID), sanitizeLog(synth.SourceProviderID), sanitizeLog(r.ID), sanitizeLog(r.SourceID))
 
 			fullRecent.Source = synth
 			if fullRecent.SourceID == "" {
@@ -1131,7 +1131,7 @@ func mapRecentsToFullResponse(recents []models.ServiceRecent, sources []models.C
 		}
 
 		log.Printf("[Marge] /full: skipping recent id=%s — source %q (id=%q, account=%q) not in configured sources and not synthesisable",
-			r.ID, r.Source, r.SourceID, r.SourceAccount)
+			sanitizeLog(r.ID), sanitizeLog(r.Source), sanitizeLog(r.SourceID), sanitizeLog(r.SourceAccount))
 	}
 
 	return fullRecents
@@ -1461,7 +1461,7 @@ func resolvePresetSource(ds *datastore.DataStore, account, device string, source
 	// credentials, so the caller will reject the PUT instead.
 	if canonical, ok := ds.CanonicalSourceByID(sourceID); ok {
 		log.Printf("[Marge] UpdatePreset(preset=%d): auto-adding canonical source id=%s type=%s providerid=%s — speaker referenced a built-in source not yet in AfterTouch's configured-sources list; saving so the preset can land",
-			presetNumber, canonical.ID, canonical.SourceKeyType, canonical.SourceProviderID)
+			presetNumber, sanitizeLog(canonical.ID), sanitizeLog(canonical.SourceKeyType), sanitizeLog(canonical.SourceProviderID))
 
 		sources = append(sources, canonical)
 		if saveErr := ds.SaveConfiguredSources(account, device, sources); saveErr != nil {
@@ -1513,7 +1513,7 @@ func UpdatePreset(ds *datastore.DataStore, account, device string, presetNumber 
 	matchingSrc, sources := resolvePresetSource(ds, account, device, sources, newPresetElem.SourceID, presetNumber)
 	if matchingSrc == nil {
 		log.Printf("[Marge] UpdatePreset(preset=%d): rejecting — source id=%q is neither in configured sources nor a canonical built-in we can auto-add. The speaker's long-press will appear to succeed locally but the preset will not survive a /full sync",
-			presetNumber, newPresetElem.SourceID)
+			presetNumber, sanitizeLog(newPresetElem.SourceID))
 
 		return nil, fmt.Errorf("invalid account/source")
 	}
@@ -1530,7 +1530,7 @@ func UpdatePreset(ds *datastore.DataStore, account, device string, presetNumber 
 	// behalf — the binding still happens as the speaker requested.
 	if inferred := inferSourceKeyTypeFromLocation(newPresetElem.Location); inferred != "" && matchingSrc.SourceKeyType != "" && inferred != matchingSrc.SourceKeyType {
 		log.Printf("[Marge] UpdatePreset(preset=%d): location URL %q suggests %s but matched source id=%s has SourceKeyType=%s — proceeding as the speaker requested, but the Sources.xml entry may be stale; consider re-running setup.syncSources from the speaker to refresh",
-			presetNumber, newPresetElem.Location, inferred, matchingSrc.ID, matchingSrc.SourceKeyType)
+			presetNumber, sanitizeLog(newPresetElem.Location), sanitizeLog(inferred), sanitizeLog(matchingSrc.ID), sanitizeLog(matchingSrc.SourceKeyType))
 	}
 
 	nowStr := strconv.FormatInt(time.Now().Unix(), 10)
@@ -1920,7 +1920,7 @@ func persistLearnedSource(ds *datastore.DataStore, account, device string, sourc
 	}
 
 	if err := ds.SaveConfiguredSources(account, device, updatedSources); err != nil {
-		log.Printf("[MARGE_ERR] Failed to persist learned source for %s: %v", device, err)
+		log.Printf("[MARGE_ERR] Failed to persist learned source for %s: %v", sanitizeLog(device), err)
 	}
 }
 
@@ -2282,7 +2282,7 @@ func AddSource(ds *datastore.DataStore, account, username, providerID, secret, s
 			newSrc.SourceKey.Type = providerID
 		}
 
-		log.Printf("[Marge] Adding source %s (%s) for device %s", newSrc.SourceKey.Type, username, devID)
+		log.Printf("[Marge] Adding source %s (%s) for device %s", sanitizeLog(newSrc.SourceKey.Type), sanitizeLog(username), sanitizeLog(devID))
 
 		PrepareConfiguredSource(&newSrc)
 

--- a/pkg/service/marge/sync.go
+++ b/pkg/service/marge/sync.go
@@ -16,7 +16,7 @@ func SyncFromAccountFull(ds *datastore.DataStore, resp *models.AccountFullRespon
 		return fmt.Errorf("account ID is missing in response")
 	}
 
-	log.Printf("[SYNC] Starting synchronization for account %s", accountID)
+	log.Printf("[SYNC] Starting synchronization for account %s", sanitizeLog(accountID))
 	// 0. Update Account Metadata
 	syncAccountInfo(ds, accountID, resp)
 
@@ -28,7 +28,7 @@ func SyncFromAccountFull(ds *datastore.DataStore, resp *models.AccountFullRespon
 			continue
 		}
 
-		log.Printf("[SYNC] Synchronizing device %s (Account: %s)", deviceID, accountID)
+		log.Printf("[SYNC] Synchronizing device %s (Account: %s)", sanitizeLog(deviceID), sanitizeLog(accountID))
 
 		// 1. Update Device Info
 		syncDeviceInfo(ds, accountID, dev)
@@ -43,7 +43,7 @@ func SyncFromAccountFull(ds *datastore.DataStore, resp *models.AccountFullRespon
 		syncConfiguredSources(ds, accountID, deviceID, resp.Sources, dev)
 	}
 
-	log.Printf("[SYNC] Synchronization completed for account %s", accountID)
+	log.Printf("[SYNC] Synchronization completed for account %s", sanitizeLog(accountID))
 
 	return nil
 }
@@ -56,7 +56,7 @@ func syncAccountInfo(ds *datastore.DataStore, accountID string, resp *models.Acc
 	}
 
 	if err := ds.SaveAccountInfo(accountID, info); err != nil {
-		log.Printf("[SYNC_ERR] Failed to save account info for %s: %v", accountID, err)
+		log.Printf("[SYNC_ERR] Failed to save account info for %s: %v", sanitizeLog(accountID), err)
 	}
 }
 
@@ -97,12 +97,12 @@ func syncDeviceInfo(ds *datastore.DataStore, accountID string, dev *models.Accou
 	if info.Name == "" {
 		if existingInfo != nil && existingInfo.Name != "" {
 			info.Name = existingInfo.Name
-			log.Printf("[SYNC_DEBUG] Preserved local name '%s' for device %s", info.Name, deviceID)
+			log.Printf("[SYNC_DEBUG] Preserved local name '%s' for device %s", sanitizeLog(info.Name), sanitizeLog(deviceID))
 		} else {
-			log.Printf("[SYNC_DEBUG] Name is empty for device %s in upstream and no local name found", deviceID)
+			log.Printf("[SYNC_DEBUG] Name is empty for device %s in upstream and no local name found", sanitizeLog(deviceID))
 		}
 	} else {
-		log.Printf("[SYNC_DEBUG] Upstream name for device %s is '%s'", deviceID, info.Name)
+		log.Printf("[SYNC_DEBUG] Upstream name for device %s is '%s'", sanitizeLog(deviceID), sanitizeLog(info.Name))
 	}
 
 	// If the name is still empty, try to find a name from other devices in the same account or globally
@@ -112,7 +112,7 @@ func syncDeviceInfo(ds *datastore.DataStore, accountID string, dev *models.Accou
 			d := &allDevices[i]
 			if d.DeviceID == deviceID && d.Name != "" {
 				info.Name = d.Name
-				log.Printf("[SYNC_DEBUG] Recovered name '%s' for device %s from global search", info.Name, deviceID)
+				log.Printf("[SYNC_DEBUG] Recovered name '%s' for device %s from global search", sanitizeLog(info.Name), sanitizeLog(deviceID))
 
 				break
 			}
@@ -120,7 +120,7 @@ func syncDeviceInfo(ds *datastore.DataStore, accountID string, dev *models.Accou
 	}
 
 	if err := ds.SaveDeviceInfo(accountID, deviceID, info); err != nil {
-		log.Printf("[SYNC_ERR] Failed to save device info for %s: %v", deviceID, err)
+		log.Printf("[SYNC_ERR] Failed to save device info for %s: %v", sanitizeLog(deviceID), err)
 	}
 }
 
@@ -170,7 +170,7 @@ func syncConfiguredSources(ds *datastore.DataStore, accountID, deviceID string, 
 	ds.DeduceSourceIDs(accountID, deviceID, deviceSources)
 
 	if err := ds.SaveConfiguredSources(accountID, deviceID, deviceSources); err != nil {
-		log.Printf("[SYNC_ERR] Failed to save sources for %s: %v", deviceID, err)
+		log.Printf("[SYNC_ERR] Failed to save sources for %s: %v", sanitizeLog(deviceID), err)
 	}
 }
 
@@ -200,7 +200,7 @@ func syncPresets(ds *datastore.DataStore, accountID, deviceID string, presetsSou
 	}
 
 	if err := ds.SavePresets(accountID, deviceID, presets); err != nil {
-		log.Printf("[SYNC_ERR] Failed to save presets for %s: %v", deviceID, err)
+		log.Printf("[SYNC_ERR] Failed to save presets for %s: %v", sanitizeLog(deviceID), err)
 	}
 }
 
@@ -228,7 +228,7 @@ func syncRecents(ds *datastore.DataStore, accountID, deviceID string, recentsSou
 	}
 
 	if err := ds.SaveRecents(accountID, deviceID, recents); err != nil {
-		log.Printf("[SYNC_ERR] Failed to save recents for %s: %v", deviceID, err)
+		log.Printf("[SYNC_ERR] Failed to save recents for %s: %v", sanitizeLog(deviceID), err)
 	}
 }
 
@@ -248,7 +248,7 @@ func sourceKeyTypeFromFullSource(s models.FullResponseSource) string {
 	}
 
 	log.Printf("[SYNC] sourceKeyTypeFromFullSource: no canonical SourceKeyType for providerid=%q (source id=%q name=%q) — persisting upstream Type=%q verbatim; downstream consumers will read repairLeakedSource fallback or display %q as-is",
-		s.SourceProviderID, s.ID, s.Name, s.Type, s.Type)
+		sanitizeLog(s.SourceProviderID), sanitizeLog(s.ID), sanitizeLog(s.Name), sanitizeLog(s.Type), sanitizeLog(s.Type))
 
 	return s.Type
 }
@@ -293,7 +293,7 @@ func LogSyncDiff(ds *datastore.DataStore, resp *models.AccountFullResponse) {
 		localPresets, _ := ds.GetPresets(accountID, deviceID)
 
 		if len(localPresets) != len(dev.Presets) {
-			log.Printf("[SYNC_DIFF] Preset count mismatch for %s: local=%d, upstream=%d", deviceID, len(localPresets), len(dev.Presets))
+			log.Printf("[SYNC_DIFF] Preset count mismatch for %s: local=%d, upstream=%d", sanitizeLog(deviceID), len(localPresets), len(dev.Presets))
 		}
 
 		// Compare presets by button number
@@ -308,7 +308,7 @@ func LogSyncDiff(ds *datastore.DataStore, resp *models.AccountFullResponse) {
 					found = true
 
 					if lp.Location != up.Location {
-						log.Printf("[SYNC_DIFF] Preset %s location mismatch for %s: local=%s, upstream=%s", up.ButtonNumber, deviceID, lp.Location, up.Location)
+						log.Printf("[SYNC_DIFF] Preset %s location mismatch for %s: local=%s, upstream=%s", sanitizeLog(up.ButtonNumber), sanitizeLog(deviceID), sanitizeLog(lp.Location), sanitizeLog(up.Location))
 					}
 
 					break
@@ -316,7 +316,7 @@ func LogSyncDiff(ds *datastore.DataStore, resp *models.AccountFullResponse) {
 			}
 
 			if !found {
-				log.Printf("[SYNC_DIFF] Preset %s missing locally for %s", up.ButtonNumber, deviceID)
+				log.Printf("[SYNC_DIFF] Preset %s missing locally for %s", sanitizeLog(up.ButtonNumber), sanitizeLog(deviceID))
 			}
 		}
 	}


### PR DESCRIPTION
Fixes CodeQL go/log-injection alerts in the datastore and marge packages.

Adds logutil.go with a package-private sanitizeLog helper to each package.

pkg/service/datastore/datastore.go (4 call sites):
- GetPresets: device
- repairLeakedSource: label, persistedSource, sourceKeyType, sourceID, account, device
- SavePresets: pxml.ID, account, device, p.Source

pkg/service/marge/marge.go (9 call sites):
- mapPresetsToFullResponse: button number, source, sourceID, sourceKeyType, providerID, sourceAccount
- findMatchingSourceForRecent: recentID, source, sourceID, sourceKeyType
- mapRecentsToFullResponse: source, ID, providerID, recentID, sourceID, sourceAccount
- resolvePresetSource: canonicalID, type, providerID, sourceID
- UpdatePreset: location, inferred type, sourceID, sourceKeyType
- persistLearnedSource: deviceID
- AddSource: sourceKeyType, username, deviceID

pkg/service/marge/sync.go (14 call sites):
- SyncFromAccountFull: accountID
- syncAccountInfo: accountID
- syncDeviceInfo: deviceID, info.Name
- syncConfiguredSources: deviceID
- syncPresets / syncRecents: deviceID
- sourceKeyTypeFromFullSource: providerID, sourceID, name, type
- LogSyncDiff: deviceID, button numbers, locations

No behaviour change. make check passes.
