### PR TITLE
feat(health): DNS-path and speaker-clock diagnostics for the #345 failure mode

### DIFF
--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1287,6 +1287,8 @@ func setupRouter(server *handlers.Server, stockholmHandler *stockholm.Handler) *
 		// validated the app_key against its cloud; as the cloud replacement we
 		// accept it (200). A 404 here makes the speaker report "invalid app key"
 		// (HandleInvalidAppKeyCb) and refuse TTS/URL notifications.
+		// When an active DNS-path probe is running (POST /setup/health/dns-path-probe),
+		// a matching probe nonce returns 403 instead so no audio plays.
 		r.Get("/auth", server.HandleSpeakerAuth)
 	})
 
@@ -1379,6 +1381,7 @@ func setupRouter(server *handlers.Server, stockholmHandler *stockholm.Handler) *
 
 		r.Get("/health", server.HandleHealthChecks)
 		r.Post("/health/fix", server.HandleHealthFix)
+		r.Post("/health/dns-path-probe", server.HandleDNSPathProbe)
 		r.Get("/export/diagnostic", server.HandleExportDiagnostic)
 		r.Get("/logs", server.HandleGetLogs)
 

--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -141,6 +141,7 @@ POST     /setup/backup/{deviceId}                                     handlers.(
 POST     /setup/devices                                               handlers.(*Server).HandleAddManualDevice-fm
 POST     /setup/discover                                              handlers.(*Server).HandleTriggerDiscovery-fm
 POST     /setup/ensure-remote-services/{deviceId}                     handlers.(*Server).HandleEnsureRemoteServices-fm
+POST     /setup/health/dns-path-probe                                 handlers.(*Server).HandleDNSPathProbe-fm
 POST     /setup/health/fix                                            handlers.(*Server).HandleHealthFix-fm
 POST     /setup/logging-settings                                      handlers.(*Server).HandleUpdateLoggingSettings-fm
 POST     /setup/migrate/{deviceId}                                    handlers.(*Server).HandleMigrateDevice-fm

--- a/pkg/discovery/dns.go
+++ b/pkg/discovery/dns.go
@@ -29,8 +29,9 @@ type DNSDiscovery struct {
 	derivedHosts []string
 
 	// State
-	discovered map[string]*DiscoveredHost
-	mu         sync.RWMutex
+	discovered       map[string]*DiscoveredHost
+	interceptClients map[string]time.Time
+	mu               sync.RWMutex
 
 	// Callbacks
 	onNewDiscovery func(hostname string)
@@ -73,12 +74,13 @@ func NewDNSDiscovery(upstreamDNS []string, serviceIP, serverURL string) *DNSDisc
 	}
 
 	return &DNSDiscovery{
-		upstreamDNS:  upstreamDNS,
-		serviceIP:    serviceIP,
-		derivedHosts: derived,
-		discovered:   make(map[string]*DiscoveredHost),
-		timeout:      2 * time.Second,
-		lastLog:      make(map[string]time.Time),
+		upstreamDNS:      upstreamDNS,
+		serviceIP:        serviceIP,
+		derivedHosts:     derived,
+		discovered:       make(map[string]*DiscoveredHost),
+		interceptClients: make(map[string]time.Time),
+		timeout:          2 * time.Second,
+		lastLog:          make(map[string]time.Time),
 	}
 }
 
@@ -219,6 +221,21 @@ func (d *DNSDiscovery) recordQuery(hostname string, isIntercepted bool, remoteAd
 		host.IsIntercepted = isIntercepted
 		if remoteAddr != "" {
 			host.RemoteAddr = remoteAddr
+		}
+	}
+
+	// Track distinct non-loopback clients that queried an intercepted hostname.
+	// Used by the dns_speaker_usage health check to detect whether any speaker
+	// actually resolves Bose hostnames through AfterTouch's DNS interceptor.
+	if isIntercepted && remoteAddr != "" {
+		clientHost, _, err := net.SplitHostPort(remoteAddr)
+		if err != nil {
+			// remoteAddr doesn't parse as host:port; use as-is.
+			clientHost = remoteAddr
+		}
+
+		if ip := net.ParseIP(clientHost); ip != nil && !ip.IsLoopback() {
+			d.interceptClients[clientHost] = time.Now()
 		}
 	}
 }
@@ -428,6 +445,24 @@ func (d *DNSDiscovery) GetDiscovered() map[string]*DiscoveredHost {
 	// Return copy
 	result := make(map[string]*DiscoveredHost)
 	for k, v := range d.discovered {
+		result[k] = v
+	}
+
+	return result
+}
+
+// InterceptClientIPs returns a copy of the set of non-loopback client IPs
+// that have queried an intercepted Bose hostname. The value for each key is
+// the timestamp of the most recent intercepted query from that client.
+// Empty map means no non-loopback speaker has ever used AfterTouch's DNS
+// interceptor. Callers receive a snapshot; the map is safe to read after
+// this method returns.
+func (d *DNSDiscovery) InterceptClientIPs() map[string]time.Time {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	result := make(map[string]time.Time, len(d.interceptClients))
+	for k, v := range d.interceptClients {
 		result[k] = v
 	}
 

--- a/pkg/discovery/dns_test.go
+++ b/pkg/discovery/dns_test.go
@@ -545,3 +545,84 @@ func TestDNSDiscovery_UnresolvableHostname(t *testing.T) {
 		t.Errorf("Expected CNAME record for unresolvable hostname, got %T", rw.msg.Answer[0])
 	}
 }
+
+// mockResponseWriterWithAddr is like mockResponseWriter but returns a
+// configurable remote address; used to simulate queries from speaker IPs.
+type mockResponseWriterWithAddr struct {
+	mockResponseWriter
+	remote net.Addr
+}
+
+func (m *mockResponseWriterWithAddr) RemoteAddr() net.Addr { return m.remote }
+
+// mockUDPAddr implements net.Addr for test purposes.
+type mockUDPAddr struct{ addr string }
+
+func (a *mockUDPAddr) Network() string { return "udp" }
+func (a *mockUDPAddr) String() string  { return a.addr }
+
+func TestDNSDiscovery_InterceptClientTracking_NonLoopback(t *testing.T) {
+	d := NewDNSDiscovery([]string{"8.8.8.8"}, "192.0.2.100", "")
+
+	// Query for an intercepted Bose hostname from a non-loopback address.
+	msg := new(dns.Msg)
+	msg.SetQuestion("content.api.bose.io.", dns.TypeA)
+
+	rw := &mockResponseWriterWithAddr{
+		remote: &mockUDPAddr{addr: "10.1.103.209:54321"},
+	}
+	d.ServeDNS(rw, msg)
+
+	clients := d.InterceptClientIPs()
+	if _, ok := clients["10.1.103.209"]; !ok {
+		t.Errorf("expected 10.1.103.209 in interceptClients, got %v", clients)
+	}
+}
+
+func TestDNSDiscovery_InterceptClientTracking_LoopbackExcluded(t *testing.T) {
+	d := NewDNSDiscovery([]string{"8.8.8.8"}, "192.0.2.100", "")
+
+	// Query for an intercepted hostname from loopback (health-probe scenario).
+	msg := new(dns.Msg)
+	msg.SetQuestion("api.bose.com.", dns.TypeA)
+
+	rw := &mockResponseWriterWithAddr{
+		remote: &mockUDPAddr{addr: "127.0.0.1:55069"},
+	}
+	d.ServeDNS(rw, msg)
+
+	clients := d.InterceptClientIPs()
+	if len(clients) != 0 {
+		t.Errorf("expected no clients (loopback should be excluded), got %v", clients)
+	}
+}
+
+func TestDNSDiscovery_InterceptClientTracking_NonInterceptedNotRecorded(t *testing.T) {
+	// Forwarded (non-intercepted) queries should not populate interceptClients.
+	upstreamMux := dns.NewServeMux()
+	upstreamMux.HandleFunc("google.com.", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		_ = w.WriteMsg(m)
+	})
+	ts := &dns.Server{Addr: "127.0.0.1:5360", Net: "udp", Handler: upstreamMux,
+		ReadTimeout: 100 * time.Millisecond, WriteTimeout: 100 * time.Millisecond}
+	go func() { _ = ts.ListenAndServe() }()
+	defer func() { _ = ts.Shutdown() }()
+	time.Sleep(100 * time.Millisecond)
+
+	d := NewDNSDiscovery([]string{"127.0.0.1:5360"}, "192.0.2.100", "")
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("google.com.", dns.TypeA)
+
+	rw := &mockResponseWriterWithAddr{
+		remote: &mockUDPAddr{addr: "10.1.103.209:54321"},
+	}
+	d.ServeDNS(rw, msg)
+
+	clients := d.InterceptClientIPs()
+	if len(clients) != 0 {
+		t.Errorf("expected no intercept clients for non-intercepted query, got %v", clients)
+	}
+}

--- a/pkg/service/handlers/auth_probe.go
+++ b/pkg/service/handlers/auth_probe.go
@@ -1,0 +1,276 @@
+package handlers
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/client"
+)
+
+const (
+	defaultAuthProbeTTL     = 30 * time.Second
+	defaultAuthProbeTimeout = 8 * time.Second
+	authProbePollInterval   = 200 * time.Millisecond
+)
+
+// authProbe holds the state for a single active DNS-path probe.
+type authProbe struct {
+	Nonce        string
+	DeviceID     string
+	TargetIP     string // datastore IP the notification was sent to
+	CreatedAt    time.Time
+	ExpiresAt    time.Time
+	ObservedFrom string    // source IP of the /v1/auth callback (set on hit)
+	ObservedAt   time.Time // zero until observed
+}
+
+// authProbeRegistry is an in-memory, mutex-guarded registry of active probes.
+// Expired entries are pruned opportunistically on each write operation.
+type authProbeRegistry struct {
+	mu     sync.Mutex
+	active map[string]*authProbe // nonce -> probe
+	ttl    time.Duration         // default defaultAuthProbeTTL; injectable for tests
+}
+
+// newAuthProbeRegistry creates a new registry with the given ttl.
+func newAuthProbeRegistry(ttl time.Duration) *authProbeRegistry {
+	if ttl <= 0 {
+		ttl = defaultAuthProbeTTL
+	}
+
+	return &authProbeRegistry{
+		active: make(map[string]*authProbe),
+		ttl:    ttl,
+	}
+}
+
+// pruneExpired removes expired entries. Caller must hold r.mu.
+func (r *authProbeRegistry) pruneExpired() {
+	now := time.Now()
+
+	for nonce, p := range r.active {
+		if now.After(p.ExpiresAt) {
+			delete(r.active, nonce)
+		}
+	}
+}
+
+// register stores a new probe. Prunes expired entries first.
+func (r *authProbeRegistry) register(nonce, deviceID, targetIP string) {
+	now := time.Now()
+	p := &authProbe{
+		Nonce:     nonce,
+		DeviceID:  deviceID,
+		TargetIP:  targetIP,
+		CreatedAt: now,
+		ExpiresAt: now.Add(r.ttl),
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.pruneExpired()
+	r.active[nonce] = p
+}
+
+// observe marks the probe as observed if the nonce matches an active,
+// non-expired entry. Returns true if the probe was found and recorded.
+// No loopback filtering: every matching callback is a genuine probe
+// response by construction, and tests drive it from loopback.
+func (r *authProbeRegistry) observe(nonce, sourceIP string) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, ok := r.active[nonce]
+	if !ok {
+		return false
+	}
+
+	if time.Now().After(p.ExpiresAt) {
+		return false
+	}
+
+	p.ObservedFrom = sourceIP
+	p.ObservedAt = time.Now()
+
+	return true
+}
+
+// get returns a snapshot of the probe for the given nonce, or false if not present.
+func (r *authProbeRegistry) get(nonce string) (*authProbe, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	p, ok := r.active[nonce]
+	if !ok {
+		return nil, false
+	}
+
+	// Return a copy so the caller never races on the struct fields.
+	snapshot := *p
+
+	return &snapshot, true
+}
+
+// deregister removes the probe after it completes.
+func (r *authProbeRegistry) deregister(nonce string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	delete(r.active, nonce)
+}
+
+// generateNonce returns a 32-char hex-encoded random nonce prefixed with "atp_".
+func generateNonce() (string, error) {
+	buf := make([]byte, 16)
+
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate nonce: %w", err)
+	}
+
+	return "atp_" + hex.EncodeToString(buf), nil
+}
+
+// clientHostFromRemoteAddr extracts the host part from a "host:port" RemoteAddr.
+// If parsing fails it returns the raw value unchanged.
+func clientHostFromRemoteAddr(remoteAddr string) string {
+	if host, _, err := net.SplitHostPort(remoteAddr); err == nil {
+		return host
+	}
+
+	return remoteAddr
+}
+
+// dnsProbeSpeakerRequest is the JSON body for POST /setup/health/dns-path-probe.
+type dnsProbeSpeakerRequest struct {
+	DeviceID string `json:"deviceId,omitempty"`
+	Host     string `json:"host,omitempty"`
+}
+
+// dnsProbeSpeakerResponse is the JSON response body for the dns-path probe.
+type dnsProbeSpeakerResponse struct {
+	Success      bool    `json:"success"`
+	ObservedFrom string  `json:"observedFrom,omitempty"`
+	LatencyMs    float64 `json:"latencyMs,omitempty"`
+	NATOrProxy   bool    `json:"natOrProxy,omitempty"`
+	Reason       string  `json:"reason,omitempty"`
+	Remediation  string  `json:"remediation,omitempty"`
+}
+
+// runDNSPathProbe contains the core probe logic: resolve the target IP,
+// register the nonce, send the PlayURL notification, poll for the /v1/auth
+// callback up to the configured timeout, deregister the nonce, and return the
+// result. It is the shared implementation used by both HandleDNSPathProbe and
+// the health QuickFix registered in server.go.
+func (s *Server) runDNSPathProbe(deviceID, host string) (dnsProbeSpeakerResponse, error) {
+	// Reuse resolveTTSHost for SSRF-safe target resolution (always a datastore IP).
+	targetIP, err := s.resolveTTSHost(ttsSpeakRequest{
+		DeviceID: deviceID,
+		Host:     host,
+	})
+	if err != nil {
+		return dnsProbeSpeakerResponse{}, err
+	}
+
+	nonce, err := generateNonce()
+	if err != nil {
+		return dnsProbeSpeakerResponse{}, fmt.Errorf("failed to generate probe nonce: %w", err)
+	}
+
+	// Register BEFORE sending the notification so a fast callback matches.
+	s.authProbes.register(nonce, deviceID, targetIP)
+
+	defer s.authProbes.deregister(nonce)
+
+	// Build the probe URL using the service's own base URL. The speaker
+	// refuses the notification on 403 before fetching this URL.
+	probeURL := s.serverURL + "/media/tts/dns-probe"
+
+	c := client.NewClientFromHost(targetIP)
+
+	if err := c.PlayURL(probeURL, nonce, "AfterTouch DNS probe", "DNS path probe", ""); err != nil {
+		return dnsProbeSpeakerResponse{
+			Success: false,
+			Reason:  "speaker unreachable or notification not accepted: " + err.Error(),
+		}, nil
+	}
+
+	// Determine the polling timeout: use injected value or default.
+	timeout := s.authProbeTimeout()
+	deadline := time.Now().Add(timeout)
+
+	for {
+		p, ok := s.authProbes.get(nonce)
+		if ok && !p.ObservedAt.IsZero() {
+			latency := p.ObservedAt.Sub(p.CreatedAt).Seconds() * 1000
+
+			return dnsProbeSpeakerResponse{
+				Success:      true,
+				ObservedFrom: p.ObservedFrom,
+				LatencyMs:    latency,
+				NATOrProxy:   p.ObservedFrom != targetIP,
+			}, nil
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+
+		time.Sleep(authProbePollInterval)
+	}
+
+	// Timeout path: notification was accepted but no /v1/auth callback arrived.
+	return dnsProbeSpeakerResponse{
+		Success: false,
+		Reason:  "notification accepted but no /v1/auth callback received within timeout",
+		Remediation: "The speaker likely resolves Bose hostnames via a different DNS resolver, " +
+			"not AfterTouch's DNS server. " +
+			"To fix: point speakers at AfterTouch's DNS server via DHCP option 6, " +
+			"configure the upstream resolvers to forward Bose zones to AfterTouch, " +
+			"or re-run migration with the resolv method.",
+	}, nil
+}
+
+// HandleDNSPathProbe actively tests whether a specific speaker resolves Bose
+// hostnames through AfterTouch's DNS by sending a /speaker notification with
+// a per-probe nonce as the app_key and waiting for the speaker to call back
+// at GET /v1/auth with that nonce in the Apikeyheader header.
+//
+// POST /setup/health/dns-path-probe
+// Body: {"deviceId":"...","host":"..."}
+func (s *Server) HandleDNSPathProbe(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+
+	var req dnsProbeSpeakerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"invalid JSON body"}`, http.StatusBadRequest)
+		return
+	}
+
+	resp, err := s.runDNSPathProbe(req.DeviceID, req.Host)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadRequest)
+		return
+	}
+
+	if encErr := json.NewEncoder(w).Encode(resp); encErr != nil {
+		http.Error(w, "failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// authProbeTimeout returns the configured probe timeout for polling. It reads
+// the unexported field so tests can inject a short value without a setter.
+// Falls back to the default when the field is zero.
+func (s *Server) authProbeTimeout() time.Duration {
+	if s.authProbeTimeoutOverride > 0 {
+		return s.authProbeTimeoutOverride
+	}
+
+	return defaultAuthProbeTimeout
+}

--- a/pkg/service/handlers/auth_probe_test.go
+++ b/pkg/service/handlers/auth_probe_test.go
@@ -1,0 +1,449 @@
+package handlers
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// --- Registry unit tests ---
+
+func TestAuthProbeRegistry_RegisterAndGet(t *testing.T) {
+	reg := newAuthProbeRegistry(5 * time.Second)
+	reg.register("nonce1", "DEVICEID01", "192.0.2.10")
+
+	p, ok := reg.get("nonce1")
+	if !ok {
+		t.Fatal("expected probe to be found")
+	}
+
+	if p.Nonce != "nonce1" {
+		t.Errorf("nonce = %q, want nonce1", p.Nonce)
+	}
+
+	if p.DeviceID != "DEVICEID01" {
+		t.Errorf("deviceID = %q, want DEVICEID01", p.DeviceID)
+	}
+
+	if p.TargetIP != "192.0.2.10" {
+		t.Errorf("targetIP = %q, want 192.0.2.10", p.TargetIP)
+	}
+}
+
+func TestAuthProbeRegistry_ObserveMatch(t *testing.T) {
+	reg := newAuthProbeRegistry(5 * time.Second)
+	reg.register("nonce1", "DEVICEID01", "192.0.2.10")
+
+	matched := reg.observe("nonce1", "192.0.2.10")
+	if !matched {
+		t.Fatal("expected observe to match")
+	}
+
+	p, ok := reg.get("nonce1")
+	if !ok {
+		t.Fatal("expected probe to still be present")
+	}
+
+	if p.ObservedFrom != "192.0.2.10" {
+		t.Errorf("observedFrom = %q, want 192.0.2.10", p.ObservedFrom)
+	}
+
+	if p.ObservedAt.IsZero() {
+		t.Error("observedAt is zero, expected a timestamp")
+	}
+}
+
+func TestAuthProbeRegistry_ObserveNoMatch(t *testing.T) {
+	reg := newAuthProbeRegistry(5 * time.Second)
+	reg.register("nonce1", "DEVICEID01", "192.0.2.10")
+
+	matched := reg.observe("wrong-nonce", "192.0.2.10")
+	if matched {
+		t.Fatal("expected observe to not match for unknown nonce")
+	}
+}
+
+func TestAuthProbeRegistry_ObserveExpired(t *testing.T) {
+	reg := newAuthProbeRegistry(1 * time.Millisecond)
+	reg.register("nonce1", "DEVICEID01", "192.0.2.10")
+
+	time.Sleep(10 * time.Millisecond)
+
+	matched := reg.observe("nonce1", "192.0.2.10")
+	if matched {
+		t.Fatal("expected observe to not match for expired nonce")
+	}
+}
+
+func TestAuthProbeRegistry_Deregister(t *testing.T) {
+	reg := newAuthProbeRegistry(5 * time.Second)
+	reg.register("nonce1", "DEVICEID01", "192.0.2.10")
+	reg.deregister("nonce1")
+
+	_, ok := reg.get("nonce1")
+	if ok {
+		t.Fatal("expected probe to be gone after deregister")
+	}
+}
+
+func TestAuthProbeRegistry_PrunesExpired(t *testing.T) {
+	reg := newAuthProbeRegistry(1 * time.Millisecond)
+	reg.register("old", "DEV01", "192.0.2.10")
+
+	time.Sleep(10 * time.Millisecond)
+
+	// Registering a new entry triggers pruning of expired ones.
+	reg.register("new", "DEV02", "192.0.2.11")
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	if _, found := reg.active["old"]; found {
+		t.Error("expected expired entry 'old' to be pruned")
+	}
+
+	if _, found := reg.active["new"]; !found {
+		t.Error("expected new entry to be present")
+	}
+}
+
+// --- HandleSpeakerAuth tests ---
+
+func probeAuthRouter(t *testing.T) (*Server, *http.ServeMux) {
+	t.Helper()
+
+	ds := datastore.NewDataStore(t.TempDir())
+	server := NewServer(ds, nil, "http://localhost:8001", false, false, false)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/auth", server.HandleSpeakerAuth)
+
+	return server, mux
+}
+
+func TestHandleSpeakerAuth_EmptyHeader(t *testing.T) {
+	_, mux := probeAuthRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandleSpeakerAuth_UnknownToken(t *testing.T) {
+	_, mux := probeAuthRouter(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth", nil)
+	req.Header.Set("Apikeyheader", "aftertouch")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for unknown token", rec.Code)
+	}
+}
+
+func TestHandleSpeakerAuth_MatchingNonce_Returns403(t *testing.T) {
+	server, mux := probeAuthRouter(t)
+
+	// Register a probe nonce.
+	server.authProbes.register("atp_testfixednonce", "DEVICEID01", "192.0.2.10")
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth", nil)
+	req.Header.Set("Apikeyheader", "atp_testfixednonce")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for matching probe nonce", rec.Code)
+	}
+
+	// Also confirm the probe was recorded.
+	p, ok := server.authProbes.get("atp_testfixednonce")
+	if !ok {
+		t.Fatal("expected probe to still be in registry")
+	}
+
+	if p.ObservedAt.IsZero() {
+		t.Error("expected ObservedAt to be set")
+	}
+}
+
+func TestHandleSpeakerAuth_ExpiredNonce_Returns200(t *testing.T) {
+	server, mux := probeAuthRouter(t)
+
+	// Register with a very short TTL.
+	server.authProbes = newAuthProbeRegistry(1 * time.Millisecond)
+	server.authProbes.register("atp_expirednonce", "DEVICEID01", "192.0.2.10")
+
+	time.Sleep(10 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth", nil)
+	req.Header.Set("Apikeyheader", "atp_expirednonce")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for expired nonce", rec.Code)
+	}
+}
+
+// --- End-to-end loop test ---
+
+// fakeSpeaker is an httptest server that:
+//  1. On POST /speaker: parses the app_key from the PlayInfo XML and calls
+//     GET /v1/auth on afterTouchURL with Apikeyheader set to that key.
+//  2. Returns 200 for the /speaker request.
+func fakeSpeaker(t *testing.T, afterTouchURL string) *httptest.Server {
+	t.Helper()
+
+	var callCount int32
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/speaker" {
+			http.NotFound(w, r)
+			return
+		}
+
+		atomic.AddInt32(&callCount, 1)
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read error", http.StatusInternalServerError)
+			return
+		}
+
+		var play models.PlayInfo
+		if err := xml.Unmarshal(body, &play); err != nil {
+			http.Error(w, "xml parse error", http.StatusInternalServerError)
+			return
+		}
+
+		// Simulate the speaker calling back /v1/auth on AfterTouch.
+		authReq, err := http.NewRequest(http.MethodGet, afterTouchURL+"/v1/auth", nil)
+		if err != nil {
+			http.Error(w, "build auth req error", http.StatusInternalServerError)
+			return
+		}
+
+		authReq.Header.Set("Apikeyheader", play.AppKey)
+		_, _ = http.DefaultClient.Do(authReq) //nolint:bodyclose
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<status>OK</status>"))
+	}))
+}
+
+// probeRouter builds a minimal router with the probe and auth endpoints.
+func probeRouter(t *testing.T, server *Server) *http.ServeMux {
+	t.Helper()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/setup/health/dns-path-probe", server.HandleDNSPathProbe)
+	mux.HandleFunc("/v1/auth", server.HandleSpeakerAuth)
+
+	return mux
+}
+
+func TestHandleDNSPathProbe_EndToEnd_Success(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	if err := ds.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// We need the AfterTouch test server URL to give to the fake speaker.
+	// Use a two-step approach: create the server first, then wire up the URL.
+	server := NewServer(ds, nil, "http://placeholder", false, false, false)
+	server.authProbes = newAuthProbeRegistry(5 * time.Second)
+	server.authProbeTimeoutOverride = 3 * time.Second
+
+	atServer := httptest.NewServer(probeRouter(t, server))
+	defer atServer.Close()
+
+	// Update server to know its own URL (needed for the probe URL construction).
+	server.serverURL = atServer.URL
+
+	// Fake speaker that calls /v1/auth on the AfterTouch test server.
+	speaker := fakeSpeaker(t, atServer.URL)
+	defer speaker.Close()
+
+	// Extract the speaker's host:port.
+	speakerHost := strings.TrimPrefix(speaker.URL, "http://")
+
+	// Register the speaker as a known device so resolveTTSHost accepts it.
+	if err := ds.SaveDeviceInfo("1000001", "DEVICEID01", &models.ServiceDeviceInfo{
+		DeviceID:  "DEVICEID01",
+		AccountID: "1000001",
+		IPAddress: speakerHost,
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	body := `{"deviceId":"DEVICEID01"}`
+	req := httptest.NewRequest(http.MethodPost, "/setup/health/dns-path-probe", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	http.HandlerFunc(server.HandleDNSPathProbe).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp dnsProbeSpeakerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body: %s", err, rec.Body.String())
+	}
+
+	if !resp.Success {
+		t.Errorf("success = false, want true; reason: %s", resp.Reason)
+	}
+
+	if resp.ObservedFrom == "" {
+		t.Error("observedFrom is empty, expected a source IP")
+	}
+}
+
+func TestHandleDNSPathProbe_Timeout_NoCallback(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	if err := ds.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// A fake speaker that accepts /speaker but never calls /v1/auth back.
+	silentSpeaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/speaker" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("<status>OK</status>"))
+			return
+		}
+
+		http.NotFound(w, r)
+	}))
+	defer silentSpeaker.Close()
+
+	speakerHost := strings.TrimPrefix(silentSpeaker.URL, "http://")
+
+	server := NewServer(ds, nil, "http://localhost:8001", false, false, false)
+	server.authProbes = newAuthProbeRegistry(5 * time.Second)
+	server.authProbeTimeoutOverride = 300 * time.Millisecond // fast timeout for tests
+
+	if err := ds.SaveDeviceInfo("1000001", "DEVICEID01", &models.ServiceDeviceInfo{
+		DeviceID:  "DEVICEID01",
+		AccountID: "1000001",
+		IPAddress: speakerHost,
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	body := `{"deviceId":"DEVICEID01"}`
+	req := httptest.NewRequest(http.MethodPost, "/setup/health/dns-path-probe", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	http.HandlerFunc(server.HandleDNSPathProbe).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp dnsProbeSpeakerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body: %s", err, rec.Body.String())
+	}
+
+	if resp.Success {
+		t.Error("success = true, want false (speaker never called back)")
+	}
+
+	if resp.Remediation == "" {
+		t.Error("remediation is empty, expected a hint")
+	}
+}
+
+func TestHandleDNSPathProbe_SpeakerUnreachable(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	if err := ds.Initialize(); err != nil {
+		t.Fatalf("Initialize: %v", err)
+	}
+
+	// Find a loopback port with nothing listening so the TCP dial fails fast
+	// (connection refused). We must register it as a known device first.
+	closedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {}))
+	closedAddr := strings.TrimPrefix(closedServer.URL, "http://")
+	closedServer.Close() // immediately close so the port becomes unreachable
+
+	if err := ds.SaveDeviceInfo("1000001", "DEVICEID01", &models.ServiceDeviceInfo{
+		DeviceID:  "DEVICEID01",
+		AccountID: "1000001",
+		IPAddress: closedAddr,
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	server := NewServer(ds, nil, "http://localhost:8001", false, false, false)
+	server.authProbes = newAuthProbeRegistry(5 * time.Second)
+	server.authProbeTimeoutOverride = 300 * time.Millisecond
+
+	body := `{"deviceId":"DEVICEID01"}`
+	req := httptest.NewRequest(http.MethodPost, "/setup/health/dns-path-probe", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	http.HandlerFunc(server.HandleDNSPathProbe).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp dnsProbeSpeakerResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v; body: %s", err, rec.Body.String())
+	}
+
+	if resp.Success {
+		t.Error("success = true, want false (speaker unreachable)")
+	}
+
+	if !strings.Contains(resp.Reason, "speaker unreachable") {
+		t.Errorf("reason = %q, want it to mention 'speaker unreachable'", resp.Reason)
+	}
+}
+
+func TestHandleDNSPathProbe_InvalidBody(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	server := NewServer(ds, nil, "http://localhost:8001", false, false, false)
+
+	req := httptest.NewRequest(http.MethodPost, "/setup/health/dns-path-probe", strings.NewReader(`not json`))
+	rec := httptest.NewRecorder()
+
+	http.HandlerFunc(server.HandleDNSPathProbe).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}
+
+func TestHandleDNSPathProbe_UnknownDevice(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	server := NewServer(ds, nil, "http://localhost:8001", false, false, false)
+
+	body := `{"deviceId":"NOPE"}`
+	req := httptest.NewRequest(http.MethodPost, "/setup/health/dns-path-probe", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	http.HandlerFunc(server.HandleDNSPathProbe).ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+}

--- a/pkg/service/handlers/handlers_tts.go
+++ b/pkg/service/handlers/handlers_tts.go
@@ -142,7 +142,25 @@ func buildCustomPlaybackURL(base, audioURL, name string) string {
 // sufficient; real Bose validated against its cloud, but as the cloud
 // replacement we always accept, so the speaker doesn't report an invalid app
 // key (HandleInvalidAppKeyCb) and refuse the notification.
-func (s *Server) HandleSpeakerAuth(w http.ResponseWriter, _ *http.Request) {
+//
+// When an active DNS-path probe is running (HandleDNSPathProbe), the probe
+// registers its nonce as the app_key. If the nonce matches, this handler
+// returns 403 so the speaker treats the key as invalid and refuses the
+// notification (no audio plays). The callback arrival itself already proved
+// the speaker resolved a Bose host through AfterTouch's DNS.
+func (s *Server) HandleSpeakerAuth(w http.ResponseWriter, r *http.Request) {
+	token := r.Header.Get("Apikeyheader")
+	if token != "" && s.authProbes != nil {
+		if s.authProbes.observe(token, clientHostFromRemoteAddr(r.RemoteAddr)) {
+			// Active DNS-path probe: the callback arrival already proved the
+			// speaker resolved a Bose host through AfterTouch. Returning 403
+			// makes the speaker treat the key as invalid and refuse the
+			// notification, so no audio plays.
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+	}
+	// Normal path: accept any app_key so real TTS/URL notifications proceed.
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -35,51 +35,53 @@ import (
 
 // Server handles HTTP requests for the SoundTouch service.
 type Server struct {
-	ds                  *datastore.DataStore
-	sm                  *setup.Manager
-	mu                  sync.RWMutex
-	serverURL           string
-	httpsServerURL      string
-	discovering         bool
-	redactLogs          bool
-	logBodies           bool
-	recordEnabled       bool
-	discoveryInterval   time.Duration
-	discoveryEnabled    bool
-	dnsEnabled          bool
-	dnsUpstream         []string
-	dnsBindAddr         string
-	internalPaths       []string
-	shortcuts           map[string]int
-	recorder            *proxy.Recorder
-	dnsDiscovery        *discovery.DNSDiscovery
-	Version             string
-	Commit              string
-	Date                string
-	RepoURL             string
-	mgmtUsername        string
-	mgmtPassword        string
-	spotifyClientID     string
-	spotifyClientSecret string
-	spotifyRedirectURI  string
-	spotifyService      *spotify.Service
-	amazonClientID      string
-	amazonClientSecret  string
-	amazonRedirectURI   string
-	amazonService       *amazon.Service
-	ttsService          *tts.Service
-	ttsProvider         string
-	ttsGoogleAPIKey     string
-	ttsGoogleEndpoint   string // test-only override; not exposed in the UI
-	ttsAppKey           string
-	ttsLanguage         string
-	ttsVoice            string
-	ttsVolume           int
-	peerObserver        *peerObserver
-	healthRegistry      *health.Registry
-	logBuf              *logbuf.Buffer
-	expectedHosts       []string
-	ownCACache          struct {
+	ds                       *datastore.DataStore
+	sm                       *setup.Manager
+	mu                       sync.RWMutex
+	serverURL                string
+	httpsServerURL           string
+	discovering              bool
+	redactLogs               bool
+	logBodies                bool
+	recordEnabled            bool
+	discoveryInterval        time.Duration
+	discoveryEnabled         bool
+	dnsEnabled               bool
+	dnsUpstream              []string
+	dnsBindAddr              string
+	internalPaths            []string
+	shortcuts                map[string]int
+	recorder                 *proxy.Recorder
+	dnsDiscovery             *discovery.DNSDiscovery
+	authProbes               *authProbeRegistry
+	authProbeTimeoutOverride time.Duration // zero means use defaultAuthProbeTimeout; injectable for tests
+	Version                  string
+	Commit                   string
+	Date                     string
+	RepoURL                  string
+	mgmtUsername             string
+	mgmtPassword             string
+	spotifyClientID          string
+	spotifyClientSecret      string
+	spotifyRedirectURI       string
+	spotifyService           *spotify.Service
+	amazonClientID           string
+	amazonClientSecret       string
+	amazonRedirectURI        string
+	amazonService            *amazon.Service
+	ttsService               *tts.Service
+	ttsProvider              string
+	ttsGoogleAPIKey          string
+	ttsGoogleEndpoint        string // test-only override; not exposed in the UI
+	ttsAppKey                string
+	ttsLanguage              string
+	ttsVoice                 string
+	ttsVolume                int
+	peerObserver             *peerObserver
+	healthRegistry           *health.Registry
+	logBuf                   *logbuf.Buffer
+	expectedHosts            []string
+	ownCACache               struct {
 		once sync.Once
 		cert *x509.Certificate
 	}
@@ -119,6 +121,7 @@ func NewServer(ds *datastore.DataStore, sm *setup.Manager, serverURL string, red
 		discoveryEnabled:  true,
 		peerObserver:      newPeerObserver(),
 		healthRegistry:    health.NewRegistry(),
+		authProbes:        newAuthProbeRegistry(defaultAuthProbeTTL),
 	}
 
 	health.RegisterSourcesXMLPresent(s.healthRegistry, ds)
@@ -206,6 +209,53 @@ func NewServer(ds *datastore.DataStore, sm *setup.Manager, serverURL string, red
 			}
 
 			return ip
+		},
+	)
+	health.RegisterDNSSpeakerUsageCheck(
+		s.healthRegistry,
+		s.ds,
+		s.GetDNSRunning,
+		func() map[string]time.Time {
+			if s.dnsDiscovery == nil {
+				return map[string]time.Time{}
+			}
+
+			return s.dnsDiscovery.InterceptClientIPs()
+		},
+	)
+
+	// QuickFix executor for the dns_speaker_usage per-device info findings.
+	// Lives here (not in the health package) because it needs runDNSPathProbe,
+	// which is part of the handlers layer. The health package deliberately
+	// avoids importing handlers to keep its transitive dep surface small.
+	//
+	// Registered without refresh: this probe is a diagnostic whose value is the
+	// result message ("DNS path OK" / "no callback ..."). A refresh would re-fetch
+	// the whole health list and wipe that message from the UI before the operator
+	// can read it. The operator can refresh manually to see a now-confirmed
+	// speaker drop its finding.
+	s.healthRegistry.RegisterFixNoRefresh(
+		health.CheckIDDNSSpeakerUsage,
+		"probe_dns_path",
+		func(target health.Target) (string, error) {
+			res, err := s.runDNSPathProbe(target.Device, "")
+			if err != nil {
+				return "", err
+			}
+
+			if res.Success {
+				return fmt.Sprintf(
+					"Speaker resolved a Bose hostname through AfterTouch in %.0fms. DNS path OK.",
+					res.LatencyMs,
+				), nil
+			}
+
+			msg := "No /v1/auth callback within the timeout; this speaker likely resolves Bose hostnames via a different DNS resolver."
+			if res.Remediation != "" {
+				msg += " " + res.Remediation
+			}
+
+			return msg, nil
 		},
 	)
 

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -150,6 +150,28 @@ func NewServer(ds *datastore.DataStore, sm *setup.Manager, serverURL string, red
 	health.RegisterSpeakerCABundleCheck(s.healthRegistry, ds, func(deviceIP string) (string, string, bool) {
 		return s.sm.ProbeCABundles(deviceIP)
 	})
+	health.RegisterSpeakerClockCheck(s.healthRegistry, ds, func(ip string) (int64, int64, bool) {
+		cfg := client.DefaultConfig()
+		cfg.Host = ip
+		cfg.Timeout = 5 * time.Second
+
+		c := client.NewClient(cfg)
+		ct, err := c.GetClockTime()
+
+		if err != nil || ct == nil || ct.GetUTC() == 0 {
+			return 0, 0, false
+		}
+
+		return ct.GetUTC(), ct.GetUTCSyncTime(), true
+	}, func(ip string) error {
+		cfg := client.DefaultConfig()
+		cfg.Host = ip
+		cfg.Timeout = 5 * time.Second
+
+		c := client.NewClient(cfg)
+
+		return c.SetClockTime(models.NewClockTimeRequest(time.Now()))
+	})
 	health.RegisterServerURLReachableCheck(s.healthRegistry, func() string {
 		serverURL, _ := s.GetSettings()
 		return serverURL

--- a/pkg/service/health/checks_dns_speaker_usage.go
+++ b/pkg/service/health/checks_dns_speaker_usage.go
@@ -1,0 +1,109 @@
+package health
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// CheckIDDNSSpeakerUsage is the registry ID of the check that verifies
+// speakers are actually resolving Bose hostnames through AfterTouch's DNS
+// interceptor rather than via the operator's own resolvers, which would
+// route content requests to the decommissioned Bose cloud.
+const CheckIDDNSSpeakerUsage = "dns_speaker_usage"
+
+// probeDNSPathQuickFix is the QuickFix descriptor attached to per-device
+// info findings for speakers not yet observed resolving through AfterTouch.
+// The probe is silent and quick, so no confirmation dialog is needed.
+var probeDNSPathQuickFix = QuickFix{
+	ID:    "probe_dns_path",
+	Label: "Test DNS path",
+}
+
+// RegisterDNSSpeakerUsageCheck registers a check that cross-references the
+// set of known speaker IPs against the set of non-loopback clients that have
+// sent intercepted-hostname queries to AfterTouch's DNS server. It surfaces:
+//
+//   - An info finding per device that has not yet been observed resolving a
+//     Bose hostname through AfterTouch. Each finding carries a "Test DNS path"
+//     QuickFix so the operator can run an active probe on demand.
+//
+// Devices whose IP is present in the querier set are confirmed (no finding
+// is emitted for them).
+// Reuses the existing DNSStatusFunc type from checks_dns_sanity.go.
+func RegisterDNSSpeakerUsageCheck(
+	r *Registry,
+	ds *datastore.DataStore,
+	statusFn DNSStatusFunc,
+	clientIPsFn func() map[string]time.Time,
+) {
+	r.Register(Check{
+		ID:    CheckIDDNSSpeakerUsage,
+		Title: "Speakers resolve Bose hostnames through AfterTouch",
+		Run: func() []Finding {
+			return runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+		},
+	})
+}
+
+func runDNSSpeakerUsageCheck(
+	ds *datastore.DataStore,
+	statusFn DNSStatusFunc,
+	clientIPsFn func() map[string]time.Time,
+) []Finding {
+	running, _ := statusFn()
+	if !running {
+		// dns_sanity already covers the "DNS not running" case; emit nothing
+		// here to avoid duplicating that finding.
+		return nil
+	}
+
+	if ds == nil {
+		return nil
+	}
+
+	devices, err := ds.ListAllDevices()
+	if err != nil {
+		return []Finding{{
+			Severity: SeverityError,
+			Message:  "Could not enumerate devices: " + err.Error(),
+		}}
+	}
+
+	queriers := clientIPsFn()
+
+	var findings []Finding
+
+	for i := range devices {
+		dev := &devices[i]
+		if dev.IPAddress == "" {
+			continue
+		}
+
+		if _, seen := queriers[dev.IPAddress]; seen {
+			// Confirmed: this device has queried an intercepted hostname.
+			continue
+		}
+
+		name := displayName(dev.Name, dev.DeviceID)
+
+		findings = append(findings, Finding{
+			Severity: SeverityInfo,
+			Target:   Target{Account: dev.AccountID, Device: dev.DeviceID},
+			Message: fmt.Sprintf(
+				"Device %s (%s) is not yet confirmed to resolve Bose hostnames through AfterTouch. "+
+					"Use 'Test DNS path' to check now.",
+				name, dev.IPAddress,
+			),
+			Details: "This device's IP has not appeared as a querier for intercepted " +
+				"Bose hostnames. It may simply not have played a TuneIn stream since the " +
+				"last restart, or it may be using a different DNS resolver. " +
+				"Click 'Test DNS path' to run an active probe that sends a silent " +
+				"notification and waits for the speaker to call back through AfterTouch's DNS.",
+			QuickFixes: []QuickFix{probeDNSPathQuickFix},
+		})
+	}
+
+	return findings
+}

--- a/pkg/service/health/checks_dns_speaker_usage_test.go
+++ b/pkg/service/health/checks_dns_speaker_usage_test.go
@@ -1,0 +1,232 @@
+package health
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// newSpeakerUsageDatastore creates a temporary datastore and populates it
+// with the given device records. Each entry is [accountID, deviceID, ipAddress].
+func newSpeakerUsageDatastore(t *testing.T, devices ...[]string) *datastore.DataStore {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "dns-speaker-usage-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	ds := datastore.NewDataStore(tempDir)
+	for _, d := range devices {
+		if err := ds.SaveDeviceInfo(d[0], d[1], &models.ServiceDeviceInfo{
+			DeviceID:  d[1],
+			AccountID: d[0],
+			Name:      "Speaker-" + d[1],
+			IPAddress: d[2],
+		}); err != nil {
+			t.Fatalf("SaveDeviceInfo(%v): %v", d, err)
+		}
+	}
+	return ds
+}
+
+func TestDNSSpeakerUsage_DNSNotRunning(t *testing.T) {
+	ds := newSpeakerUsageDatastore(t, []string{"1000001", "DEVICE01", "192.0.2.10"})
+	statusFn := func() (bool, string) { return false, "" }
+	clientIPsFn := func() map[string]time.Time { return map[string]time.Time{"192.0.2.10": time.Now()} }
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 0 {
+		t.Errorf("expected no findings when DNS not running, got %+v", got)
+	}
+}
+
+// TestDNSSpeakerUsage_EmptyQuerierSet_WithDevices verifies that when DNS is
+// running but no device has been observed yet (empty querier set), the check
+// emits a SeverityInfo finding per device with the probe_dns_path QuickFix,
+// and does NOT emit any SeverityWarning.
+func TestDNSSpeakerUsage_EmptyQuerierSet_WithDevices(t *testing.T) {
+	ds := newSpeakerUsageDatastore(t, []string{"1000001", "DEVICE01", "192.0.2.10"})
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time { return map[string]time.Time{} }
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+
+	// Must be info, not warning — the empty querier set no longer emits a warning.
+	if got[0].Severity != SeverityInfo {
+		t.Errorf("expected SeverityInfo, got %s", got[0].Severity)
+	}
+
+	// Must mention the device IP and the action label.
+	if !strings.Contains(got[0].Message, "192.0.2.10") {
+		t.Errorf("expected device IP in message, got %q", got[0].Message)
+	}
+
+	if !strings.Contains(got[0].Message, "Test DNS path") {
+		t.Errorf("expected 'Test DNS path' in message, got %q", got[0].Message)
+	}
+
+	// Must carry the probe_dns_path QuickFix.
+	if len(got[0].QuickFixes) == 0 {
+		t.Fatal("expected at least one QuickFix in the info finding")
+	}
+
+	if got[0].QuickFixes[0].ID != "probe_dns_path" {
+		t.Errorf("expected QuickFix ID 'probe_dns_path', got %q", got[0].QuickFixes[0].ID)
+	}
+
+	if got[0].QuickFixes[0].Label != "Test DNS path" {
+		t.Errorf("expected QuickFix Label 'Test DNS path', got %q", got[0].QuickFixes[0].Label)
+	}
+
+	// Must have no ManualCommands (those were on the old warning).
+	if len(got[0].ManualCommands) != 0 {
+		t.Errorf("expected no ManualCommands on info finding, got %+v", got[0].ManualCommands)
+	}
+
+	// Target must be set so the fix dispatcher knows which device to probe.
+	if got[0].Target.Device != "DEVICE01" {
+		t.Errorf("expected Target.Device = 'DEVICE01', got %q", got[0].Target.Device)
+	}
+}
+
+func TestDNSSpeakerUsage_EmptyQuerierSet_NoDevices(t *testing.T) {
+	// No devices registered: nothing to assert about, so no findings.
+	ds := newSpeakerUsageDatastore(t) // no device entries
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time { return map[string]time.Time{} }
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 0 {
+		t.Errorf("expected no findings when no devices registered, got %+v", got)
+	}
+}
+
+func TestDNSSpeakerUsage_DeviceObserved(t *testing.T) {
+	ds := newSpeakerUsageDatastore(t, []string{"1000001", "DEVICE01", "192.0.2.10"})
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time {
+		return map[string]time.Time{"192.0.2.10": time.Now()}
+	}
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 0 {
+		t.Errorf("expected no findings when device IP is in querier set, got %+v", got)
+	}
+}
+
+func TestDNSSpeakerUsage_Mixed(t *testing.T) {
+	// DEVICE01 observed, DEVICE02 not observed.
+	ds := newSpeakerUsageDatastore(t,
+		[]string{"1000001", "DEVICE01", "192.0.2.10"},
+		[]string{"1000001", "DEVICE02", "192.0.2.11"},
+	)
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time {
+		return map[string]time.Time{"192.0.2.10": time.Now()}
+	}
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding for unobserved device, got %+v", got)
+	}
+
+	if got[0].Severity != SeverityInfo {
+		t.Errorf("expected SeverityInfo for unobserved device, got %s", got[0].Severity)
+	}
+
+	if !strings.Contains(got[0].Message, "192.0.2.11") {
+		t.Errorf("expected unobserved IP in message, got %q", got[0].Message)
+	}
+
+	if strings.Contains(got[0].Message, "192.0.2.10") {
+		t.Errorf("observed device IP should not appear in findings, but it did: %q", got[0].Message)
+	}
+
+	// Must carry probe_dns_path QuickFix.
+	if len(got[0].QuickFixes) == 0 || got[0].QuickFixes[0].ID != "probe_dns_path" {
+		t.Errorf("expected probe_dns_path QuickFix, got %+v", got[0].QuickFixes)
+	}
+
+	// Target must identify DEVICE02.
+	if got[0].Target.Device != "DEVICE02" {
+		t.Errorf("expected Target.Device = 'DEVICE02', got %q", got[0].Target.Device)
+	}
+}
+
+func TestDNSSpeakerUsage_AllDevicesObserved(t *testing.T) {
+	ds := newSpeakerUsageDatastore(t,
+		[]string{"1000001", "DEVICE01", "192.0.2.10"},
+		[]string{"1000001", "DEVICE02", "192.0.2.11"},
+	)
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time {
+		return map[string]time.Time{
+			"192.0.2.10": time.Now(),
+			"192.0.2.11": time.Now(),
+		}
+	}
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	if len(got) != 0 {
+		t.Errorf("expected no findings when all devices observed, got %+v", got)
+	}
+}
+
+func TestDNSSpeakerUsage_DevicesWithNoIP_Skipped(t *testing.T) {
+	// A device with no IP address should not contribute to findings.
+	tempDir, err := os.MkdirTemp("", "dns-speaker-usage-noip-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	ds := datastore.NewDataStore(tempDir)
+	if err := ds.SaveDeviceInfo("1000001", "DEVICE01", &models.ServiceDeviceInfo{
+		DeviceID:  "DEVICE01",
+		AccountID: "1000001",
+		Name:      "NoIPSpeaker",
+		IPAddress: "", // intentionally empty
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+	clientIPsFn := func() map[string]time.Time { return map[string]time.Time{} }
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	// knownIPs is empty after skipping the no-IP device, so no findings expected.
+	if len(got) != 0 {
+		t.Errorf("expected no findings when all devices lack IP, got %+v", got)
+	}
+}
+
+// TestDNSSpeakerUsage_NoWarningEverEmitted verifies the core invariant: the
+// dns_speaker_usage check must never emit a SeverityWarning finding, regardless
+// of the querier-set state. Warnings were the source of the false-positive on
+// restart that this rework eliminates.
+func TestDNSSpeakerUsage_NoWarningEverEmitted(t *testing.T) {
+	ds := newSpeakerUsageDatastore(t,
+		[]string{"1000001", "DEVICE01", "192.0.2.10"},
+		[]string{"1000001", "DEVICE02", "192.0.2.11"},
+	)
+	statusFn := func() (bool, string) { return true, "0.0.0.0:53" }
+
+	// Test with empty querier set (the classic false-positive scenario).
+	clientIPsFn := func() map[string]time.Time { return map[string]time.Time{} }
+
+	got := runDNSSpeakerUsageCheck(ds, statusFn, clientIPsFn)
+	for _, f := range got {
+		if f.Severity == SeverityWarning {
+			t.Errorf("dns_speaker_usage must never emit SeverityWarning; got finding: %+v", f)
+		}
+	}
+}

--- a/pkg/service/health/checks_speaker_clock.go
+++ b/pkg/service/health/checks_speaker_clock.go
@@ -1,0 +1,275 @@
+package health
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// CheckIDSpeakerClock is the registry ID of the speaker clock skew check.
+const CheckIDSpeakerClock = "speaker_clock"
+
+// clockPlausibilityMin is the lower bound of the plausibility window (year 2000).
+// Matches the lower bound used by ClockTimeRequest.Validate in pkg/models/clocktime.go.
+const clockPlausibilityMin int64 = 946684800
+
+// clockPlausibilityMax is the upper bound of the plausibility window (year 2100).
+// Matches the upper bound used by ClockTimeRequest.Validate in pkg/models/clocktime.go.
+const clockPlausibilityMax int64 = 4102444800
+
+// clockStaleNTPThreshold is how long after the last NTP sync before we flag it
+// as stale.
+const clockStaleNTPThreshold = time.Hour
+
+// setClockQuickFix is the QuickFix descriptor for the set_clock action.
+// Attached to Warning and Error findings only (Info is harmless sub-5-minute drift).
+var setClockQuickFix = QuickFix{
+	ID:    "set_clock",
+	Label: "Set clock from AfterTouch",
+	Confirm: "Sets the speaker's clock to this server's current time. " +
+		"If the speaker's NTP sync is failing, the clock may drift again or reset on reboot " +
+		"— restoring time sync is the durable fix.",
+}
+
+// RegisterSpeakerClockCheck registers a per-device health check that
+// compares each speaker's UTC epoch to the service's UTC epoch and surfaces
+// findings when the skew is large enough to cause TLS certificate failures.
+//
+// clockFn must return the speaker's clock as epoch seconds (utc), its last
+// NTP sync epoch (sync), and ok=false when /clockTime could not be read or
+// had no usable UTC time.
+//
+// setFn sets the clock on the speaker at the given IP. It is called by the
+// set_clock QuickFix. Passing nil disables the fix registration.
+func RegisterSpeakerClockCheck(
+	r *Registry,
+	ds *datastore.DataStore,
+	clockFn func(deviceIP string) (utc, sync int64, ok bool),
+	setFn func(deviceIP string) error,
+) {
+	r.Register(Check{
+		ID:    CheckIDSpeakerClock,
+		Title: "Speaker clock accuracy",
+		Run: func() []Finding {
+			return runSpeakerClockCheck(ds, clockFn, time.Now())
+		},
+	})
+
+	if setFn == nil {
+		return
+	}
+
+	r.RegisterFix(CheckIDSpeakerClock, "set_clock", func(target Target) (string, error) {
+		devices, err := ds.ListAllDevices()
+		if err != nil {
+			return "", fmt.Errorf("could not enumerate devices: %w", err)
+		}
+
+		var (
+			ip      string
+			devName string
+		)
+
+		for i := range devices {
+			if devices[i].DeviceID == target.Device {
+				ip = devices[i].IPAddress
+				devName = displayName(devices[i].Name, devices[i].DeviceID)
+
+				break
+			}
+		}
+
+		if ip == "" {
+			return "", fmt.Errorf("device %q not found or has no IP address", target.Device)
+		}
+
+		if err := setFn(ip); err != nil {
+			return "", fmt.Errorf("set clock on %s: %w", devName, err)
+		}
+
+		now := time.Now().UTC().Format(time.RFC3339)
+
+		return fmt.Sprintf(
+			"Set clock on %s to %s. "+
+				"If NTP is still failing the clock may drift again or reset on reboot "+
+				"— restoring time sync is the durable fix.",
+			devName, now,
+		), nil
+	})
+}
+
+func runSpeakerClockCheck(
+	ds *datastore.DataStore,
+	clockFn func(deviceIP string) (utc, sync int64, ok bool),
+	now time.Time,
+) []Finding {
+	if ds == nil {
+		return nil
+	}
+
+	devices, err := ds.ListAllDevices()
+	if err != nil {
+		return []Finding{{
+			Severity: SeverityError,
+			Message:  "Could not enumerate devices: " + err.Error(),
+		}}
+	}
+
+	var findings []Finding
+
+	for i := range devices {
+		dev := &devices[i]
+		if dev.IPAddress == "" {
+			continue
+		}
+
+		utc, sync, ok := clockFn(dev.IPAddress)
+		if !ok {
+			// Reachability is speaker_info_reachable's job; do not duplicate.
+			continue
+		}
+
+		target := Target{Account: dev.AccountID, Device: dev.DeviceID}
+		name := displayName(dev.Name, dev.DeviceID)
+
+		skew := now.Unix() - utc
+
+		abs := skew
+		if abs < 0 {
+			abs = -abs
+		}
+
+		// Build common details lines for enrichment.
+		speakerTimeStr := time.Unix(utc, 0).UTC().Format(time.RFC3339)
+		serviceTimeStr := now.UTC().Format(time.RFC3339)
+
+		var skewSign string
+		if skew >= 0 {
+			skewSign = fmt.Sprintf("+%ds", skew)
+		} else {
+			skewSign = fmt.Sprintf("%ds", skew)
+		}
+
+		details := fmt.Sprintf(
+			"Speaker UTC: %s. Service UTC: %s. Signed skew: %s.",
+			speakerTimeStr, serviceTimeStr, skewSign,
+		)
+
+		// NTP staleness note.
+		ntpNote := ""
+		if sync == 0 {
+			ntpNote = " Speaker has never successfully synced with an NTP server — NTP is likely failing."
+		} else if now.Unix()-sync > int64(clockStaleNTPThreshold.Seconds()) {
+			lastSync := time.Unix(sync, 0).UTC().Format(time.RFC3339)
+			ntpNote = fmt.Sprintf(" Speaker's last NTP sync was %s (more than 1 hour ago) — NTP is likely failing.", lastSync)
+		}
+
+		if ntpNote != "" {
+			details += ntpNote
+		}
+
+		remediation := " Remediation: ensure the speaker can reach an NTP server" +
+			" (UDP/123 outbound to a reachable time server). AfterTouch can also" +
+			" push the current time via /clockTime (soundtouch-cli set-clock-time) if needed."
+		details += remediation
+
+		// Determine tier. The plausibility check is applied regardless of abs
+		// magnitude: a speaker claiming year 2000 or year 2101 is an Error even
+		// if the arithmetic skew happens to be small.
+		outsidePlausibility := utc < clockPlausibilityMin || utc > clockPlausibilityMax
+
+		switch {
+		case outsidePlausibility || abs >= int64(24*time.Hour/time.Second):
+			var msg string
+			if outsidePlausibility {
+				msg = fmt.Sprintf(
+					"Device %s: speaker clock is implausible (speaker reads %s, service is %s)."+
+						" HTTPS/TLS will fail: certificates appear not-yet-valid or expired,"+
+						" so TuneIn/BMX content and any HTTPS source will break until time sync is restored.",
+					name, speakerTimeStr, serviceTimeStr,
+				)
+			} else {
+				msg = fmt.Sprintf(
+					"Device %s: speaker clock is far off (speaker reads %s, service is %s)."+
+						" HTTPS/TLS will fail: certificates appear not-yet-valid or expired,"+
+						" so TuneIn/BMX content and any HTTPS source will break until time sync is restored.",
+					name, speakerTimeStr, serviceTimeStr,
+				)
+			}
+
+			findings = append(findings, Finding{
+				Severity:   SeverityError,
+				Target:     target,
+				Message:    msg,
+				Details:    details,
+				QuickFixes: []QuickFix{setClockQuickFix},
+			})
+
+		case abs >= int64(5*time.Minute/time.Second):
+			findings = append(findings, Finding{
+				Severity: SeverityWarning,
+				Target:   target,
+				Message: fmt.Sprintf(
+					"Device %s: clock is off by %s; may cause intermittent HTTPS/TLS failures.",
+					name, formatDuration(abs),
+				),
+				Details:    details,
+				QuickFixes: []QuickFix{setClockQuickFix},
+			})
+
+		case abs >= 60:
+			findings = append(findings, Finding{
+				Severity: SeverityInfo,
+				Target:   target,
+				Message: fmt.Sprintf(
+					"Device %s: minor clock drift of %s; NTP sync may be loose.",
+					name, formatDuration(abs),
+				),
+				Details: details,
+			})
+
+		default:
+			// abs < 60s: healthy, no finding.
+		}
+	}
+
+	return findings
+}
+
+// formatDuration renders a duration (given as unsigned seconds) as a
+// human-readable string (e.g. "10m30s", "2h5m", "33d").
+func formatDuration(secs int64) string {
+	days := secs / 86400
+	rem := secs % 86400
+	hours := rem / 3600
+	rem %= 3600
+	minutes := rem / 60
+	seconds := rem % 60
+
+	if days > 0 {
+		if hours > 0 {
+			return fmt.Sprintf("%dd%dh", days, hours)
+		}
+
+		return fmt.Sprintf("%dd", days)
+	}
+
+	if hours > 0 {
+		if minutes > 0 {
+			return fmt.Sprintf("%dh%dm", hours, minutes)
+		}
+
+		return fmt.Sprintf("%dh", hours)
+	}
+
+	if minutes > 0 {
+		if seconds > 0 {
+			return fmt.Sprintf("%dm%ds", minutes, seconds)
+		}
+
+		return fmt.Sprintf("%dm", minutes)
+	}
+
+	return fmt.Sprintf("%ds", seconds)
+}

--- a/pkg/service/health/checks_speaker_clock_test.go
+++ b/pkg/service/health/checks_speaker_clock_test.go
@@ -1,0 +1,398 @@
+package health
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// newSpeakerClockDatastore creates a temporary datastore populated with a
+// single device. ip may be "" to test the empty-IP skip behaviour.
+func newSpeakerClockDatastore(t *testing.T, accountID, deviceID, ip string) *datastore.DataStore {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "speaker-clock-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempDir) })
+
+	ds := datastore.NewDataStore(tempDir)
+	if err := ds.SaveDeviceInfo(accountID, deviceID, &models.ServiceDeviceInfo{
+		DeviceID:  deviceID,
+		AccountID: accountID,
+		Name:      "Speaker-" + deviceID,
+		IPAddress: ip,
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	return ds
+}
+
+func TestSpeakerClock_InSync(t *testing.T) {
+	now := time.Unix(1748908800, 0) // fixed reference: 2025-06-03 00:00:00 UTC
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 5, now.Unix() - 30, true // 5s skew, recent NTP sync
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 0 {
+		t.Errorf("expected no findings for in-sync clock, got %+v", got)
+	}
+}
+
+func TestSpeakerClock_InfoTier_90sSkew(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 90, now.Unix() - 30, true
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding for 90s skew, got %+v", got)
+	}
+	if got[0].Severity != SeverityInfo {
+		t.Errorf("expected SeverityInfo, got %s", got[0].Severity)
+	}
+}
+
+func TestSpeakerClock_WarningTier_10mSkew(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 600, now.Unix() - 30, true // 10 minutes
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding for 10m skew, got %+v", got)
+	}
+	if got[0].Severity != SeverityWarning {
+		t.Errorf("expected SeverityWarning, got %s", got[0].Severity)
+	}
+	if !strings.Contains(got[0].Message, "10m") {
+		t.Errorf("expected duration in message, got %q", got[0].Message)
+	}
+}
+
+func TestSpeakerClock_ErrorTier_33daysSkew(t *testing.T) {
+	// The #345 case: speaker clock ~33 days behind service time.
+	now := time.Unix(1748908800, 0)
+	skewSecs := int64(33 * 24 * 60 * 60)
+	speakerUTC := now.Unix() - skewSecs
+
+	ds := newSpeakerClockDatastore(t, "1000001", "606405FE97AE", "192.0.2.20")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return speakerUTC, 0, true // sync==0 means never NTP-synced
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding for 33d skew, got %+v", got)
+	}
+	if got[0].Severity != SeverityError {
+		t.Errorf("expected SeverityError, got %s", got[0].Severity)
+	}
+
+	// Message must name both the speaker time and the service time.
+	speakerTimeStr := time.Unix(speakerUTC, 0).UTC().Format(time.RFC3339)
+	serviceTimeStr := now.UTC().Format(time.RFC3339)
+
+	if !strings.Contains(got[0].Message, speakerTimeStr) {
+		t.Errorf("expected speaker time %q in message, got %q", speakerTimeStr, got[0].Message)
+	}
+	if !strings.Contains(got[0].Message, serviceTimeStr) {
+		t.Errorf("expected service time %q in message, got %q", serviceTimeStr, got[0].Message)
+	}
+	if !strings.Contains(strings.ToLower(got[0].Message), "tls") {
+		t.Errorf("expected TLS mention in message, got %q", got[0].Message)
+	}
+}
+
+func TestSpeakerClock_ErrorTier_PlausibilityWindow(t *testing.T) {
+	// Speaker epoch is just inside year 2000 boundary (but within a minute of it),
+	// which is outside the plausibility window.
+	now := time.Unix(1748908800, 0)
+	speakerUTC := int64(946684800 + 60) // year 2000 + 60s: inside window but barely
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return speakerUTC, 0, true
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one error finding for year-2000 epoch, got %+v", got)
+	}
+	if got[0].Severity != SeverityError {
+		t.Errorf("expected SeverityError (>24h skew), got %s", got[0].Severity)
+	}
+}
+
+func TestSpeakerClock_ErrorTier_BeforePlausibilityMin(t *testing.T) {
+	// Epoch before year 2000 (e.g. Unix 0 = 1970).
+	now := time.Unix(1748908800, 0)
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return 0, 0, true // epoch 0 = 1970, outside plausibility window
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one error finding for epoch 0, got %+v", got)
+	}
+	if got[0].Severity != SeverityError {
+		t.Errorf("expected SeverityError for implausible epoch, got %s", got[0].Severity)
+	}
+	if !strings.Contains(got[0].Message, "implausible") {
+		t.Errorf("expected 'implausible' in message, got %q", got[0].Message)
+	}
+}
+
+func TestSpeakerClock_OkFalse_Skipped(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return 0, 0, false // unreachable
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 0 {
+		t.Errorf("expected no findings when clockFn returns ok=false, got %+v", got)
+	}
+}
+
+func TestSpeakerClock_EmptyIP_Skipped(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "") // empty IP
+
+	called := false
+	clockFn := func(string) (int64, int64, bool) {
+		called = true
+		return now.Unix(), now.Unix() - 30, true
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 0 {
+		t.Errorf("expected no findings for device with empty IP, got %+v", got)
+	}
+	if called {
+		t.Error("clockFn should not be called for a device with empty IP")
+	}
+}
+
+func TestSpeakerClock_StaleNTPSync_DetailsNote(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	// Skew of 90s (Info tier) but NTP sync was 2 hours ago.
+	lastSync := now.Unix() - int64(2*time.Hour/time.Second)
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 90, lastSync, true
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+	if !strings.Contains(got[0].Details, "NTP is likely failing") {
+		t.Errorf("expected NTP staleness note in Details, got %q", got[0].Details)
+	}
+}
+
+func TestSpeakerClock_ZeroSync_DetailsNote(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	// Skew of 90s (Info tier) with zero sync (never synced).
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 90, 0, true // sync == 0
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+	if !strings.Contains(got[0].Details, "never") {
+		t.Errorf("expected 'never' in NTP staleness note in Details, got %q", got[0].Details)
+	}
+	if !strings.Contains(got[0].Details, "NTP is likely failing") {
+		t.Errorf("expected 'NTP is likely failing' in Details, got %q", got[0].Details)
+	}
+}
+
+// --- QuickFix descriptor tests ---
+
+func TestSpeakerClock_ErrorFinding_CarriesSetClockQuickFix(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+	skewSecs := int64(33 * 24 * 60 * 60)
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - skewSecs, 0, true
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+	if got[0].Severity != SeverityError {
+		t.Fatalf("expected SeverityError, got %s", got[0].Severity)
+	}
+
+	hasSetClock := false
+	for _, qf := range got[0].QuickFixes {
+		if qf.ID == "set_clock" {
+			hasSetClock = true
+		}
+	}
+	if !hasSetClock {
+		t.Errorf("expected set_clock QuickFix on Error finding, got %+v", got[0].QuickFixes)
+	}
+}
+
+func TestSpeakerClock_WarningFinding_CarriesSetClockQuickFix(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 600, now.Unix() - 30, true // 10 minutes skew
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+	if got[0].Severity != SeverityWarning {
+		t.Fatalf("expected SeverityWarning, got %s", got[0].Severity)
+	}
+
+	hasSetClock := false
+	for _, qf := range got[0].QuickFixes {
+		if qf.ID == "set_clock" {
+			hasSetClock = true
+		}
+	}
+	if !hasSetClock {
+		t.Errorf("expected set_clock QuickFix on Warning finding, got %+v", got[0].QuickFixes)
+	}
+}
+
+func TestSpeakerClock_InfoFinding_NoSetClockQuickFix(t *testing.T) {
+	now := time.Unix(1748908800, 0)
+
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	clockFn := func(string) (int64, int64, bool) {
+		return now.Unix() - 90, now.Unix() - 30, true // 90s skew = Info tier
+	}
+
+	got := runSpeakerClockCheck(ds, clockFn, now)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+	if got[0].Severity != SeverityInfo {
+		t.Fatalf("expected SeverityInfo, got %s", got[0].Severity)
+	}
+
+	for _, qf := range got[0].QuickFixes {
+		if qf.ID == "set_clock" {
+			t.Errorf("Info finding must not carry set_clock QuickFix, but got one")
+		}
+	}
+}
+
+// --- RunFix dispatch tests ---
+
+// newSpeakerClockRegistry creates a Registry with RegisterSpeakerClockCheck
+// wired up using the provided setFn stub.
+func newSpeakerClockRegistry(t *testing.T, ds *datastore.DataStore, setFn func(string) error) *Registry {
+	t.Helper()
+
+	r := NewRegistry()
+	clockFn := func(string) (int64, int64, bool) {
+		return time.Now().Unix(), time.Now().Unix() - 30, true
+	}
+	RegisterSpeakerClockCheck(r, ds, clockFn, setFn)
+
+	return r
+}
+
+func TestSpeakerClock_RunFix_Success(t *testing.T) {
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	var calledIP string
+	setFn := func(ip string) error {
+		calledIP = ip
+		return nil
+	}
+
+	r := newSpeakerClockRegistry(t, ds, setFn)
+
+	msg, _, err := r.RunFix(CheckIDSpeakerClock, "set_clock", Target{Device: "DEVICE01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calledIP != "192.0.2.10" {
+		t.Errorf("setFn called with IP %q, want 192.0.2.10", calledIP)
+	}
+	if !strings.Contains(msg, "Set clock on") {
+		t.Errorf("expected 'Set clock on' in message, got %q", msg)
+	}
+	if !strings.Contains(msg, "restoring time sync is the durable fix") {
+		t.Errorf("expected NTP band-aid note in message, got %q", msg)
+	}
+}
+
+func TestSpeakerClock_RunFix_SetFnError_Propagates(t *testing.T) {
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	setFn := func(string) error {
+		return errors.New("connection refused")
+	}
+
+	r := newSpeakerClockRegistry(t, ds, setFn)
+
+	_, _, err := r.RunFix(CheckIDSpeakerClock, "set_clock", Target{Device: "DEVICE01"})
+	if err == nil {
+		t.Fatal("expected error from failing setFn, got nil")
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("expected original error in message, got %q", err.Error())
+	}
+}
+
+func TestSpeakerClock_RunFix_UnknownDevice_ReturnsError(t *testing.T) {
+	ds := newSpeakerClockDatastore(t, "1000001", "DEVICE01", "192.0.2.10")
+
+	setFn := func(string) error { return nil }
+
+	r := newSpeakerClockRegistry(t, ds, setFn)
+
+	_, _, err := r.RunFix(CheckIDSpeakerClock, "set_clock", Target{Device: "NOSUCHDEVICE"})
+	if err == nil {
+		t.Fatal("expected error for unknown device, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## What & why

#345 surfaced a silent failure mode: a speaker resolves the firmware-hardcoded
`content.api.bose.io` through the operator's own DNS instead of AfterTouch, so
TuneIn/BMX content escapes to the decommissioned Bose cloud and the speaker
reports `INVALID_SOURCE`. The existing `dns_sanity` check only probes
AfterTouch's own answering side over loopback, so it stays green even when no
speaker uses AfterTouch as its resolver. This PR adds diagnostics that surface
the speaker side, plus a clock check that catches a second, related,
TLS-breaking cause.

This does not change the reporter's fix (that is operational: set
`dns_enabled=false` and/or restore the speaker's clock), so it intentionally
does not close the issue. Relates to #345; leaving it open pending reporter
confirmation.

## What's added

**1. On-demand DNS-path check (`dns_speaker_usage` + `/v1/auth` probe).** The
Health tab lists, per speaker, whether it has been observed resolving an
intercepted Bose hostname through AfterTouch. Speakers not yet confirmed get an
informational entry with a **"Test DNS path"** button (a QuickFix). Clicking it
runs an active probe: AfterTouch sends a `/speaker` notification carrying a
per-probe nonce as the app_key; to accept it the speaker must resolve
`audionotification.api.bosecm.com` (intercepted) and call back `GET /v1/auth`
with that nonce. The callback arriving is direct proof the speaker resolves Bose
hosts through AfterTouch. `HandleSpeakerAuth` returns 403 for a matching nonce so
the speaker refuses the notification (silent, no audio, confirmed on hardware);
any other key still gets 200 so real TTS is untouched. The same probe is also
exposed at `POST /setup/health/dns-path-probe`. The check is deliberately
**on-demand**: it never emits a standing warning, so it does not false-positive
after a restart (the observation set is in-memory). DNS-query tracking
(`pkg/discovery/dns.go`, `InterceptClientIPs()`) excludes loopback so
`dns_sanity`'s own probes don't register. SSRF-safe targeting via
`resolveTTSHost`.

**2. `speaker_clock` (+ `set_clock` quick-fix).** Reads each speaker's
`/clockTime` and compares its UTC epoch to the service's (epoch comparison, so
timezone-independent). Tiers: under 60s none; 60s-5m info; 5m-24h warning; 24h or
more, or a time outside the year 2000..2100 plausibility window, error. A wrong
clock makes HTTPS certificates look not-yet-valid (the CURL 60 seen in #345). The
`set_clock` quick-fix on warning/error findings pushes the current time via
`POST /clockTime`; it is a band-aid (the clock drifts again or resets on reboot
if NTP is failing), so the confirm dialog and success message point at restoring
NTP as the durable fix.

## Testing

- New/updated unit tests across `pkg/discovery`, `pkg/service/health`, and
  `pkg/service/handlers`, including the end-to-end `/v1/auth` probe loop with a
  fake speaker, the `probe_dns_path` quick-fix dispatch, and the clock-skew tiers.
- `make check` and `make lint` are clean. (`test-http-client` needs Docker and
  was not run.)

## Follow-ups (not in this PR, tracked locally)

- Health-tab UX polish: sweep progress indicator; per-speaker grouping with
  names + IDs; render confirmed speakers as collapsed OK rows instead of hiding
  them; distinguish unmigrated speakers from real DNS-path failures; and clearer
  timeout/unreachable states.
- Optional SSH `set-clock` fallback (the HTTP path is confirmed on firmware 27).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
