### PR TITLE
fix(web): update stale Jekyll doc URLs in admin UI

### DIFF
--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -134,16 +134,16 @@
         <div class="info-box safety-box">
             <strong>⚠️ Safety First:</strong> Before starting any
             migration, please read our
-            <a href="https://gesellix.github.io/Bose-SoundTouch/guides/MIGRATION-SAFETY.html" target="_blank">Professional
+            <a href="https://gesellix.github.io/Bose-SoundTouch/docs/guides/MIGRATION-SAFETY/" target="_blank">Professional
                 Migration & Safety Guide</a>. The toolkit automatically creates backups, but understanding the process
             is key to a smooth transition.
         </div>
 
         <h3>Useful Links</h3>
         <ul>
-            <li><a href="https://gesellix.github.io/Bose-SoundTouch/guides/SURVIVAL-GUIDE.html" target="_blank">Cloud
+            <li><a href="https://gesellix.github.io/Bose-SoundTouch/docs/guides/SURVIVAL-GUIDE/" target="_blank">Cloud
                 Shutdown Survival Guide</a></li>
-            <li><a href="https://gesellix.github.io/Bose-SoundTouch/guides/CLI-REFERENCE.html" target="_blank">CLI
+            <li><a href="https://gesellix.github.io/Bose-SoundTouch/docs/guides/CLI-REFERENCE/" target="_blank">CLI
                 Reference</a></li>
         </ul>
     </div>


### PR DESCRIPTION
Three links in pkg/service/handlers/web/index.html still pointed to the old Jekyll URL structure (/guides/FOO.html). The docs site moved to Hugo+Hextra; correct URLs now include /docs/ and drop the .html extension in favour of a trailing slash.

  MIGRATION-SAFETY.html  → docs/guides/MIGRATION-SAFETY/
  SURVIVAL-GUIDE.html    → docs/guides/SURVIVAL-GUIDE/
  CLI-REFERENCE.html     → docs/guides/CLI-REFERENCE/

The GitHub blob links in script.js and the hostname-resolution warning in index.html point to source Markdown files and remain valid.
