### PR TITLE
fix(datastore): fsync atomicWriteFile for crash-safe durability (#458)

### DIFF
--- a/pkg/service/datastore/atomic_write_test.go
+++ b/pkg/service/datastore/atomic_write_test.go
@@ -1,0 +1,52 @@
+package datastore
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAtomicWriteFile_DurableRoundTrip guards the durable write path added for
+// #458: content must round-trip, an overwrite must truncate cleanly, and no
+// `.tmp` sidecar may be left behind. (The fsync durability itself isn't
+// unit-testable without power-loss fault injection; this is the functional
+// regression guard so the fsync rework doesn't break writes.)
+func TestAtomicWriteFile_DurableRoundTrip(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "st-atomic-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	ds := NewDataStore(tempDir)
+
+	dir := ds.AccountDeviceDir("1234567", "001122334455")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(dir, "Sources.xml")
+
+	if err := ds.atomicWriteFile(path, []byte("first")); err != nil {
+		t.Fatalf("atomicWriteFile (create) failed: %v", err)
+	}
+
+	if got, _ := os.ReadFile(path); string(got) != "first" {
+		t.Errorf("content after create = %q, want %q", got, "first")
+	}
+
+	// Overwrite must truncate the previous (longer) content, not leave a tail.
+	if err := ds.atomicWriteFile(path, []byte("hi")); err != nil {
+		t.Fatalf("atomicWriteFile (overwrite) failed: %v", err)
+	}
+
+	if got, _ := os.ReadFile(path); string(got) != "hi" {
+		t.Errorf("content after overwrite = %q, want %q", got, "hi")
+	}
+
+	// No leftover temp sidecar.
+	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("expected no %s.tmp leftover, stat err = %v", path, err)
+	}
+}

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -1210,15 +1210,83 @@ func (ds *DataStore) SavePresets(account, device string, presets []models.Servic
 	return ds.atomicWriteFile(path, append(header, data...))
 }
 
+// atomicWriteFile writes data to filename atomically AND durably: it writes a
+// temp file, fsyncs it, renames it into place, then fsyncs the parent
+// directory. Without the fsyncs an unclean power-cut on a journaling NAND
+// filesystem (UBIFS, the speaker's /mnt/nv) can leave the renamed file present
+// but 0 bytes — the rename was journalled but the data blocks were never
+// flushed. See #458.
 func (ds *DataStore) atomicWriteFile(filename string, data []byte) error {
 	perm := os.FileMode(0644)
 
 	tempFile := filename + ".tmp"
-	if err := ds.rootWriteFile(tempFile, data, perm); err != nil {
+	if err := ds.rootWriteFileSync(tempFile, data, perm); err != nil {
 		return err
 	}
 
-	return ds.rootRename(tempFile, filename)
+	if err := ds.rootRename(tempFile, filename); err != nil {
+		return err
+	}
+
+	// Fsync the parent directory so the rename itself survives a power-cut.
+	// Best-effort: not every filesystem permits directory fsync, and the data +
+	// rename have already succeeded by this point.
+	ds.rootSyncDir(filepath.Dir(filename))
+
+	return nil
+}
+
+// rootWriteFileSync writes data to absPath (truncating any existing file) and
+// fsyncs the file before returning, so the contents are on stable storage. This
+// is the durable equivalent of rootWriteFile.
+func (ds *DataStore) rootWriteFileSync(absPath string, data []byte, perm os.FileMode) error {
+	r, err := ds.getRoot()
+	if err != nil {
+		return err
+	}
+
+	rel, err := ds.rootRel(absPath)
+	if err != nil {
+		return err
+	}
+
+	f, err := r.OpenFile(rel, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+
+	if _, werr := f.Write(data); werr != nil {
+		_ = f.Close()
+
+		return werr
+	}
+
+	if serr := f.Sync(); serr != nil {
+		_ = f.Close()
+
+		return serr
+	}
+
+	return f.Close()
+}
+
+// rootSyncDir fsyncs the directory at absDir so a preceding create/rename is
+// durable. Best-effort: directory fsync isn't supported on every filesystem, so
+// failures are logged and swallowed rather than failing an already-successful
+// write.
+func (ds *DataStore) rootSyncDir(absDir string) {
+	d, err := ds.rootOpen(absDir)
+	if err != nil {
+		log.Printf("[Datastore] rootSyncDir: open %s failed (best-effort): %v", sanitizeLog(absDir), err)
+
+		return
+	}
+
+	if serr := d.Sync(); serr != nil {
+		log.Printf("[Datastore] rootSyncDir: fsync %s failed (best-effort): %v", sanitizeLog(absDir), serr)
+	}
+
+	_ = d.Close()
 }
 
 // GetRecents returns the list of recently played items for the specified account and device.

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -999,7 +999,7 @@ func (ds *DataStore) readPresetsLocked(account, device string) ([]models.Service
 	needsRewrite := !bytes.Equal(normalized, data)
 
 	if err := xml.Unmarshal(normalized, &presetsWrap); err != nil {
-		log.Printf("[Datastore] readPresetsLocked: malformed Presets.xml at %s (%v) — treating as no presets (#458)", sanitizeLog(path), err)
+		log.Printf("[Datastore] readPresetsLocked: malformed Presets.xml at %s (%s) — treating as no presets (#458)", sanitizeLog(path), sanitizeErr(err))
 
 		return []models.ServicePreset{}, false, nil
 	}
@@ -1342,7 +1342,7 @@ func (ds *DataStore) GetRecents(account, device string) ([]models.ServiceRecent,
 
 	var wrap RecentsXML
 	if err := xml.Unmarshal(data, &wrap); err != nil {
-		log.Printf("[Datastore] GetRecents: malformed Recents.xml at %s (%v) — treating as no recents (#458)", sanitizeLog(path), err)
+		log.Printf("[Datastore] GetRecents: malformed Recents.xml at %s (%s) — treating as no recents (#458)", sanitizeLog(path), sanitizeErr(err))
 
 		return []models.ServiceRecent{}, nil
 	}
@@ -1938,7 +1938,7 @@ func (ds *DataStore) GetConfiguredSources(account, device string) ([]models.Conf
 	}
 
 	if err := xml.Unmarshal(data, &sourcesWrap); err != nil {
-		log.Printf("[Datastore] GetConfiguredSources: malformed Sources.xml at %s (%v) — treating as missing, serving defaults (#458)", sanitizeLog(path), err)
+		log.Printf("[Datastore] GetConfiguredSources: malformed Sources.xml at %s (%s) — treating as missing, serving defaults (#458)", sanitizeLog(path), sanitizeErr(err))
 
 		return defaultSources(), nil
 	}


### PR DESCRIPTION
## What

Make `DataStore.atomicWriteFile` crash-safe: `fsync` the temp file before the rename and `fsync` the parent directory after, via `os.Root.OpenFile` / `os.Root.Open`. Directory fsync is best-effort (logged, not fatal — not every filesystem permits it).

## Why

`atomicWriteFile` was atomic w.r.t. the rename but **not durable** — it never fsync'd. On a journaling NAND filesystem (UBIFS, the speaker's `/mnt/nv` on an on-device install), an unclean power-cut after the rename was journalled but before the data blocks were flushed could leave the renamed datastore file **present but 0 bytes**. That is exactly how a reporter's `Presets.xml` / `Recents.xml` / `Sources.xml` were zeroed after a power-cycle (`UBIFS: recovery needed` on the next boot), while the already-flushed `DeviceInfo.xml` survived. See #458.

## Relationship to #459

This is the **write-side durability** half of #458; #459 (merged) was the **read-side resilience** half. Durability prevents new 0-byte files; resilience makes the service tolerate any that already exist (serve defaults / empty instead of wiping or 500ing).

## Tests

`atomic_write_test.go`: content round-trips, overwrite truncates cleanly, no `.tmp` leftover. `make check` (unit) + `make lint` green. (The fsync durability itself isn't unit-testable without power-loss fault injection; this guards the write path against regressions.)

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
