### PR TITLE
docs: remove duplicate H1 headings from 91 pages

### DIFF
--- a/docs/content/docs/analysis/ANONYMIZATION-SUMMARY.md
+++ b/docs/content/docs/analysis/ANONYMIZATION-SUMMARY.md
@@ -1,9 +1,6 @@
 ---
 title: "Placeholder values for examples"
 ---
-
-# Placeholder values for examples
-
 This repo is public. Documentation, READMEs, example configs, and test
 fixtures must never carry real LAN IPs, real device MACs, real Bose
 account IDs, or personal device names from any maintainer or

--- a/docs/content/docs/analysis/API-COVERAGE.md
+++ b/docs/content/docs/analysis/API-COVERAGE.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch API Coverage Analysis"
 ---
-
-# Bose SoundTouch API Coverage Analysis
-
 **Last Updated:** February 2026
 **API Version:** Official Bose SoundTouch Web API v1.0
 **Implementation Status:** 100% Official Coverage + Extended Features

--- a/docs/content/docs/analysis/BOSE-APP-ADB-Emulator.md
+++ b/docs/content/docs/analysis/BOSE-APP-ADB-Emulator.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch Traffic Interception Runbook"
 ---
-
-# Bose SoundTouch Traffic Interception Runbook
-
 Intercept HTTPS/WebSocket traffic from the Bose SoundTouch Android app using an Android emulator, mitmproxy, and Frida. Tested on Apple Silicon (ARM64) Mac.
 
 ## Automated Setup

--- a/docs/content/docs/analysis/BOSE-LAB-RUNBOOK.md
+++ b/docs/content/docs/analysis/BOSE-LAB-RUNBOOK.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch – Traffic Analysis Runbook"
 ---
-
-# Bose SoundTouch – Traffic Analysis Runbook
-
 > **Goal:** Set up a Raspberry Pi as a transparent access point to fully observe the traffic of the Bose SoundTouch app – specifically the pairing flow with the Bose Cloud. This serves as a basis for later reverse engineering / simulation of the cloud endpoints.
 
 ---

--- a/docs/content/docs/analysis/DEVICE-REDIRECT-METHODS.md
+++ b/docs/content/docs/analysis/DEVICE-REDIRECT-METHODS.md
@@ -1,9 +1,6 @@
 ---
 title: "Device Redirect Methods & Custom Service Setup"
 ---
-
-# Device Redirect Methods & Custom Service Setup
-
 To enable offline operation or use custom services like **SoundCork** or **ÜberBöse API**, SoundTouch devices must be redirected from Bose's official cloud endpoints to a local or custom server. This document outlines the three known methods to achieve this, gathered from community reverse-engineering efforts in the **SoundCork** and **ÜberBöse API** projects.
 
 > A fourth, **SSH-free** path — driving the device's diagnostic shell on TCP port 17000 — is being added as a peer to the XML and DNS methods. See **[TELNET-MIGRATION-METHOD.md](TELNET-MIGRATION-METHOD.md)** for the use cases, community findings, and feasibility analysis. The `/etc/hosts` method documented below is now deprecated and will not be exposed in the web UI.

--- a/docs/content/docs/analysis/FACTORY-RESET-PROTOCOL.md
+++ b/docs/content/docs/analysis/FACTORY-RESET-PROTOCOL.md
@@ -1,9 +1,6 @@
 ---
 title: "What a SoundTouch speaker does during factory reset"
 ---
-
-# What a SoundTouch speaker does during factory reset
-
 Observed live on ST10 firmware `27.0.6.46330.5043500` (build `epdbuild.trunk.hepdswbld04.2022-08-04`) on 2026-05-12, by running `soundtouch-cli setup factory-reset` and tailing the speaker's `logread` over SSH. The trace is preserved at `_/logs/factory-reset.txt` for reference.
 
 ## Sequence

--- a/docs/content/docs/analysis/IOT-CONFIG-SUMMARY.md
+++ b/docs/content/docs/analysis/IOT-CONFIG-SUMMARY.md
@@ -1,9 +1,6 @@
 ---
 title: "IoT Configuration Quick Reference"
 ---
-
-# IoT Configuration Quick Reference
-
 ## Key Files and Locations
 
 | File/Location                           | Purpose                | Notes                                   |

--- a/docs/content/docs/analysis/IOT-CONFIGURATION-ANALYSIS.md
+++ b/docs/content/docs/analysis/IOT-CONFIGURATION-ANALYSIS.md
@@ -1,9 +1,6 @@
 ---
 title: "IoT Configuration Analysis"
 ---
-
-# IoT Configuration Analysis
-
 ## Overview
 
 This document provides a detailed analysis of the AWS IoT configuration system used by Bose SoundTouch devices, based on firmware backup analysis from ST10 and ST20 models.

--- a/docs/content/docs/analysis/MISSING-ROUTES-SPOTIFY.md
+++ b/docs/content/docs/analysis/MISSING-ROUTES-SPOTIFY.md
@@ -1,9 +1,6 @@
 ---
 title: "Spotify Account Addition Implementation Status"
 ---
-
-# Spotify Account Addition Implementation Status
-
 To fully replace Bose cloud services for the Spotify account addition flow in the "Stockholm" SoundTouch application, the following routes have been implemented in the `soundtouch-service`:
 
 ## 1. OAuth Token Exchange (Bose Cloud)

--- a/docs/content/docs/analysis/SETUP-WEBSOCKET-EXPERIMENT.md
+++ b/docs/content/docs/analysis/SETUP-WEBSOCKET-EXPERIMENT.md
@@ -1,9 +1,6 @@
 ---
 title: "Experiment: Does bare `setMargeAccount` work outside the SETUP bracket?"
 ---
-
-# Experiment: Does bare `setMargeAccount` work outside the SETUP bracket?
-
 ## Why we are doing this
 
 Our captured pairing flow (`docs/reference/DEVICE-PAIRING-FLOW.md`) shows the official Bose app always sends `setMargeAccount` *inside* a `SETUP_START` → `SETUP_ENTER` → `SETUP_LEAVE` state-machine bracket over WebSocket. The question this experiment answers:

--- a/docs/content/docs/analysis/SUPPORTED-URLS.md
+++ b/docs/content/docs/analysis/SUPPORTED-URLS.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch supportedURLs Endpoint Analysis"
 ---
-
-# SoundTouch supportedURLs Endpoint Analysis
-
 This document provides a comprehensive analysis of the `/supportedURLs` endpoint response from real Bose SoundTouch devices and compares it with our current implementation.
 
 ## Discovery Summary

--- a/docs/content/docs/analysis/TELNET-COMMAND-REFERENCE.md
+++ b/docs/content/docs/analysis/TELNET-COMMAND-REFERENCE.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch Telnet (Port 17000) Command Reference"
 ---
-
-# Bose SoundTouch Telnet (Port 17000) Command Reference
-
 A consolidated reference for the diagnostic shell that listens on TCP port
 17000 across the SoundTouch line. Compiled from multiple community sources
 to give a single map of what's been observed in the wild — useful both for

--- a/docs/content/docs/analysis/TELNET-MIGRATION-METHOD.md
+++ b/docs/content/docs/analysis/TELNET-MIGRATION-METHOD.md
@@ -1,9 +1,6 @@
 ---
 title: "Telnet (Port 17000) Migration Method — Analysis"
 ---
-
-# Telnet (Port 17000) Migration Method — Analysis
-
 This document captures the use cases, community findings, and feasibility analysis
 for adding a **Telnet/port 17000** migration path to `soundtouch-service` as a
 peer of the existing XML and DNS-based methods. The `/etc/hosts` method stays

--- a/docs/content/docs/analysis/UPSTREAM-URLS.md
+++ b/docs/content/docs/analysis/UPSTREAM-URLS.md
@@ -1,9 +1,6 @@
 ---
 title: "Upstream URLs & Domains Analysis"
 ---
-
-# Upstream URLs & Domains Analysis
-
 This document provides a comprehensive overview of the upstream Bose cloud services and domains that SoundTouch devices communicate with. These details were gathered from firmware analysis of ST10/ST20 devices, binary string extraction, and community research from the **SoundCork** project (Issue #128).
 
 ## Core Service Domains

--- a/docs/content/docs/analysis/WIKI-COMPARISON.md
+++ b/docs/content/docs/analysis/WIKI-COMPARISON.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch API Comparison: Community Wiki vs Current Implementation"
 ---
-
-# SoundTouch API Comparison: Community Wiki vs Current Implementation
-
 **Date:** January 2026
 **Source:** [SoundTouch Plus Wiki](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API)
 **Our Implementation:** Bose-SoundTouch Go Library v1.0

--- a/docs/content/docs/analysis/bose-soundtouch-community-tools.md
+++ b/docs/content/docs/analysis/bose-soundtouch-community-tools.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch — Community Tools for Post-EOL Preservation"
 ---
-
-# Bose SoundTouch — Community Tools for Post-EOL Preservation
-
 > **Context:** Bose announced the shutdown of SoundTouch cloud services, extended to **May 6, 2026**. On that date the official SoundTouch app will update to a local-only version. Bose has released the [SoundTouch Web API documentation](https://assets.bosecreative.com/m/496577402d128874/original/SoundTouch-Web-API.pdf) as open-source to enable community-driven development. This document surveys the active community projects, their feature coverage, and open development opportunities.
 
 ---

--- a/docs/content/docs/appendix/API-NAVIGATION-REFERENCE.md
+++ b/docs/content/docs/appendix/API-NAVIGATION-REFERENCE.md
@@ -3,9 +3,6 @@ title: "Navigation API Reference"
 sidebar:
   exclude: true
 ---
-
-# Navigation API Reference
-
 ## Overview
 
 This document provides a complete API reference for the Bose SoundTouch navigation and station management functionality. For usage examples and workflows, see [NAVIGATION-GUIDE.md](NAVIGATION-GUIDE.md).

--- a/docs/content/docs/appendix/CLAUDE.md
+++ b/docs/content/docs/appendix/CLAUDE.md
@@ -3,9 +3,6 @@ title: "CLAUDE.md - Development Guidelines for Bose SoundTouch Project"
 sidebar:
   exclude: true
 ---
-
-# CLAUDE.md - Development Guidelines for Bose SoundTouch Project
-
 ## Documentation Overview
 
 This document contains important development guidelines for working on the Bose SoundTouch project. Please also read the following documentation:

--- a/docs/content/docs/appendix/CONTENT-SELECTION-IMPLEMENTATION.md
+++ b/docs/content/docs/appendix/CONTENT-SELECTION-IMPLEMENTATION.md
@@ -3,9 +3,6 @@ title: "Content Selection Implementation Summary"
 sidebar:
   exclude: true
 ---
-
-# Content Selection Implementation Summary
-
 This document summarizes the implementation of advanced content selection features for the Bose SoundTouch Go client, including full support for the LOCAL_INTERNET_RADIO streamUrl format and LOCAL_MUSIC/STORED_MUSIC content selection.
 
 ## ✅ Implementation Status: COMPLETE

--- a/docs/content/docs/appendix/DEVICE-CUSTOMIZATION-SETUP.md
+++ b/docs/content/docs/appendix/DEVICE-CUSTOMIZATION-SETUP.md
@@ -3,9 +3,6 @@ title: "Device Customization Setup Guide"
 sidebar:
   exclude: true
 ---
-
-# Device Customization Setup Guide
-
 This guide documents the manual steps required to configure your Bose SoundTouch device for customization using the SoundCork approach.
 
 Based on: https://github.com/deborahgu/soundcork

--- a/docs/content/docs/appendix/DEVICE-LOGGING.md
+++ b/docs/content/docs/appendix/DEVICE-LOGGING.md
@@ -3,9 +3,6 @@ title: "Device Logging & Troubleshooting"
 sidebar:
   exclude: true
 ---
-
-# Device Logging & Troubleshooting
-
 Accessing logs from SoundTouch devices is critical for debugging custom service integrations and understanding internal device behavior. This document outlines the methods for collecting logs, as discovered by the **SoundCork** and **ÜberBöse API** communities.
 
 ## Log Types

--- a/docs/content/docs/appendix/DEVICE-SETUP.md
+++ b/docs/content/docs/appendix/DEVICE-SETUP.md
@@ -3,9 +3,6 @@ title: "Bose SoundTouch Device Setup Flow"
 sidebar:
   exclude: true
 ---
-
-# Bose SoundTouch Device Setup Flow
-
 This document details the multi-step process required to fully set up a Bose SoundTouch device, as derived from the Stockholm firmware (`setup/js/`) analysis.
 
 A complete setup flow involves a sequence of local (WebSocket) and cloud (HTTP) actions that move the device from a factory-reset state to a fully registered, functional system.

--- a/docs/content/docs/appendix/DIAGNOSTIC-EXPORT.md
+++ b/docs/content/docs/appendix/DIAGNOSTIC-EXPORT.md
@@ -3,9 +3,6 @@ title: "Encrypted Diagnostic Export"
 sidebar:
   exclude: true
 ---
-
-# Encrypted Diagnostic Export
-
 AfterTouch can produce an encrypted diagnostic report that users can download and
 send to the project maintainer without exposing sensitive data to third parties.
 The report is encrypted with an SSH public key using

--- a/docs/content/docs/appendix/EXTERNAL-SERVICES-ABSTRACTION.md
+++ b/docs/content/docs/appendix/EXTERNAL-SERVICES-ABSTRACTION.md
@@ -3,9 +3,6 @@ title: "Technical Proposal: External Service Provider Abstraction"
 sidebar:
   exclude: true
 ---
-
-# Technical Proposal: External Service Provider Abstraction
-
 This document outlines a strategy to refactor the SoundTouch Service's content handling into a modular provider-based system.
 
 ## 1. Problem Statement

--- a/docs/content/docs/appendix/FEATURE_HISTORY.md
+++ b/docs/content/docs/appendix/FEATURE_HISTORY.md
@@ -3,9 +3,6 @@ title: "Feature Development History"
 sidebar:
   exclude: true
 ---
-
-# Feature Development History
-
 This document tracks the detailed evolution of features and capabilities in the Bose SoundTouch API client library.
 
 ## Development Timeline

--- a/docs/content/docs/appendix/HOST-PORT-PARSING.md
+++ b/docs/content/docs/appendix/HOST-PORT-PARSING.md
@@ -3,9 +3,6 @@ title: "Host:Port Parsing Feature"
 sidebar:
   exclude: true
 ---
-
-# Host:Port Parsing Feature
-
 This document describes the automatic host:port parsing functionality added to the SoundTouch CLI, which allows users to specify both host and port in a single `-host` flag.
 
 ## Overview

--- a/docs/content/docs/appendix/MANUAL-NETWORK-DISCOVERY.md
+++ b/docs/content/docs/appendix/MANUAL-NETWORK-DISCOVERY.md
@@ -3,9 +3,6 @@ title: "Manual Network Discovery on macOS"
 sidebar:
   exclude: true
 ---
-
-# Manual Network Discovery on macOS
-
 This document provides comprehensive guidance for manually discovering network services and devices using built-in macOS tools and command-line utilities. This is particularly useful for troubleshooting network discovery issues or understanding what services are available on your local network.
 
 ## Overview

--- a/docs/content/docs/appendix/NAVIGATION-GUIDE.md
+++ b/docs/content/docs/appendix/NAVIGATION-GUIDE.md
@@ -3,9 +3,6 @@ title: "Navigation and Station Management Guide"
 sidebar:
   exclude: true
 ---
-
-# Navigation and Station Management Guide
-
 ## Overview
 
 The Bose SoundTouch Go client provides comprehensive navigation and station management functionality that allows you to:

--- a/docs/content/docs/appendix/OFFICIAL-API-VERIFICATION.md
+++ b/docs/content/docs/appendix/OFFICIAL-API-VERIFICATION.md
@@ -3,9 +3,6 @@ title: "Official SoundTouch Web API Verification"
 sidebar:
   exclude: true
 ---
-
-# Official SoundTouch Web API Verification
-
 **Source**: Official Bose SoundTouch Web API v1.0 Documentation (January 7, 2026)  
 **Verification Date**: January 9, 2026  
 **Project Status**: Complete API coverage verification

--- a/docs/content/docs/appendix/PARITY-OPENCLOUDTOUCH.md
+++ b/docs/content/docs/appendix/PARITY-OPENCLOUDTOUCH.md
@@ -3,9 +3,6 @@ title: "Parity Analysis: Bose-SoundTouch (Go) vs. OpenCloudTouch (Python)"
 sidebar:
   exclude: true
 ---
-
-# Parity Analysis: Bose-SoundTouch (Go) vs. OpenCloudTouch (Python)
-
 This document provides a comparative analysis of the current Go implementation and the `scheilch/opencloudtouch` project, identifying functional gaps and potential improvements.
 
 ## 1. Core Architecture and Language

--- a/docs/content/docs/appendix/PARITY-SOUNDCORK.md
+++ b/docs/content/docs/appendix/PARITY-SOUNDCORK.md
@@ -3,9 +3,6 @@ title: "Parity Analysis: Bose-SoundTouch (Go) vs. SoundCork (Python)"
 sidebar:
   exclude: true
 ---
-
-# Parity Analysis: Bose-SoundTouch (Go) vs. SoundCork (Python)
-
 This document provides a comparative analysis of the current Go implementation and the `deborahgu/soundcork` project, identifying functional gaps and potential improvements.
 
 ## 1. Core Architecture and Language

--- a/docs/content/docs/appendix/PRESET-QUICKSTART.md
+++ b/docs/content/docs/appendix/PRESET-QUICKSTART.md
@@ -3,9 +3,6 @@ title: "Preset Management Quick Start Guide"
 sidebar:
   exclude: true
 ---
-
-# Preset Management Quick Start Guide
-
 **Save your favorite music, radio stations, and playlists as 1-6 presets for instant access.**
 
 ## Overview

--- a/docs/content/docs/appendix/PROJECT-PATTERNS.md
+++ b/docs/content/docs/appendix/PROJECT-PATTERNS.md
@@ -3,8 +3,6 @@ title: "Project Structure Patterns: Bose SoundTouch API Client"
 sidebar:
   exclude: true
 ---
-
-# Project Structure Patterns: Bose SoundTouch API Client
 ## Summary for Reuse in API Client Projects
 
 This document describes the most important patterns for the Bose SoundTouch API client, especially for XML-based API clients with Web UI, CLI tool, and WASM support.

--- a/docs/content/docs/appendix/REQUEST_RECORDING_CONCEPT.md
+++ b/docs/content/docs/appendix/REQUEST_RECORDING_CONCEPT.md
@@ -3,9 +3,6 @@ title: "Request Recording Concept"
 sidebar:
   exclude: true
 ---
-
-# Request Recording Concept
-
 ## Problem Statement
 
 The current request recording system has fundamental issues when dealing with request cloning, body consumption, and multiple response scenarios. Specifically:

--- a/docs/content/docs/appendix/SCMUDC-ENRICHMENT-IMPLEMENTATION.md
+++ b/docs/content/docs/appendix/SCMUDC-ENRICHMENT-IMPLEMENTATION.md
@@ -3,9 +3,6 @@ title: "SCMUDC Enrichment Implementation Summary"
 sidebar:
   exclude: true
 ---
-
-# SCMUDC Enrichment Implementation Summary
-
 ## Overview
 
 This document summarizes the implementation of SCMUDC (Sound Control Management Usage Data Collection) event enrichment in the AfterTouch toolkit. The enhancement provides human-readable analysis of device telemetry data to improve usability and debugging capabilities.

--- a/docs/content/docs/appendix/SERVICE-AVAILABILITY-IMPLEMENTATION.md
+++ b/docs/content/docs/appendix/SERVICE-AVAILABILITY-IMPLEMENTATION.md
@@ -3,9 +3,6 @@ title: "Service Availability Implementation Summary"
 sidebar:
   exclude: true
 ---
-
-# Service Availability Implementation Summary
-
 ## Overview
 
 This document summarizes the implementation of the `/serviceAvailability` endpoint support in the Bose SoundTouch Go client library. This feature enables applications to query which music services and input sources are available on a SoundTouch device, providing better user feedback about supported stations and sources.

--- a/docs/content/docs/appendix/SOUNDTOUCH-SERVICE-ANNOUNCEMENT.md
+++ b/docs/content/docs/appendix/SOUNDTOUCH-SERVICE-ANNOUNCEMENT.md
@@ -3,9 +3,6 @@ title: "🎉 Introducing SoundTouch Service: Local Cloud Service Emulation"
 sidebar:
   exclude: true
 ---
-
-# 🎉 Introducing SoundTouch Service: Local Cloud Service Emulation
-
 **Date**: February 2026
 **Version**: v2.0.0+
 **Status**: Production Ready

--- a/docs/content/docs/appendix/UNDOCUMENTED-COMMUNITY-FEATURES.md
+++ b/docs/content/docs/appendix/UNDOCUMENTED-COMMUNITY-FEATURES.md
@@ -3,8 +3,6 @@ title: "Undocumented Community Features & API Discoveries"
 sidebar:
   exclude: true
 ---
-
-# Undocumented Community Features & API Discoveries
 This document captures advanced API endpoints and device behaviors discovered by the SoundTouch community through reverse engineering projects like **SoundCork** and **ÜberBöse API**. These features are not documented in the official Bose SoundTouch Web API v1.0 but are crucial for full device emulation and offline operation.
 ## Cloud Emulation (Marge/BMX) Discoveries
 While the local `/8090` API is well-documented, the cloud-side service emulation reveals deeper device integration points.

--- a/docs/content/docs/appendix/UNIMPLEMENTED-ENDPOINTS.md
+++ b/docs/content/docs/appendix/UNIMPLEMENTED-ENDPOINTS.md
@@ -3,9 +3,6 @@ title: "Unimplemented SoundTouch API Endpoints"
 sidebar:
   exclude: true
 ---
-
-# Unimplemented SoundTouch API Endpoints
-
 **Last Updated:** January 2026  
 **Source:** [SoundTouch Plus Wiki](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API)  
 **Current Implementation:** 35 endpoints (including preset & navigation management discovered via SoundTouch Plus Wiki)  

--- a/docs/content/docs/appendix/device-lifecycle-and-power-on-enhancement.md
+++ b/docs/content/docs/appendix/device-lifecycle-and-power-on-enhancement.md
@@ -3,9 +3,6 @@ title: "Device Lifecycle and /power_on Enhancement"
 sidebar:
   exclude: true
 ---
-
-# Device Lifecycle and /power_on Enhancement
-
 ## Overview
 
 This document provides a comprehensive analysis of the current SoundTouch device registration and lifecycle management implementation, and proposes enhancements using the `/power_on` endpoint to reduce dependency on local network connectivity.

--- a/docs/content/docs/appendix/device-lifecycle-summary.md
+++ b/docs/content/docs/appendix/device-lifecycle-summary.md
@@ -3,9 +3,6 @@ title: "Device Lifecycle Analysis - Executive Summary"
 sidebar:
   exclude: true
 ---
-
-# Device Lifecycle Analysis - Executive Summary
-
 ## Current State Assessment
 
 The SoundTouch service currently relies heavily on local network connectivity for device discovery and management:

--- a/docs/content/docs/appendix/power-on-implementation-guide.md
+++ b/docs/content/docs/appendix/power-on-implementation-guide.md
@@ -3,9 +3,6 @@ title: "/power_on Implementation Guide"
 sidebar:
   exclude: true
 ---
-
-# /power_on Implementation Guide
-
 ## Overview
 
 This guide provides detailed technical specifications for implementing `/power_on` endpoint enhancements to reduce network dependency and improve device lifecycle management in the SoundTouch service.

--- a/docs/content/docs/appendix/preset-store.md
+++ b/docs/content/docs/appendix/preset-store.md
@@ -3,9 +3,6 @@ title: "SoundTouch `/storePreset` Implementation Guide"
 sidebar:
   exclude: true
 ---
-
-# SoundTouch `/storePreset` Implementation Guide
-
 ## Overview
 
 This document analyzes the feasibility and implementation approach for adding `/storePreset` functionality to the Bose SoundTouch API client, based on [GitHub Issue #14](https://github.com/gesellix/Bose-SoundTouch/issues/14) and endpoints discovered through the comprehensive [SoundTouch Plus Wiki](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API).

--- a/docs/content/docs/appendix/scmudc-events-analysis.md
+++ b/docs/content/docs/appendix/scmudc-events-analysis.md
@@ -3,9 +3,6 @@ title: "SCMUDC Events Analysis"
 sidebar:
   exclude: true
 ---
-
-# SCMUDC Events Analysis
-
 ## Overview
 
 SCMUDC (Sound Control Management Usage Data Collection) events are telemetry data sent from SoundTouch devices to `events.api.bosecm.com` via `/v1/scmudc/{deviceId}` endpoints. These events track user interactions and device behaviors for analytics and monitoring.

--- a/docs/content/docs/appendix/soundtouch-web-roadmap.md
+++ b/docs/content/docs/appendix/soundtouch-web-roadmap.md
@@ -3,9 +3,6 @@ title: "soundtouch-web: remaining features"
 sidebar:
   exclude: true
 ---
-
-# soundtouch-web: remaining features
-
 Four features complete the parity gap between soundtouch-web and the Stockholm
 app's local-control functionality. Everything else in Stockholm (OAuth flows,
 setup wizard, service account linking, onboarding, analytics) is cloud

--- a/docs/content/docs/appendix/stockholm-port-guide.md
+++ b/docs/content/docs/appendix/stockholm-port-guide.md
@@ -3,9 +3,6 @@ title: "Stockholm Backend — Port Guide for Bose-SoundTouch (Go)"
 sidebar:
   exclude: true
 ---
-
-# Stockholm Backend — Port Guide for Bose-SoundTouch (Go)
-
 This document describes everything needed to integrate the
 [krahl/soundcork-stockholm-app](https://github.com/krahl/soundcork-stockholm-app)
 functionality into the Go service. It is written as a reference; nothing here

--- a/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
+++ b/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
@@ -1,9 +1,6 @@
 ---
 title: "Device-Local Install: Four User Journeys"
 ---
-
-# Device-Local Install: Four User Journeys
-
 > **Looking for how to actually install AfterTouch?**
 > See the [Deployment Overview](../guides/DEPLOYMENT-OVERVIEW.md) for user-friendly
 > step-by-step guides for both deployment scenarios (external host and on-device).

--- a/docs/content/docs/concepts/ENCRYPTED-EXPORT.md
+++ b/docs/content/docs/concepts/ENCRYPTED-EXPORT.md
@@ -1,9 +1,6 @@
 ---
 title: "Encrypting Sensitive Data Exports with SSH/age or GPG"
 ---
-
-# Encrypting Sensitive Data Exports with SSH/age or GPG
-
 ## Problem
 
 Allow users of our software to export potentially sensitive data, encrypt it locally, and send it to us. We decrypt on our side. Goal: no key exchange, minimal user friction.

--- a/docs/content/docs/concepts/amazon-music-oauth.md
+++ b/docs/content/docs/concepts/amazon-music-oauth.md
@@ -1,9 +1,6 @@
 ---
 title: "Amazon Music OAuth Integration"
 ---
-
-# Amazon Music OAuth Integration
-
 This document describes the plan and specification for adding Amazon Music OAuth support to the SoundTouch service, enabling continued Amazon Music playback after the Bose cloud shutdown (May 2026).
 
 The implementation mirrors the [Spotify OAuth integration](spotify-oauth.md) closely. Read that document first — this one calls out only the differences.

--- a/docs/content/docs/concepts/spotify-oauth.md
+++ b/docs/content/docs/concepts/spotify-oauth.md
@@ -1,9 +1,6 @@
 ---
 title: "Spotify OAuth Integration"
 ---
-
-# Spotify OAuth Integration
-
 > **New here?** Start with [spotify-overview.md](spotify-overview.md) for the
 > mental model (Spotify Connect vs OAuth-intercept, DNS rewrite gotcha,
 > end-to-end token lifecycle). This document zooms in on the OAuth flows and

--- a/docs/content/docs/concepts/spotify-overview.md
+++ b/docs/content/docs/concepts/spotify-overview.md
@@ -1,9 +1,6 @@
 ---
 title: "Spotify on SoundTouch — Overview"
 ---
-
-# Spotify on SoundTouch — Overview
-
 This is the entry point for understanding how Spotify works on a SoundTouch
 speaker behind AfterTouch. Read this first; the deeper docs assume you already
 have the mental model below.

--- a/docs/content/docs/concepts/spotify-priming-strategy.md
+++ b/docs/content/docs/concepts/spotify-priming-strategy.md
@@ -1,9 +1,6 @@
 ---
 title: "Spotify Priming Strategy"
 ---
-
-# Spotify Priming Strategy
-
 > **New here?** Start with [spotify-overview.md](spotify-overview.md) for the
 > mental model. This document goes deep on the priming protocol, ZeroConf DH
 > exchange, and deployment topologies.

--- a/docs/content/docs/diagrams/migration-flow.md
+++ b/docs/content/docs/diagrams/migration-flow.md
@@ -1,9 +1,6 @@
 ---
 title: "Migration Flow Diagrams"
 ---
-
-# Migration Flow Diagrams
-
 This document specifies the diagrams needed for the migration guide, with descriptions that can be used to create actual visual diagrams.
 
 ## 1. Overall Migration Process Flow

--- a/docs/content/docs/guides/CAPTURE-DEVICE-PAIRING.md
+++ b/docs/content/docs/guides/CAPTURE-DEVICE-PAIRING.md
@@ -1,9 +1,6 @@
 ---
 title: "Capture Device Pairing Traffic"
 ---
-
-# Capture Device Pairing Traffic
-
 Step-by-step runbook for factory-resetting a SoundTouch speaker, pairing it to a Bose cloud account, and capturing every cloud request via mitmproxy. Tested on Apple Silicon Mac.
 
 **Goal:** obtain a full `.mitm` recording of the account-pairing flow (streaming.bose.com) triggered by the official Android app.

--- a/docs/content/docs/guides/CAPTURE-MIGRATION-TRAFFIC.md
+++ b/docs/content/docs/guides/CAPTURE-MIGRATION-TRAFFIC.md
@@ -1,9 +1,6 @@
 ---
 title: "Capture Speaker Migration Traffic"
 ---
-
-# Capture Speaker Migration Traffic
-
 Runbook for migrating a SoundTouch speaker to `soundtouch-service` and capturing
 all traffic (App→Service and Speaker→Service) to identify unimplemented endpoints.
 

--- a/docs/content/docs/guides/CLI-REFERENCE.md
+++ b/docs/content/docs/guides/CLI-REFERENCE.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch CLI Reference"
 ---
-
-# SoundTouch CLI Reference
-
 **Complete command reference for the soundtouch-cli tool**
 
 This document provides comprehensive documentation for all available commands and options in the `soundtouch-cli` tool.

--- a/docs/content/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
+++ b/docs/content/docs/guides/CLOUD-DEPLOY-WALKTHROUGH.md
@@ -1,9 +1,6 @@
 ---
 title: "Cloud Deployment Walkthrough"
 ---
-
-# Cloud Deployment Walkthrough
-
 A step-by-step guide to running AfterTouch on a VPS or cloud server and
 pointing your local Bose SoundTouch speakers at it.
 

--- a/docs/content/docs/guides/DEPLOYMENT-OVERVIEW.md
+++ b/docs/content/docs/guides/DEPLOYMENT-OVERVIEW.md
@@ -1,9 +1,6 @@
 ---
 title: "AfterTouch Deployment Overview"
 ---
-
-# AfterTouch Deployment Overview
-
 AfterTouch replaces the Bose SoundTouch cloud, which shut down on 2026-05-06. There are
 three ways to run it — pick the one that fits your situation.
 

--- a/docs/content/docs/guides/DEPLOYMENT.md
+++ b/docs/content/docs/guides/DEPLOYMENT.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Production Deployment Guide"
 ---
-
-# SoundTouch Production Deployment Guide
-
 **Best practices for deploying SoundTouch Go applications in production environments**
 
 This guide covers everything you need to know to deploy robust, scalable SoundTouch applications in production, including configuration management, monitoring, security, and operational considerations.

--- a/docs/content/docs/guides/DEVICE-INITIAL-SETUP.md
+++ b/docs/content/docs/guides/DEVICE-INITIAL-SETUP.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Device Initial Setup Variants"
 ---
-
-# SoundTouch Device Initial Setup Variants
-
 Based on community research from the **SoundCork** and **ÜberBöse API** projects, as well as analysis of the Stockholm firmware (`firmware/Stockholm/.../setup/`), this document outlines the methods used for the "out-of-the-box" setup of SoundTouch devices.
 
 ## Setup Overview

--- a/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -1,9 +1,6 @@
 ---
 title: "External Host Walkthrough"
 ---
-
-# External Host Walkthrough
-
 A step-by-step guide to running AfterTouch on a Raspberry Pi (or any always-on
 computer) and migrating your Bose SoundTouch speakers to use it.
 

--- a/docs/content/docs/guides/GETTING-STARTED.md
+++ b/docs/content/docs/guides/GETTING-STARTED.md
@@ -1,9 +1,6 @@
 ---
 title: "Getting Started with SoundTouch Go Client"
 ---
-
-# Getting Started with SoundTouch Go Client
-
 **A complete guide to controlling your Bose SoundTouch devices with Go**
 
 This guide will get you up and running with the SoundTouch Go client in under 10 minutes. By the end, you'll be able to discover devices, control playback, manage volume, and monitor real-time events.

--- a/docs/content/docs/guides/HTTPS-SETUP.md
+++ b/docs/content/docs/guides/HTTPS-SETUP.md
@@ -1,9 +1,6 @@
 ---
 title: "HTTPS & Custom CA Certificate"
 ---
-
-# HTTPS & Custom CA Certificate
-
 SoundTouch speakers communicate with cloud services over HTTPS. For the local service to work over HTTPS, speakers must trust the AfterTouch Root CA. The service manages this automatically — it generates a CA on first start and the web UI guides you through installing it on each speaker as part of the migration flow.
 
 > ### ⚠️ Speakers connect to `:443`, AfterTouch defaults to `:8443`

--- a/docs/content/docs/guides/IOT-IMPLEMENTATION-GUIDE.md
+++ b/docs/content/docs/guides/IOT-IMPLEMENTATION-GUIDE.md
@@ -1,9 +1,6 @@
 ---
 title: "IoT Implementation Guide"
 ---
-
-# IoT Implementation Guide
-
 ## Overview
 
 This guide provides technical implementation details for integrating with the Bose SoundTouch IoT configuration system. It covers the AWS IoT Core integration, certificate management, and device shadow operations.

--- a/docs/content/docs/guides/MAC-ADDRESS-MAPPING.md
+++ b/docs/content/docs/guides/MAC-ADDRESS-MAPPING.md
@@ -1,9 +1,6 @@
 ---
 title: "MAC Address to Serial Number Mapping"
 ---
-
-# MAC Address to Serial Number Mapping
-
 **Understanding and troubleshooting device identification in SoundTouch service**
 
 This guide explains how the SoundTouch service handles device identification through MAC address to serial number mapping, and how to troubleshoot related issues.

--- a/docs/content/docs/guides/MIGRATION-GUIDE.md
+++ b/docs/content/docs/guides/MIGRATION-GUIDE.md
@@ -1,9 +1,6 @@
 ---
 title: "Migration Guide: From Bose Cloud to AfterTouch"
 ---
-
-# Migration Guide: From Bose Cloud to AfterTouch
-
 This guide walks through the complete process of migrating your SoundTouch speakers from Bose's cloud services to **AfterTouch**, the replacement provided by `soundtouch-service`. By the end, your speakers will work fully independently of Bose's servers.
 
 For a shorter overview, see the [Survival Guide](SURVIVAL-GUIDE.md). For safety considerations and rollback options, see the [Migration & Safety Guide](MIGRATION-SAFETY.md).

--- a/docs/content/docs/guides/MIGRATION-SAFETY.md
+++ b/docs/content/docs/guides/MIGRATION-SAFETY.md
@@ -1,9 +1,6 @@
 ---
 title: "Migration & Safety Guide"
 ---
-
-# Migration & Safety Guide
-
 Starting a migration on real hardware requires a "Safety First" approach. This guide outlines the safety features implemented in the `soundtouch-service` and provides a checklist for a successful migration.
 
 #### 🛠 Technical Safety Enhancements

--- a/docs/content/docs/guides/MQTT-INTEGRATION-DESIGN.md
+++ b/docs/content/docs/guides/MQTT-INTEGRATION-DESIGN.md
@@ -1,9 +1,6 @@
 ---
 title: "MQTT Integration Design for SoundTouch Service"
 ---
-
-# MQTT Integration Design for SoundTouch Service
-
 ## Overview
 
 This document outlines the design for integrating MQTT support into the existing SoundTouch service to simulate AWS IoT Core functionality. The integration will provide real-time device communication, shadow state management, and prepare for the AWS IoT service shutdown in May 2026.

--- a/docs/content/docs/guides/MUSIC-SERVICES.md
+++ b/docs/content/docs/guides/MUSIC-SERVICES.md
@@ -1,9 +1,6 @@
 ---
 title: "Connecting Music Services (Spotify & Amazon Music)"
 ---
-
-# Connecting Music Services (Spotify & Amazon Music)
-
 This guide explains how to link your Spotify or Amazon Music account to AfterTouch so your speakers can stream music from those services.
 
 > For Spotify, a higher-level mental model of how the integration works —

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -1,9 +1,6 @@
 ---
 title: "On-Device Install Walkthrough"
 ---
-
-# On-Device Install Walkthrough
-
 A complete end-to-end runbook for installing AfterTouch directly on a
 Bose SoundTouch speaker — from first SSH connection through verified
 radio preset playback.

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -1,9 +1,6 @@
 ---
 title: "Raspberry Pi Installation Guide"
 ---
-
-# Raspberry Pi Installation Guide
-
 This guide explains how to install the `soundtouch-service` as a persistent systemd service on a Raspberry Pi (tested on Raspberry Pi Zero 2W, 3, and 4).
 
 For a complete walkthrough — from install through speaker migration and preset setup — see

--- a/docs/content/docs/guides/SELF-HOSTING.md
+++ b/docs/content/docs/guides/SELF-HOSTING.md
@@ -1,9 +1,6 @@
 ---
 title: "Self-Hosting AfterTouch"
 ---
-
-# Self-Hosting AfterTouch
-
 This guide walks you through running AfterTouch on your own computer or server. No programming knowledge required.
 
 ---

--- a/docs/content/docs/guides/SOUNDTOUCH-SERVICE.md
+++ b/docs/content/docs/guides/SOUNDTOUCH-SERVICE.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Service"
 ---
-
-# SoundTouch Service
-
 The `soundtouch-service` is a comprehensive local server that emulates Bose's cloud services, enabling offline SoundTouch device operation and advanced debugging capabilities. This service is particularly valuable given Bose's announcement that cloud support will end in May 2026.
 
 ## Overview

--- a/docs/content/docs/guides/SURVIVAL-GUIDE.md
+++ b/docs/content/docs/guides/SURVIVAL-GUIDE.md
@@ -1,9 +1,6 @@
 ---
 title: "Keeping Your Speakers Alive After the Bose Cloud Shutdown"
 ---
-
-# Keeping Your Speakers Alive After the Bose Cloud Shutdown
-
 Bose shut down SoundTouch cloud services on **May 6, 2026**. Per the [official end-of-life page](https://www.bose.com/soundtouch-end-of-life), the following no longer work:
 
 - **Presets** — preset buttons on the product and in the app

--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Troubleshooting Guide"
 ---
-
-# SoundTouch Troubleshooting Guide
-
 **Complete guide to diagnosing and fixing common SoundTouch Go client issues**
 
 This guide helps you quickly identify and resolve problems with the SoundTouch Go client library. Issues are organized by category with step-by-step solutions.

--- a/docs/content/docs/reference/API-COOKBOOK.md
+++ b/docs/content/docs/reference/API-COOKBOOK.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch API Cookbook"
 ---
-
-# SoundTouch API Cookbook
-
 **Real-world patterns, recipes, and best practices for the SoundTouch Go client**
 
 This cookbook provides practical solutions to common SoundTouch integration challenges. Each recipe includes working code, error handling, and production considerations.

--- a/docs/content/docs/reference/API-ENDPOINTS.md
+++ b/docs/content/docs/reference/API-ENDPOINTS.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch Web API - Endpoints Overview"
 ---
-
-# Bose SoundTouch Web API - Endpoints Overview
-
 This document provides a comprehensive overview of the available API endpoints verified against the official Bose SoundTouch Web API v1.0 specification (January 7, 2026).
 
 **Acknowledgment**: Additional endpoints beyond the official API were discovered through the comprehensive [SoundTouch Plus Wiki](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus/wiki/SoundTouch-WebServices-API) maintained by the SoundTouch Plus community. Special thanks to @thlucas1 and contributors for documenting these working endpoints that enable full preset management and content navigation functionality.

--- a/docs/content/docs/reference/BASS-CONTROLS.md
+++ b/docs/content/docs/reference/BASS-CONTROLS.md
@@ -1,9 +1,6 @@
 ---
 title: "Bass Control Guide"
 ---
-
-# Bass Control Guide
-
 ## Overview
 
 The Bose SoundTouch Go client provides comprehensive bass control functionality through the `GET /bass` and `POST /bass` endpoints. This feature allows you to adjust bass levels from -9 (maximum bass cut) to +9 (maximum bass boost) with full validation and safety features.

--- a/docs/content/docs/reference/CLOUD-API.md
+++ b/docs/content/docs/reference/CLOUD-API.md
@@ -1,9 +1,6 @@
 ---
 title: "Bose SoundTouch Cloud API Emulation (Marge/BMX/Stats)"
 ---
-
-# Bose SoundTouch Cloud API Emulation (Marge/BMX/Stats)
-
 This document describes the cloud-emulation APIs provided by the SoundTouch service. These APIs mimic the Bose cloud services (Marge, BMX, Stats) that SoundTouch devices and the SoundTouch controller application (Stockholm) interact with.
 
 ## Marge API (Account & Configuration)

--- a/docs/content/docs/reference/DEVICE-PAIRING-FLOW.md
+++ b/docs/content/docs/reference/DEVICE-PAIRING-FLOW.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Device WebSocket API — Pairing & Operation Flow"
 ---
-
-# SoundTouch Device WebSocket API — Pairing & Operation Flow
-
 Reference document derived from mitmproxy captures of the Bose SoundTouch Android app
 (`bose-pairing-20260502-155542`, `bose-pairing-20260502-165549`).
 

--- a/docs/content/docs/reference/DISCOVERY.md
+++ b/docs/content/docs/reference/DISCOVERY.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Device Discovery"
 ---
-
-# SoundTouch Device Discovery
-
 This document describes the various methods available for discovering Bose SoundTouch devices on your network.
 
 ## Overview

--- a/docs/content/docs/reference/FEATURE-MAPPING.md
+++ b/docs/content/docs/reference/FEATURE-MAPPING.md
@@ -1,9 +1,6 @@
 ---
 title: "Feature Mapping Guide"
 ---
-
-# Feature Mapping Guide
-
 This guide demonstrates the comprehensive endpoint-to-feature mapping system that helps you understand exactly what your SoundTouch device can do and how to use it effectively.
 
 ## Overview

--- a/docs/content/docs/reference/KEY-CONTROLS.md
+++ b/docs/content/docs/reference/KEY-CONTROLS.md
@@ -1,9 +1,6 @@
 ---
 title: "Key Control Implementation"
 ---
-
-# Key Control Implementation
-
 This document describes the implementation of the POST `/key` endpoint for media control commands in the Bose SoundTouch API client.
 
 ## Overview

--- a/docs/content/docs/reference/PRESET-MANAGEMENT.md
+++ b/docs/content/docs/reference/PRESET-MANAGEMENT.md
@@ -1,9 +1,6 @@
 ---
 title: "Preset Management - Bose SoundTouch API"
 ---
-
-# Preset Management - Bose SoundTouch API
-
 This document covers preset management functionality in the Bose SoundTouch API client.
 
 ## Overview

--- a/docs/content/docs/reference/SOURCE-SELECTION.md
+++ b/docs/content/docs/reference/SOURCE-SELECTION.md
@@ -1,9 +1,6 @@
 ---
 title: "Source Selection Guide"
 ---
-
-# Source Selection Guide
-
 ## Overview
 
 The Bose SoundTouch Go client provides comprehensive source selection functionality through the `POST /select` endpoint. This feature allows you to switch between different audio sources like Spotify, Bluetooth, AUX input, and various streaming services.

--- a/docs/content/docs/reference/SPEAKER-ENDPOINT.md
+++ b/docs/content/docs/reference/SPEAKER-ENDPOINT.md
@@ -1,9 +1,6 @@
 ---
 title: "SoundTouch Speaker Endpoint Documentation"
 ---
-
-# SoundTouch Speaker Endpoint Documentation
-
 This document describes the implementation of the `/speaker` endpoint for Bose SoundTouch devices, which enables Text-To-Speech (TTS) notifications and URL content playback.
 
 ## Overview

--- a/docs/content/docs/reference/SYSTEM-ENDPOINTS.md
+++ b/docs/content/docs/reference/SYSTEM-ENDPOINTS.md
@@ -1,9 +1,6 @@
 ---
 title: "System Endpoints Documentation"
 ---
-
-# System Endpoints Documentation
-
 This document provides comprehensive documentation for the system management endpoints in the Bose SoundTouch Go client library.
 
 ## Overview

--- a/docs/content/docs/reference/VOLUME-CONTROLS.md
+++ b/docs/content/docs/reference/VOLUME-CONTROLS.md
@@ -1,9 +1,6 @@
 ---
 title: "Volume Control Implementation"
 ---
-
-# Volume Control Implementation
-
 This document describes the implementation of the GET/POST `/volume` endpoints for volume management in the Bose SoundTouch API client.
 
 ## Overview

--- a/docs/content/docs/reference/WEBSOCKET-EVENTS.md
+++ b/docs/content/docs/reference/WEBSOCKET-EVENTS.md
@@ -1,9 +1,6 @@
 ---
 title: "WebSocket Events - Real-time SoundTouch Monitoring"
 ---
-
-# WebSocket Events - Real-time SoundTouch Monitoring
-
 This document describes the WebSocket event functionality for real-time monitoring of Bose SoundTouch devices.
 
 ## Overview

--- a/docs/content/docs/reference/ZONE-MANAGEMENT.md
+++ b/docs/content/docs/reference/ZONE-MANAGEMENT.md
@@ -1,9 +1,6 @@
 ---
 title: "Zone Management - Multiroom SoundTouch Control"
 ---
-
-# Zone Management - Multiroom SoundTouch Control
-
 This document describes the comprehensive zone management functionality for controlling multiroom setups with Bose SoundTouch devices.
 
 ## Overview

--- a/docs/content/docs/reference/spotify-account-addition.md
+++ b/docs/content/docs/reference/spotify-account-addition.md
@@ -1,9 +1,6 @@
 ---
 title: "Spotify Account Addition Technical Reference"
 ---
-
-# Spotify Account Addition Technical Reference
-
 This document details the exact network requests performed by the Bose SoundTouch "Stockholm" application and the SoundTouch speaker when adding a new Spotify account. This information is based on analysis of the Stockholm firmware version `27.0.13-4277-8963611`.
 
 ## Flow Overview


### PR DESCRIPTION
The docs framework renders frontmatter title: as the page heading. Every file that also had a matching # Heading as the first content line displayed the title twice. Removed the redundant H1 and its following blank line from all 91 affected files.

Closes #414
