### PR TITLE
sec5d: sanitize log-injection in soundtouchweb, stockholm, zeroconf

### DIFF
--- a/pkg/service/soundtouchweb/discovery.go
+++ b/pkg/service/soundtouchweb/discovery.go
@@ -52,7 +52,7 @@ func (app *WebApp) AddDeviceByHost(host string, port int, source string) {
 
 	info, err := c.GetDeviceInfo()
 	if err != nil {
-		log.Printf("Failed to fetch device info from %s (%s): %v", host, source, err)
+		log.Printf("Failed to fetch device info from %s (%s): %v", sanitizeLog(host), sanitizeLog(source), err)
 		return
 	}
 
@@ -71,7 +71,7 @@ func (app *WebApp) AddDeviceByHost(host string, port int, source string) {
 
 	go app.UpdateDeviceStatus(host, conn)
 
-	log.Printf("Added %s device %s (%s) at %s:%d", source, info.Name, info.Type, host, port)
+	log.Printf("Added %s device %s (%s) at %s:%d", sanitizeLog(source), sanitizeLog(info.Name), sanitizeLog(info.Type), sanitizeLog(host), port)
 }
 
 // DiscoverDevices runs an mDNS/UPnP sweep and registers any found

--- a/pkg/service/soundtouchweb/logutil.go
+++ b/pkg/service/soundtouchweb/logutil.go
@@ -1,0 +1,13 @@
+package soundtouchweb
+
+import "strings"
+
+// sanitizeLog strips newline characters from s to prevent log-injection
+// (CodeQL go/log-injection). Values from speakers, HTTP requests, and
+// external APIs may contain attacker-controlled newlines.
+func sanitizeLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+
+	return s
+}

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -197,7 +197,7 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 		})
 
 		if err := wsClient.Connect(); err != nil {
-			log.Printf("Failed to connect WebSocket for device %s: %v (retrying in %s)", deviceID, err, backoff)
+			log.Printf("Failed to connect WebSocket for device %s: %v (retrying in %s)", sanitizeLog(deviceID), err, backoff)
 			time.Sleep(backoff)
 
 			backoff *= 2
@@ -214,7 +214,7 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 			s.IsConnected = true
 		})
 
-		log.Printf("WebSocket connected for device %s", deviceID)
+		log.Printf("WebSocket connected for device %s", sanitizeLog(deviceID))
 
 		// Reset backoff after a successful connect so the next failure
 		// starts at the lowest cadence again.
@@ -227,7 +227,7 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 			s.IsConnected = false
 		})
 
-		log.Printf("WebSocket disconnected for device %s — reconnecting in %s", deviceID, backoff)
+		log.Printf("WebSocket disconnected for device %s — reconnecting in %s", sanitizeLog(deviceID), backoff)
 		time.Sleep(backoff)
 
 		backoff *= 2
@@ -313,12 +313,12 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 
 	conn, err := app.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
-		log.Printf("Device WebSocket upgrade failed for %s: %v", deviceID, err)
+		log.Printf("Device WebSocket upgrade failed for %s: %v", sanitizeLog(deviceID), err)
 		return
 	}
 	defer conn.Close()
 
-	log.Printf("Device WebSocket connected for %s", deviceID)
+	log.Printf("Device WebSocket connected for %s", sanitizeLog(deviceID))
 
 	// Send initial device status
 	initialMessage := webtypes.WebSocketMessage{
@@ -350,7 +350,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 
 		for {
 			if _, _, err := conn.NextReader(); err != nil {
-				log.Printf("Device WebSocket read error for %s: %v", deviceID, err)
+				log.Printf("Device WebSocket read error for %s: %v", sanitizeLog(deviceID), err)
 				return
 			}
 		}
@@ -363,7 +363,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 	for range ticker.C {
 		// Send ping to check if client is still connected
 		if err := conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
-			log.Printf("Failed to send ping to device WebSocket %s: %v", deviceID, err)
+			log.Printf("Failed to send ping to device WebSocket %s: %v", sanitizeLog(deviceID), err)
 			return
 		}
 
@@ -379,7 +379,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 		}
 
 		if err := conn.WriteJSON(statusMessage); err != nil {
-			log.Printf("Failed to send device status update for %s: %v", deviceID, err)
+			log.Printf("Failed to send device status update for %s: %v", sanitizeLog(deviceID), err)
 			return
 		}
 
@@ -397,7 +397,7 @@ func (app *WebApp) HandleDeviceWebSocket(w http.ResponseWriter, r *http.Request)
 			}
 
 			if err := conn.WriteJSON(realtimeMessage); err != nil {
-				log.Printf("Failed to send realtime update for %s: %v", deviceID, err)
+				log.Printf("Failed to send realtime update for %s: %v", sanitizeLog(deviceID), err)
 				return
 			}
 		}

--- a/pkg/service/stockholm/bridge.go
+++ b/pkg/service/stockholm/bridge.go
@@ -101,7 +101,7 @@ func (b *Bridge) dispatch(clientID string, req appSendRequest) {
 
 	id := req.ID
 
-	log.Printf("[Stockholm bridge] method=%q client=%q", method, clientID)
+	log.Printf("[Stockholm bridge] method=%q client=%q", sanitizeLog(method), sanitizeLog(clientID))
 
 	switch method {
 	case "locale", "htmlReady", "stopHrmsUpdates":
@@ -109,7 +109,7 @@ func (b *Bridge) dispatch(clientID string, req appSendRequest) {
 
 	case "log":
 		if msg, _ := params["msg"].(string); msg != "" {
-			log.Printf("[Stockholm:%s] %s", clientID, msg)
+			log.Printf("[Stockholm:%s] %s", sanitizeLog(clientID), sanitizeLog(msg))
 		}
 
 	case "setData":

--- a/pkg/service/stockholm/discovery.go
+++ b/pkg/service/stockholm/discovery.go
@@ -61,12 +61,12 @@ func DiscoverRenderers(expectedAccountID string, onDevice func(RendererDevice)) 
 
 		info, err := fetchSpeakerInfo(host)
 		if err != nil {
-			log.Printf("[Stockholm SSDP] Failed to fetch /info from %s: %v", host, err)
+			log.Printf("[Stockholm SSDP] Failed to fetch /info from %s: %v", sanitizeLog(host), err)
 			continue
 		}
 
 		if expectedAccountID != "" && info.MargeAccountUUID != expectedAccountID {
-			log.Printf("[Stockholm SSDP] Skipping %s: account %q != %q", host, info.MargeAccountUUID, expectedAccountID)
+			log.Printf("[Stockholm SSDP] Skipping %s: account %q != %q", sanitizeLog(host), sanitizeLog(info.MargeAccountUUID), sanitizeLog(expectedAccountID))
 			continue
 		}
 

--- a/pkg/service/stockholm/logutil.go
+++ b/pkg/service/stockholm/logutil.go
@@ -1,0 +1,13 @@
+package stockholm
+
+import "strings"
+
+// sanitizeLog strips newline characters from s to prevent log-injection
+// (CodeQL go/log-injection). Values from speakers, HTTP requests, and
+// external APIs may contain attacker-controlled newlines.
+func sanitizeLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+
+	return s
+}

--- a/pkg/service/stockholm/static.go
+++ b/pkg/service/stockholm/static.go
@@ -53,7 +53,7 @@ func ServeStatic(w http.ResponseWriter, r *http.Request, stockholmDir string, ba
 
 	file, rel, err := resolveStaticFile(r.URL.Path, stockholmDir)
 	if err != nil {
-		log.Printf("[Stockholm static] Path traversal rejected: %s", r.URL.Path)
+		log.Printf("[Stockholm static] Path traversal rejected: %s", sanitizeLog(r.URL.Path))
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
 		return

--- a/pkg/service/zeroconf/logutil.go
+++ b/pkg/service/zeroconf/logutil.go
@@ -1,0 +1,13 @@
+package zeroconf
+
+import "strings"
+
+// sanitizeLog strips newline characters from s to prevent log-injection
+// (CodeQL go/log-injection). Values from speakers, HTTP requests, and
+// external APIs may contain attacker-controlled newlines.
+func sanitizeLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+
+	return s
+}

--- a/pkg/service/zeroconf/zeroconf.go
+++ b/pkg/service/zeroconf/zeroconf.go
@@ -371,7 +371,7 @@ func isAddUserNoOp(status int, body []byte) bool {
 // runs, but worded so it's clearly not a failure.
 func logAddUserNoOp(path string, base *url.URL, username string, resp *http.Response) {
 	log.Printf("[ZeroConf] addUser produced expected no-op via %s path (speaker already has activeUser=%q or equivalent state): url=%s status=%d body=<empty> — marge source registration is authoritative for preset/playback",
-		path, username, withAction(base, "addUser"), resp.StatusCode)
+		path, sanitizeLog(username), withAction(base, "addUser"), resp.StatusCode)
 }
 
 // logAddUserFailure emits a single diagnostic line capturing what the speaker
@@ -391,7 +391,7 @@ func logAddUserFailure(path string, base *url.URL, username string, resp *http.R
 	}
 
 	log.Printf("[ZeroConf] addUser rejected via %s path: url=%s userName=%q status=%d server=%q content-type=%q content-length=%q body=%q",
-		path, withAction(base, "addUser"), username, resp.StatusCode, server, ct, cl, bodySummary)
+		path, withAction(base, "addUser"), sanitizeLog(username), resp.StatusCode, sanitizeLog(server), sanitizeLog(ct), sanitizeLog(cl), sanitizeLog(bodySummary))
 }
 
 // pushSimplifiedToken is the fallback for firmware that does not support DH


### PR DESCRIPTION
Fixes CodeQL go/log-injection alerts in three packages.

Adds logutil.go with a package-private sanitizeLog helper to each.

pkg/service/soundtouchweb/discovery.go (2 call sites):
- host, source (device fetch failure)
- source, info.Name, info.Type, host (device added)

pkg/service/soundtouchweb/websocket.go (9 call sites):
- deviceID across connect/disconnect/upgrade/read/ping/status messages

pkg/service/stockholm/bridge.go (2 call sites):
- method, clientID (dispatch trace)
- clientID, msg (log bridge method)

pkg/service/stockholm/discovery.go (2 call sites):
- host (fetch failure)
- host, info.MargeAccountUUID, expectedAccountID (skipping device)

pkg/service/stockholm/static.go (1 call site):
- r.URL.Path (path-traversal rejection)

pkg/service/zeroconf/zeroconf.go (2 call sites):
- username (logAddUserNoOp)
- username, server, ct, cl, bodySummary (logAddUserFailure)

No behaviour change. golangci-lint and make check pass.
