### PR TITLE
fix(web): forward account param when selecting a source (#444)

### DIFF
--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -413,12 +413,17 @@ func (app *WebApp) handleSourceControl(w http.ResponseWriter, r *http.Request, d
 		return
 	}
 
+	// Forward the optional account parameter as sourceAccount. Devices with
+	// multiple jacks that share source="AUX" (e.g. ST-5 CD/Aux inputs)
+	// disambiguate them via distinct sourceAccount values (AUX, AUX1, …).
+	accountParam := r.URL.Query().Get("account")
+
 	if device.Client == nil {
 		app.sendError(w, "Device client not available", http.StatusInternalServerError)
 		return
 	}
 
-	err := device.Client.SelectSource(sourceParam, "")
+	err := device.Client.SelectSource(sourceParam, accountParam)
 	app.sendControlResponse(w, err, fmt.Sprintf("Selected source %s", sourceParam))
 }
 

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -704,3 +704,68 @@ func TestHandleDevicePlay_SourceAccountFiltering(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleSourceControl_ForwardsAccount verifies that the account query
+// parameter is forwarded as sourceAccount in the /select XML. Devices like
+// the ST-5 expose multiple AUX jacks that share source="AUX" and are only
+// disambiguated by distinct sourceAccount values (AUX, AUX1, …). Regression
+// test for issue #444, where the handler dropped the account parameter.
+func TestHandleSourceControl_ForwardsAccount(t *testing.T) {
+	tests := []struct {
+		name              string
+		query             string
+		wantSourceAccount string
+	}{
+		{
+			name:              "AUX with explicit account — forwarded",
+			query:             "name=AUX&account=AUX1",
+			wantSourceAccount: "AUX1",
+		},
+		{
+			name:              "AUX without account — defaults to AUX",
+			query:             "name=AUX",
+			wantSourceAccount: "AUX",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedBody string
+
+			// Fake speaker that captures the /select POST body.
+			speaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/select" {
+					b, _ := io.ReadAll(r.Body)
+					capturedBody = string(b)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer speaker.Close()
+
+			speakerClient := client.NewClient(&client.Config{Host: speaker.URL})
+
+			app := NewWebApp()
+			deviceInfo := &models.DeviceInfo{Name: "Test Speaker"}
+			conn := webtypes.NewDeviceConnection(speakerClient, deviceInfo)
+			conn.SetStatus(&webtypes.DeviceStatus{IsConnected: true, LastActivity: time.Now()})
+			app.AddDevice("source-device", conn)
+
+			req := httptest.NewRequest("GET", "/api/control/source-device/source?"+tt.query, nil)
+			req = withChiParams(req, map[string]string{"id": "source-device", "action": "source"})
+			w := httptest.NewRecorder()
+
+			app.HandleAPIControl(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			if want := `source="AUX"`; !strings.Contains(capturedBody, want) {
+				t.Errorf("XML should contain %q, got: %s", want, capturedBody)
+			}
+			if want := `sourceAccount="` + tt.wantSourceAccount + `"`; !strings.Contains(capturedBody, want) {
+				t.Errorf("XML should contain %q, got: %s", want, capturedBody)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the web UI / API being unable to select AUX sources on a SoundTouch ST-5 (issue #444).

`handleSourceControl` (`pkg/service/soundtouchweb/handler.go`) hardcoded an empty `sourceAccount` when calling `SelectSource`. Devices that expose several jacks sharing `source="AUX"` (the ST-5's CD/Aux inputs, disambiguated by distinct `sourceAccount` values `AUX`/`AUX1`/`AUX2`) therefore always received `sourceAccount="AUX"` and rejected the wrong jack with internal error 1005.

`GET /api/control/{host}/source?name=AUX&account=AUX1` now reads the `account` query parameter and forwards it as `sourceAccount`, matching what the frontend (`static/js/api.js`, `Sources.js`) already sends and what the CLI (`source select --account`) already does. No client, model, route, or frontend changes were needed; the bug was confined to this one handler.

## Changes

- `handler.go`: read `account` from the query string and pass it to `SelectSource`.
- `handler_test.go`: add `TestHandleSourceControl_ForwardsAccount` (fake-speaker capture of the `/select` POST body), asserting `name=AUX&account=AUX1` yields `sourceAccount="AUX1"`, and that omitting `account` preserves the existing AUX default (`"AUX"`).

## Verification

- New regression test passes; it fails against the old `, ""` line.
- `gofmt`, `go vet`, full `make test` (unit), and `make lint` are clean.

## Status

Candidate fix awaiting reporter confirmation on real ST-5 hardware (@Meilhl) before #444 is considered resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)