### PR TITLE
Potential fix for code scanning alert no. 308: Log entries created from user input

### DIFF
--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -1277,13 +1277,13 @@ func (ds *DataStore) rootWriteFileSync(absPath string, data []byte, perm os.File
 func (ds *DataStore) rootSyncDir(absDir string) {
 	d, err := ds.rootOpen(absDir)
 	if err != nil {
-		log.Printf("[Datastore] rootSyncDir: open %s failed (best-effort): %v", sanitizeLog(absDir), err)
+		log.Printf("[Datastore] rootSyncDir: open %s failed (best-effort): %s", sanitizeLog(absDir), sanitizeErr(err))
 
 		return
 	}
 
 	if serr := d.Sync(); serr != nil {
-		log.Printf("[Datastore] rootSyncDir: fsync %s failed (best-effort): %v", sanitizeLog(absDir), serr)
+		log.Printf("[Datastore] rootSyncDir: fsync %s failed (best-effort): %s", sanitizeLog(absDir), sanitizeErr(serr))
 	}
 
 	_ = d.Close()


### PR DESCRIPTION
Potential fix for [https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/308](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/308)

To fix log-forging risk, sanitize any error value that may include user-controlled text before writing it to logs. In this case, update `pkg/service/datastore/datastore.go` in `rootSyncDir` so the `err` and `serr` arguments are logged via `sanitizeErr(...)` instead of raw `%v`. This preserves behavior (still logs failures, still best-effort) while ensuring control characters/newlines in error messages are neutralized consistently.

Best single fix:
- File: `pkg/service/datastore/datastore.go`
- Region: `func (ds *DataStore) rootSyncDir(absDir string)` (around lines 1277–1287 in your snippet)
- Changes:
  1. Replace `...: %v", sanitizeLog(absDir), err)` with `...: %s", sanitizeLog(absDir), sanitizeErr(err))`
  2. Replace `...: %v", sanitizeLog(absDir), serr)` with `...: %s", sanitizeLog(absDir), sanitizeErr(serr))`
- No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
