### PR TITLE
Improve debuggability of source/playback failures (#345)

### DIFF
--- a/pkg/client/websocket.go
+++ b/pkg/client/websocket.go
@@ -563,7 +563,11 @@ func (ws *WebSocketClient) handleEvent(event *models.WebSocketEvent) {
 	if !hasKnownEvent && handlers.OnUnknownEvent != nil {
 		handlers.OnUnknownEvent(event)
 	} else if !hasKnownEvent {
-		ws.logger.Printf("Received unknown event types: %v", eventTypes)
+		// Log the actual unmodeled element names (e.g. nowSelectionUpdated)
+		// rather than an empty list; skip frames that carry no child events.
+		if names := event.UnknownEventNames(); len(names) > 0 {
+			ws.logger.Printf("Received unhandled event types: %v", names)
+		}
 	}
 }
 

--- a/pkg/client/websocket.go
+++ b/pkg/client/websocket.go
@@ -566,7 +566,12 @@ func (ws *WebSocketClient) handleEvent(event *models.WebSocketEvent) {
 		// Log the actual unmodeled element names (e.g. nowSelectionUpdated)
 		// rather than an empty list; skip frames that carry no child events.
 		if names := event.UnknownEventNames(); len(names) > 0 {
-			ws.logger.Printf("Received unhandled event types: %v", names)
+			sanitizedNames := make([]string, 0, len(names))
+			for _, name := range names {
+				sanitizedNames = append(sanitizedNames, sanitizeLog(name))
+			}
+
+			ws.logger.Printf("Received unhandled event types: %v", sanitizedNames)
 		}
 	}
 }

--- a/pkg/models/websocket.go
+++ b/pkg/models/websocket.go
@@ -102,7 +102,28 @@ type WebSocketEvent struct {
 	ErrorUpdated           *ErrorUpdatedEvent           `xml:"errorUpdated,omitempty"`
 	RecentsUpdated         *RecentsUpdatedEvent         `xml:"recentsUpdated,omitempty"`
 	LanguageUpdated        *LanguageUpdatedEvent        `xml:"languageUpdated,omitempty"`
-	Timestamp              time.Time                    `json:"timestamp"` // Added by client for tracking
+	// UnknownElements captures <updates> children we don't model yet (e.g.
+	// nowSelectionUpdated), so callers can log them by name instead of an
+	// empty list when no known event matched.
+	UnknownElements []UnknownElement `xml:",any"`
+	Timestamp       time.Time        `json:"timestamp"` // Added by client for tracking
+}
+
+// UnknownElement records the tag name of an <updates> child element that the
+// WebSocketEvent struct does not (yet) model.
+type UnknownElement struct {
+	XMLName xml.Name
+}
+
+// UnknownEventNames returns the tag names of any unmodeled <updates> children,
+// for diagnostic logging.
+func (e *WebSocketEvent) UnknownEventNames() []string {
+	names := make([]string, 0, len(e.UnknownElements))
+	for _, u := range e.UnknownElements {
+		names = append(names, u.XMLName.Local)
+	}
+
+	return names
 }
 
 // GetEvents returns all events present in this WebSocket event

--- a/pkg/models/websocket_test.go
+++ b/pkg/models/websocket_test.go
@@ -540,3 +540,41 @@ func TestCreateMockWebSocketEvent(t *testing.T) {
 		t.Errorf("Event types don't match expected values")
 	}
 }
+
+// TestParseWebSocketEvent_UnknownElements verifies that an <updates> envelope
+// whose only child is an unmodeled element (e.g. nowSelectionUpdated, observed
+// on real SoundTouch 10 firmware) parses with no known event types but with
+// the element captured by name, so callers can log something useful instead
+// of an empty list.
+func TestParseWebSocketEvent_UnknownElements(t *testing.T) {
+	raw := []byte(`<updates deviceID="A81B6A536A98"><nowSelectionUpdated><preset id="0"><ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s308770" sourceAccount="" isPresetable="true"><itemName>Willy</itemName></ContentItem></preset></nowSelectionUpdated></updates>`)
+
+	event, err := ParseWebSocketEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent: %v", err)
+	}
+
+	if got := event.GetEventTypes(); len(got) != 0 {
+		t.Errorf("expected no known event types, got %v", got)
+	}
+
+	names := event.UnknownEventNames()
+	if len(names) != 1 || names[0] != "nowSelectionUpdated" {
+		t.Errorf("expected [nowSelectionUpdated], got %v", names)
+	}
+}
+
+// TestParseWebSocketEvent_KnownEventNoUnknowns confirms a modeled event is not
+// also captured as an unknown element.
+func TestParseWebSocketEvent_KnownEventNoUnknowns(t *testing.T) {
+	raw := []byte(`<updates deviceID="A81B6A536A98"><nowPlayingUpdated><nowPlaying deviceID="A81B6A536A98" source="TUNEIN"></nowPlaying></nowPlayingUpdated></updates>`)
+
+	event, err := ParseWebSocketEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent: %v", err)
+	}
+
+	if names := event.UnknownEventNames(); len(names) != 0 {
+		t.Errorf("expected no unknown elements for a modeled event, got %v", names)
+	}
+}

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -423,6 +423,8 @@ func (app *WebApp) handleSourceControl(w http.ResponseWriter, r *http.Request, d
 		return
 	}
 
+	logPlaybackRequest("source-select", chi.URLParam(r, "id"), sourceParam, accountParam, "", "")
+
 	err := device.Client.SelectSource(sourceParam, accountParam)
 	app.sendControlResponse(w, err, fmt.Sprintf("Selected source %s", sourceParam))
 }
@@ -1053,6 +1055,8 @@ func (app *WebApp) HandleDevicePlay(w http.ResponseWriter, r *http.Request) {
 		contentItem.SourceAccount = req.SourceAccount
 	}
 
+	logPlaybackRequest("device-play", deviceID, contentItem.Source, contentItem.SourceAccount, contentItem.Location, contentItem.ItemName)
+
 	if err := device.Client.SelectContentItem(contentItem); err != nil {
 		app.sendError(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -1127,6 +1131,8 @@ func (app *WebApp) HandlePlayURL(w http.ResponseWriter, r *http.Request) {
 		ItemName:     req.Name,
 		IsPresetable: true,
 	}
+
+	logPlaybackRequest("play-url", deviceID, contentItem.Source, contentItem.SourceAccount, contentItem.Location, contentItem.ItemName)
 
 	if err := device.Client.SelectContentItem(contentItem); err != nil {
 		app.sendError(w, err.Error(), http.StatusInternalServerError)
@@ -1220,11 +1226,15 @@ func (app *WebApp) HandlePlayRadioBrowser(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	if err := stations.Play(device.Client, stations.PlayItem{
+	ci := stations.ResolveContentItem(stations.PlayItem{
 		Provider: stations.ProviderRadioBrowser,
 		Location: req.Location,
 		Name:     req.Name,
-	}); err != nil {
+	})
+
+	logPlaybackRequest("radiobrowser", deviceID, ci.Source, ci.SourceAccount, ci.Location, ci.ItemName)
+
+	if err := device.Client.SelectContentItem(ci); err != nil {
 		app.sendError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -1272,13 +1282,17 @@ func (app *WebApp) HandlePlayTuneIn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := stations.Play(device.Client, stations.PlayItem{
+	ci := stations.ResolveContentItem(stations.PlayItem{
 		Provider:     stations.ProviderTuneIn,
 		Location:     req.Location,
 		Name:         req.Name,
 		Type:         req.Type,
 		ContainerArt: req.ContainerArt,
-	}); err != nil {
+	})
+
+	logPlaybackRequest("tunein", deviceID, ci.Source, ci.SourceAccount, ci.Location, ci.ItemName)
+
+	if err := device.Client.SelectContentItem(ci); err != nil {
 		app.sendError(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/pkg/service/soundtouchweb/logutil.go
+++ b/pkg/service/soundtouchweb/logutil.go
@@ -1,6 +1,9 @@
 package soundtouchweb
 
-import "strings"
+import (
+	"log"
+	"strings"
+)
 
 // sanitizeLog strips newline characters from s to prevent log-injection
 // (CodeQL go/log-injection). Values from speakers, HTTP requests, and
@@ -10,4 +13,46 @@ func sanitizeLog(s string) string {
 	s = strings.ReplaceAll(s, "\r", `\r`)
 
 	return s
+}
+
+// logPlaybackRequest records what soundtouch-web is about to ask a speaker to
+// play or switch to. A SoundTouch /select returns HTTP 200 even when the
+// source is ultimately rejected: the failure only surfaces afterwards as a
+// now_playing transition to an error source (see logNowPlayingError). So this
+// line is frequently the only record of what was actually requested, and the
+// pair (request here, error transition there) is what closes the loop when
+// diagnosing source/playback failures.
+//
+// sourceAccount here is an account identifier (e.g. "AUX1" for a specific jack,
+// or a placeholder username), not a bearer credential: the real OAuth tokens
+// live in the service datastore, not in the ContentItem sent on /select. It is
+// logged as-is so multi-account sources can be debugged.
+func logPlaybackRequest(action, deviceID, source, sourceAccount, location, itemName string) {
+	log.Printf("[play] %s device=%q source=%q sourceAccount=%q location=%q itemName=%q",
+		sanitizeLog(action),
+		sanitizeLog(deviceID),
+		sanitizeLog(source),
+		sanitizeLog(sourceAccount),
+		sanitizeLog(location),
+		sanitizeLog(itemName),
+	)
+}
+
+// isErrorSource reports whether a now_playing source value indicates the
+// speaker rejected or failed a selection rather than entering a normal state.
+// It covers INVALID_SOURCE and the family of *_ERROR sources the firmware
+// emits (e.g. UNKNOWN_SOURCE_ERROR).
+func isErrorSource(source string) bool {
+	return source == "INVALID_SOURCE" || strings.HasSuffix(source, "_ERROR")
+}
+
+// logNowPlayingError logs when a speaker's now_playing enters an error source.
+// Because /select returns 200 regardless, this asynchronous transition is the
+// real signal that a selection failed on the device.
+func logNowPlayingError(deviceID, source, sourceAccount string) {
+	log.Printf("[play] device=%q now_playing entered error source=%q sourceAccount=%q",
+		sanitizeLog(deviceID),
+		sanitizeLog(source),
+		sanitizeLog(sourceAccount),
+	)
 }

--- a/pkg/service/soundtouchweb/logutil_test.go
+++ b/pkg/service/soundtouchweb/logutil_test.go
@@ -1,0 +1,88 @@
+package soundtouchweb
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+)
+
+func TestIsErrorSource(t *testing.T) {
+	tests := []struct {
+		source string
+		want   bool
+	}{
+		{"INVALID_SOURCE", true},
+		{"UNKNOWN_SOURCE_ERROR", true},
+		{"INTERNET_RADIO_ERROR", true},
+		{"STANDBY", false},
+		{"TUNEIN", false},
+		{"AUX", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := isErrorSource(tt.source); got != tt.want {
+			t.Errorf("isErrorSource(%q) = %v, want %v", tt.source, got, tt.want)
+		}
+	}
+}
+
+// captureLog redirects the standard logger for the duration of f and returns
+// what was written.
+func captureLog(t *testing.T, f func()) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	prevOut := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+
+	t.Cleanup(func() {
+		log.SetOutput(prevOut)
+		log.SetFlags(prevFlags)
+	})
+
+	f()
+
+	return buf.String()
+}
+
+func TestLogPlaybackRequest(t *testing.T) {
+	out := captureLog(t, func() {
+		logPlaybackRequest("source-select", "DEVICEID01", "AUX", "AUX1", "", "")
+	})
+
+	for _, want := range []string{`[play]`, `source-select`, `device="DEVICEID01"`, `source="AUX"`, `sourceAccount="AUX1"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log output %q missing %q", out, want)
+		}
+	}
+}
+
+func TestLogPlaybackRequest_SanitizesNewlines(t *testing.T) {
+	out := captureLog(t, func() {
+		logPlaybackRequest("device-play", "DEVICEID01", "TUNEIN", "", "http://evil/\nINJECTED line", "Station")
+	})
+
+	if strings.Contains(out, "\nINJECTED") {
+		t.Errorf("log output not sanitized against newline injection: %q", out)
+	}
+	if !strings.Contains(out, `\nINJECTED`) {
+		t.Errorf("expected escaped newline in output, got %q", out)
+	}
+}
+
+func TestLogNowPlayingError(t *testing.T) {
+	out := captureLog(t, func() {
+		logNowPlayingError("DEVICEID01", "INVALID_SOURCE", "")
+	})
+
+	for _, want := range []string{`now_playing entered error`, `source="INVALID_SOURCE"`, `device="DEVICEID01"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log output %q missing %q", out, want)
+		}
+	}
+}

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -162,6 +162,10 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 
 	backoff := initialBackoff
 
+	// Tracks the last now_playing source seen so a speaker stuck reporting an
+	// error source is logged once per transition into it, not on every event.
+	var prevSource string
+
 	for {
 		wsClient := conn.Client.NewWebSocketClient(nil)
 
@@ -169,8 +173,19 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 		// UpdateStatus so concurrent events and the periodic poller
 		// (UpdateDeviceStatus) cannot lose each other's writes.
 		wsClient.OnNowPlaying(func(event *models.NowPlayingUpdatedEvent) {
+			np := &event.NowPlaying
+
+			// A /select returns 200 even when the source is rejected; the
+			// failure shows up here as a transition to an error source. Log it
+			// so it lands in a diagnostic export without needing a live trace.
+			if np.Source != prevSource && isErrorSource(np.Source) {
+				logNowPlayingError(deviceID, np.Source, np.SourceAccount)
+			}
+
+			prevSource = np.Source
+
 			conn.UpdateStatus(func(s *webtypes.DeviceStatus) {
-				s.NowPlaying = &event.NowPlaying
+				s.NowPlaying = np
 				s.LastActivity = time.Now()
 			})
 		})

--- a/pkg/service/stations/stations.go
+++ b/pkg/service/stations/stations.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gesellix/bose-soundtouch/pkg/client"
 	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/bmx"
 )
@@ -159,11 +158,4 @@ func ResolveContentItem(item PlayItem) *models.ContentItem {
 	}
 
 	return &ci
-}
-
-// Play builds a ContentItem via ResolveContentItem and sends it to the speaker via c.
-func Play(c *client.Client, item PlayItem) error {
-	ci := ResolveContentItem(item)
-
-	return c.SelectContentItem(ci)
 }


### PR DESCRIPTION
## Summary

Improves observability around source selection and playback in `soundtouch-web`, prompted by #345 (a speaker rejecting an internet-radio source with no server-side trace). A diagnostic export for that issue contained no record of the failed play, because the web control path goes straight to the speaker and a SoundTouch `/select` returns HTTP 200 even when the source is then rejected: the failure only surfaces asynchronously as a `now_playing` transition to an error source.

Two commits:

### `feat(web): log playback requests and now_playing error transitions`
- `logPlaybackRequest`: one line per play/select with the resolved `source`, `sourceAccount`, `location`, and `itemName`, from all five handlers (`source-select`, `device-play`, `play-url`, `radiobrowser`, `tunein`). Often the only record of what was actually requested. `sourceAccount` here is an account identifier (e.g. `AUX1`), not a bearer credential, and is sanitised for log injection.
- `logNowPlayingError`: logs when a device's `now_playing` enters an error source (`INVALID_SOURCE` or any `*_ERROR`), deduped per transition. This is the real signal that a selection failed on the speaker.
- The TuneIn/RadioBrowser handlers now resolve the `ContentItem` via `stations.ResolveContentItem` and select it directly, so the log shows the authoritative outgoing source. The now-unused `stations.Play` wrapper is removed.

Confirmed along the way: TuneIn sends `source="TUNEIN"`, RadioBrowser sends `source="URL"` — neither emits `INTERNET_RADIO`, so a `source="INTERNET_RADIO"` could only arrive via `device-play` (a browser-supplied recents/preset replay). The new logging will pin that down on the next report.

### `fix(client): log unhandled WebSocket event names instead of empty list`
An `<updates>` frame whose only child is an unmodeled element (e.g. `nowSelectionUpdated`, sent by SoundTouch 10 firmware) produced no known event types, so `handleEvent` logged `Received unknown event types: []` repeatedly — noise that also polluted the `soundtouch-cli events subscribe` output we point people at for debugging. Now an `xml:",any"` catch-all captures unmodeled `<updates>` children by name and logs `Received unhandled event types: [nowSelectionUpdated]`, staying silent on childless frames. A regression test confirms a modeled event is not also captured as unknown.

## Verification
`gofmt`, `go build ./...`, `go vet`, full `go test ./...`, and `make lint` (0 issues) all clean. Verified live: the `[play]` line and the named `[nowSelectionUpdated]` log both appear in a running `soundtouch-web`, and the `[]` flood is gone.

## Follow-up (not in this PR)
Modeling `nowSelectionUpdated` as a typed event (it carries the selected preset + ContentItem) is left as a separate enhancement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)