### PR TITLE
fix(test): skip TestRadioBrowserSearch_Real unless RADIOBROWSER_INTEGRATION=1

### DIFF
--- a/pkg/service/bmx/radiobrowser_test.go
+++ b/pkg/service/bmx/radiobrowser_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -44,6 +45,9 @@ func TestRadioBrowserSearch(t *testing.T) {
 }
 
 func TestRadioBrowserSearch_Real(t *testing.T) {
+	if testing.Short() || os.Getenv("RADIOBROWSER_INTEGRATION") == "" {
+		t.Skip("skipping live network test; set RADIOBROWSER_INTEGRATION=1 to run")
+	}
 	query := "Deutschlandfunk Kultur"
 	resp, err := RadioBrowserSearch(query)
 	if err != nil {

--- a/pkg/service/bmx/radiobrowser_test.go
+++ b/pkg/service/bmx/radiobrowser_test.go
@@ -45,7 +45,7 @@ func TestRadioBrowserSearch(t *testing.T) {
 }
 
 func TestRadioBrowserSearch_Real(t *testing.T) {
-	if testing.Short() || os.Getenv("RADIOBROWSER_INTEGRATION") == "" {
+	if os.Getenv("RADIOBROWSER_INTEGRATION") == "" {
 		t.Skip("skipping live network test; set RADIOBROWSER_INTEGRATION=1 to run")
 	}
 	query := "Deutschlandfunk Kultur"


### PR DESCRIPTION
The test dials all.api.radio-browser.info directly. When the upstream TLS certificate expires the test fails and blocks the build — the local codebase has no control over third-party certificate health.

Guard with n opt-in env var so CI stays green and the live-network test can still be run explicitly when needed.

Closes #412
