### PR TITLE
refactor(web): migrate soundtouch-web to the post-merge /api/control + /app layout (refs #451)

### DIFF
--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -498,7 +498,7 @@ func TestHandleWebSocket_InvalidUpgrade(t *testing.T) {
 	app := createTestApp()
 
 	// Test without proper WebSocket headers (should fail gracefully)
-	req := httptest.NewRequest("GET", "/ws", nil)
+	req := httptest.NewRequest("GET", "/api/control/ws", nil)
 	w := httptest.NewRecorder()
 
 	// This will fail because it's not a real WebSocket upgrade, but should not panic

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -65,7 +65,7 @@ func TestNewWebApp(t *testing.T) {
 func TestHandleAPIDevices(t *testing.T) {
 	app := createTestApp()
 
-	req := httptest.NewRequest("GET", "/api/devices", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices", nil)
 	w := httptest.NewRecorder()
 
 	app.HandleAPIDevices(w, req)
@@ -111,21 +111,21 @@ func TestHandleAPIDevice(t *testing.T) {
 	}{
 		{
 			name:           "valid device",
-			path:           "/api/device/test-device",
+			path:           "/api/control/devices/test-device",
 			chiID:          "test-device",
 			expectedStatus: http.StatusOK,
 			expectSuccess:  true,
 		},
 		{
 			name:           "missing device ID",
-			path:           "/api/device/",
+			path:           "/api/control/devices/",
 			chiID:          "",
 			expectedStatus: http.StatusBadRequest,
 			expectSuccess:  false,
 		},
 		{
 			name:           "unknown device",
-			path:           "/api/device/unknown",
+			path:           "/api/control/devices/unknown",
 			chiID:          "unknown",
 			expectedStatus: http.StatusNotFound,
 			expectSuccess:  false,
@@ -166,7 +166,7 @@ func TestHandleAPIDevice(t *testing.T) {
 func TestHandleAPIControl_InvalidDevice(t *testing.T) {
 	app := createTestApp()
 
-	req := httptest.NewRequest("GET", "/api/control/unknown-device/play", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices/unknown-device/action/play", nil)
 	req = withChiParams(req, map[string]string{"id": "unknown-device", "action": "play"})
 	w := httptest.NewRecorder()
 
@@ -197,8 +197,8 @@ func TestHandleAPIControl_InvalidPath(t *testing.T) {
 		name string
 		path string
 	}{
-		{"missing action", "/api/control/test-device"},
-		{"missing device and action", "/api/control/"},
+		{"missing action", "/api/control/devices/test-device/action/"},
+		{"missing device and action", "/api/control/devices//action/"},
 	}
 
 	for _, tt := range tests {
@@ -268,9 +268,9 @@ func TestHandleAPIControl_VolumeValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var req *http.Request
 			if tt.body != "" {
-				req = httptest.NewRequest(tt.method, "/api/control/test-device/volume", strings.NewReader(tt.body))
+				req = httptest.NewRequest(tt.method, "/api/control/devices/test-device/volume/50", strings.NewReader(tt.body))
 			} else {
-				req = httptest.NewRequest(tt.method, "/api/control/test-device/volume", nil)
+				req = httptest.NewRequest(tt.method, "/api/control/devices/test-device/volume/50", nil)
 			}
 			req = withChiParams(req, map[string]string{"id": "test-device", "action": "volume"})
 			req.Header.Set("Content-Type", "application/json")
@@ -322,7 +322,7 @@ func TestHandleAPIControl_BassValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, "/api/control/test-device/bass", strings.NewReader(tt.body))
+			req := httptest.NewRequest(tt.method, "/api/control/devices/test-device/action/bass", strings.NewReader(tt.body))
 			req = withChiParams(req, map[string]string{"id": "test-device", "action": "bass"})
 			req.Header.Set("Content-Type", "application/json")
 
@@ -370,7 +370,7 @@ func TestHandleAPIControl_PresetValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest("GET", "/api/control/test-device/preset"+tt.query, nil)
+			req := httptest.NewRequest("GET", "/api/control/devices/test-device/action/preset"+tt.query, nil)
 			req = withChiParams(req, map[string]string{"id": "test-device", "action": "preset"})
 			w := httptest.NewRecorder()
 
@@ -395,7 +395,7 @@ func TestHandleAPIControl_PresetValidation(t *testing.T) {
 func TestHandleAPIControl_SourceValidation(t *testing.T) {
 	app := createTestApp()
 
-	req := httptest.NewRequest("GET", "/api/control/test-device/source", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices/test-device/action/source", nil)
 	req = withChiParams(req, map[string]string{"id": "test-device", "action": "source"})
 	w := httptest.NewRecorder()
 
@@ -444,7 +444,7 @@ func TestHandleAPIDiscover(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, "/api/discover", nil)
+			req := httptest.NewRequest(tt.method, "/api/control/discover", nil)
 			w := httptest.NewRecorder()
 
 			app.HandleAPIDiscover(w, req)
@@ -511,7 +511,7 @@ func TestHandleWebSocket_InvalidUpgrade(t *testing.T) {
 func TestHandleAPIControl_UnsupportedAction(t *testing.T) {
 	app := createTestApp()
 
-	req := httptest.NewRequest("GET", "/api/control/test-device/unsupported", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices/test-device/action/unsupported", nil)
 	req = withChiParams(req, map[string]string{"id": "test-device", "action": "unsupported"})
 	w := httptest.NewRecorder()
 
@@ -542,7 +542,7 @@ func TestHandleAPIVersion(t *testing.T) {
 	app.Date = "2023-01-01"
 	app.RepoURL = "https://github.com/example/repo"
 
-	req := httptest.NewRequest("GET", "/api/version", nil)
+	req := httptest.NewRequest("GET", "/api/control/version", nil)
 	w := httptest.NewRecorder()
 
 	app.HandleAPIVersion(w, req)
@@ -593,7 +593,7 @@ func BenchmarkHandleAPIDevices(b *testing.B) {
 		app.AddDevice(deviceID, conn)
 	}
 
-	req := httptest.NewRequest("GET", "/api/devices", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices", nil)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -604,7 +604,7 @@ func BenchmarkHandleAPIDevices(b *testing.B) {
 
 func BenchmarkHandleAPIDevice(b *testing.B) {
 	app := createTestApp()
-	req := httptest.NewRequest("GET", "/api/device/test-device", nil)
+	req := httptest.NewRequest("GET", "/api/control/devices/test-device", nil)
 	req = withChiParams(req, map[string]string{"id": "test-device"})
 
 	b.ResetTimer()
@@ -684,7 +684,7 @@ func TestHandleDevicePlay_SourceAccountFiltering(t *testing.T) {
 				"sourceAccount":"` + tt.sourceAccount + `",
 				"itemName":"Venice Classic Radio"
 			}`)
-			req := httptest.NewRequest("POST", "/api/device-play/play-device", body)
+			req := httptest.NewRequest("POST", "/api/control/devices/play-device/play", body)
 			req.Header.Set("Content-Type", "application/json")
 			req = withChiParams(req, map[string]string{"id": "play-device"})
 			w := httptest.NewRecorder()
@@ -750,7 +750,7 @@ func TestHandleSourceControl_ForwardsAccount(t *testing.T) {
 			conn.SetStatus(&webtypes.DeviceStatus{IsConnected: true, LastActivity: time.Now()})
 			app.AddDevice("source-device", conn)
 
-			req := httptest.NewRequest("GET", "/api/control/source-device/source?"+tt.query, nil)
+			req := httptest.NewRequest("GET", "/api/control/devices/source-device/action/source?"+tt.query, nil)
 			req = withChiParams(req, map[string]string{"id": "source-device", "action": "source"})
 			w := httptest.NewRecorder()
 

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -99,14 +99,25 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 		})
 	})
 
-	// SPA routes — serve index.html for client-side routing
-	r.Get("/", app.serveIndex)
-	r.Get("/devices", app.serveIndex)
-	r.Get("/device/*", app.serveIndex)
-	r.Get("/tunein", app.serveIndex)
-	r.Get("/radiobrowser", app.serveIndex)
-	r.Get("/playurl", app.serveIndex)
-	r.Get("/tts", app.serveIndex)
+	// SPA — served under /app/*. The client navigates via component state
+	// rather than the URL, so these entries only ensure deep links and
+	// refreshes return index.html instead of 404. Per #451 this keeps the
+	// whole web UI under one /app subtree, so folding -web into -service is an
+	// additive mount.
+	r.Get("/app", app.serveIndex)
+	r.Get("/app/devices", app.serveIndex)
+	r.Get("/app/device/*", app.serveIndex)
+	r.Get("/app/tunein", app.serveIndex)
+	r.Get("/app/radiobrowser", app.serveIndex)
+	r.Get("/app/playurl", app.serveIndex)
+	r.Get("/app/tts", app.serveIndex)
+
+	// Standalone convenience: the bare root jumps into the app. When -web is
+	// folded into -service, / instead serves a landing page (admin vs app) and
+	// this redirect is replaced.
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/app", http.StatusFound)
+	})
 }
 
 func (app *WebApp) serveIndex(w http.ResponseWriter, _ *http.Request) {

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -19,19 +19,21 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 	subFS, _ := fs.Sub(StaticFS, "static")
 	r.Get("/static/*", http.StripPrefix("/static", http.FileServer(http.FS(subFS))).ServeHTTP)
 
-	// WebSocket endpoint
-	r.Get("/ws", app.HandleWebSocket)
-
 	// Health / liveness
 	r.Get("/health", app.HandleHealth)
 
 	// Player / control API. Per #451 this is the post-merge canonical shape:
 	// device-scoped actions nest under devices/{id}/, so every direct child of
-	// /api/control is a literal namespace (version, discover, devices,
+	// /api/control is a literal namespace (version, ws, discover, devices,
 	// providers) — no static-vs-param sibling, so routing never depends on
 	// chi's static-over-param precedence.
 	r.Route("/api/control", func(r chi.Router) {
 		r.Get("/version", app.HandleAPIVersion)
+
+		// App-wide event stream: device list, discovery status, per-device
+		// status updates. The read/event half of the control surface (the
+		// per-device socket lives at devices/{id}/ws).
+		r.Get("/ws", app.HandleWebSocket)
 
 		r.Post("/discover", func(w http.ResponseWriter, r *http.Request) {
 			app.HandleAPIDiscover(w, r)

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -27,9 +27,9 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 
 	// Player / control API. Per #451 this is the post-merge canonical shape:
 	// device-scoped actions nest under devices/{id}/, so every direct child of
-	// /api/control is a literal namespace (devices, tunein, radiobrowser,
-	// version, discover) — no static-vs-param sibling, so routing never depends
-	// on chi's static-over-param precedence.
+	// /api/control is a literal namespace (version, discover, devices,
+	// providers) — no static-vs-param sibling, so routing never depends on
+	// chi's static-over-param precedence.
 	r.Route("/api/control", func(r chi.Router) {
 		r.Get("/version", app.HandleAPIVersion)
 
@@ -64,10 +64,8 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 				r.Post("/power", app.HandleDevicePower)
 				r.Get("/power-status", app.HandleDevicePowerStatus)
 				r.Get("/recents", app.HandleDeviceRecents)
+				// Low-level "play this ContentItem" primitive (not a provider).
 				r.Post("/play", app.HandleDevicePlay)
-				r.Post("/play-url", app.HandlePlayURL)
-				// Proxied to the AfterTouch service's /api/setup/tts/speak.
-				r.Post("/speak", app.HandleAPISpeakText)
 				// Generic key / preset / source / bass actions.
 				r.Get("/action/{action}", app.HandleAPIControl)
 				r.Post("/action/{action}", app.HandleAPIControl)
@@ -81,21 +79,33 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 					r.Post("/leave", app.HandleZoneLeave)
 				})
 
-				r.Post("/tunein/play", app.HandlePlayTuneIn)
-				r.Post("/radiobrowser/play", app.HandlePlayRadioBrowser)
+				// Play a result from a content provider on this device.
+				// Browsable providers (tunein, radiobrowser) take a catalog item;
+				// input providers (url, tts) take the raw input.
+				r.Route("/providers", func(r chi.Router) {
+					r.Post("/tunein/play", app.HandlePlayTuneIn)
+					r.Post("/radiobrowser/play", app.HandlePlayRadioBrowser)
+					r.Post("/url/play", app.HandlePlayURL)
+					// Proxied to the AfterTouch service's /api/setup/tts/speak.
+					r.Post("/tts/play", app.HandleAPISpeakText)
+				})
 			})
 		})
 
-		// Browse / search (global, not device-scoped).
-		r.Route("/tunein", func(r chi.Router) {
-			r.Get("/search", app.HandleTuneInSearch)
-			r.Get("/search/next", app.HandleTuneInSearchNext)
-			r.Get("/navigate", app.HandleTuneInNavigate)
-			r.Get("/navigate/*", app.HandleTuneInNavigate)
-		})
+		// Provider browse / search (global, not device-scoped). Only browsable
+		// providers (a catalog you search/navigate) appear here; input
+		// providers (url, tts) exist solely as a device play above.
+		r.Route("/providers", func(r chi.Router) {
+			r.Route("/tunein", func(r chi.Router) {
+				r.Get("/search", app.HandleTuneInSearch)
+				r.Get("/search/next", app.HandleTuneInSearchNext)
+				r.Get("/navigate", app.HandleTuneInNavigate)
+				r.Get("/navigate/*", app.HandleTuneInNavigate)
+			})
 
-		r.Route("/radiobrowser", func(r chi.Router) {
-			r.Get("/search", app.HandleRadioBrowserSearch)
+			r.Route("/radiobrowser", func(r chi.Router) {
+				r.Get("/search", app.HandleRadioBrowserSearch)
+			})
 		})
 	})
 

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -25,62 +25,79 @@ func (app *WebApp) Mount(r chi.Router, discoveryService *discovery.UnifiedDiscov
 	// Health / liveness
 	r.Get("/health", app.HandleHealth)
 
-	// API endpoints
-	r.Get("/api/devices", app.HandleAPIDevices)
-	r.Get("/api/device/{id}", app.HandleAPIDevice)
-	r.Get("/api/version", app.HandleAPIVersion)
-	r.Post("/api/discover", func(w http.ResponseWriter, r *http.Request) {
-		app.HandleAPIDiscover(w, r)
+	// Player / control API. Per #451 this is the post-merge canonical shape:
+	// device-scoped actions nest under devices/{id}/, so every direct child of
+	// /api/control is a literal namespace (devices, tunein, radiobrowser,
+	// version, discover) — no static-vs-param sibling, so routing never depends
+	// on chi's static-over-param precedence.
+	r.Route("/api/control", func(r chi.Router) {
+		r.Get("/version", app.HandleAPIVersion)
 
-		// Trigger discovery
-		//nolint:contextcheck // Context is created within goroutine
-		go func() {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-			defer cancel()
+		r.Post("/discover", func(w http.ResponseWriter, r *http.Request) {
+			app.HandleAPIDiscover(w, r)
 
-			app.BroadcastDiscoveryStatus("starting", app.DeviceCount())
+			// Trigger discovery
+			//nolint:contextcheck // Context is created within goroutine
+			go func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				defer cancel()
 
-			app.DiscoverDevices(ctx, discoveryService)
+				app.BroadcastDiscoveryStatus("starting", app.DeviceCount())
 
-			app.BroadcastDiscoveryStatus("completed", app.DeviceCount())
-			app.BroadcastDeviceList()
-		}()
+				app.DiscoverDevices(ctx, discoveryService)
+
+				app.BroadcastDiscoveryStatus("completed", app.DeviceCount())
+				app.BroadcastDeviceList()
+			}()
+		})
+
+		// One /devices subrouter holds both the list and the /{id} subtree (the
+		// issue #285 single-subrouter lesson). Under /{id} every child is a
+		// literal action.
+		r.Route("/devices", func(r chi.Router) {
+			r.Get("/", app.HandleAPIDevices)
+
+			r.Route("/{id}", func(r chi.Router) {
+				r.Get("/", app.HandleAPIDevice)
+				r.Post("/key/{key}", app.HandleDeviceKey)
+				r.Post("/volume/{volume}", app.HandleDirectVolumeControl)
+				r.Post("/power", app.HandleDevicePower)
+				r.Get("/power-status", app.HandleDevicePowerStatus)
+				r.Get("/recents", app.HandleDeviceRecents)
+				r.Post("/play", app.HandleDevicePlay)
+				r.Post("/play-url", app.HandlePlayURL)
+				// Proxied to the AfterTouch service's /api/setup/tts/speak.
+				r.Post("/speak", app.HandleAPISpeakText)
+				// Generic key / preset / source / bass actions.
+				r.Get("/action/{action}", app.HandleAPIControl)
+				r.Post("/action/{action}", app.HandleAPIControl)
+				r.Get("/ws", app.HandleDeviceWebSocket)
+
+				r.Route("/zone", func(r chi.Router) {
+					r.Get("/", app.HandleGetZone)
+					r.Post("/add/{slaveId}", app.HandleZoneAdd)
+					r.Post("/remove/{slaveId}", app.HandleZoneRemove)
+					r.Post("/dissolve", app.HandleZoneDissolve)
+					r.Post("/leave", app.HandleZoneLeave)
+				})
+
+				r.Post("/tunein/play", app.HandlePlayTuneIn)
+				r.Post("/radiobrowser/play", app.HandlePlayRadioBrowser)
+			})
+		})
+
+		// Browse / search (global, not device-scoped).
+		r.Route("/tunein", func(r chi.Router) {
+			r.Get("/search", app.HandleTuneInSearch)
+			r.Get("/search/next", app.HandleTuneInSearchNext)
+			r.Get("/navigate", app.HandleTuneInNavigate)
+			r.Get("/navigate/*", app.HandleTuneInNavigate)
+		})
+
+		r.Route("/radiobrowser", func(r chi.Router) {
+			r.Get("/search", app.HandleRadioBrowserSearch)
+		})
 	})
-
-	// Device control endpoints (GET for most actions, POST for volume/bass)
-	r.Get("/api/control/{id}/{action}", app.HandleAPIControl)
-	r.Post("/api/control/{id}/{action}", app.HandleAPIControl)
-
-	// TuneIn browse, search, and playback
-	r.Get("/api/tunein/search", app.HandleTuneInSearch)
-	r.Get("/api/tunein/search/next", app.HandleTuneInSearchNext)
-	r.Get("/api/tunein/navigate", app.HandleTuneInNavigate)
-	r.Get("/api/tunein/navigate/*", app.HandleTuneInNavigate)
-	r.Post("/api/tunein/play/{id}", app.HandlePlayTuneIn)
-
-	// Enhanced device control endpoints
-	r.Post("/api/device-key/{id}/{key}", app.HandleDeviceKey)
-	r.Post("/api/device-volume/{id}/{volume}", app.HandleDirectVolumeControl)
-	r.Post("/api/device-power/{id}", app.HandleDevicePower)
-	r.Get("/api/device-power-status/{id}", app.HandleDevicePowerStatus)
-	r.Get("/api/device-recents/{id}", app.HandleDeviceRecents)
-	r.Post("/api/device-play/{id}", app.HandleDevicePlay)
-	r.Get("/api/zone/{id}", app.HandleGetZone)
-	r.Post("/api/zone/{id}/add/{slaveId}", app.HandleZoneAdd)
-	r.Post("/api/zone/{id}/remove/{slaveId}", app.HandleZoneRemove)
-	r.Post("/api/zone/{id}/dissolve", app.HandleZoneDissolve)
-	r.Post("/api/zone/{id}/leave", app.HandleZoneLeave)
-	r.Get("/api/device-ws/{id}", app.HandleDeviceWebSocket)
-
-	// RadioBrowser search
-	r.Get("/api/radiobrowser/search", app.HandleRadioBrowserSearch)
-	r.Post("/api/radiobrowser/play/{id}", app.HandlePlayRadioBrowser)
-
-	// Custom URL playback
-	r.Post("/api/play-url/{id}", app.HandlePlayURL)
-
-	// Text-to-speech (proxied to the AfterTouch service's /setup/tts/speak)
-	r.Post("/api/device-speak/{id}", app.HandleAPISpeakText)
 
 	// SPA routes — serve index.html for client-side routing
 	r.Get("/", app.serveIndex)

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -59,3 +59,42 @@ func TestMountControlAPIShape(t *testing.T) {
 		t.Errorf("expected /api/control/version to be registered; got %v", apiRoutes)
 	}
 }
+
+// TestMountSPARoutes verifies the issue #451 SPA move: the web UI is served
+// under /app/* and the old top-level page paths are gone, with / kept only as
+// a redirect into the app.
+func TestMountSPARoutes(t *testing.T) {
+	app := NewWebApp()
+
+	r := chi.NewRouter()
+	app.Mount(r, nil)
+
+	routes := map[string]bool{}
+
+	walkErr := chi.Walk(r, func(_, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		routes[route] = true
+
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk routes: %v", walkErr)
+	}
+
+	for _, want := range []string{"/app", "/app/devices", "/app/tunein"} {
+		if !routes[want] {
+			t.Errorf("expected SPA route %q under /app to be registered", want)
+		}
+	}
+
+	// The old top-level page paths moved under /app.
+	for _, gone := range []string{"/devices", "/device/*", "/tunein", "/radiobrowser", "/playurl", "/tts"} {
+		if routes[gone] {
+			t.Errorf("top-level SPA route %q should have moved under /app", gone)
+		}
+	}
+
+	// / stays registered, but only as the redirect into the app.
+	if !routes["/"] {
+		t.Error("expected / to remain registered (redirect into the app)")
+	}
+}

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -21,7 +21,11 @@ func TestMountControlAPIShape(t *testing.T) {
 
 	var apiRoutes []string
 
+	registered := map[string]bool{}
+
 	walkErr := chi.Walk(r, func(_, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		registered[route] = true
+
 		if strings.HasPrefix(route, "/api/") {
 			apiRoutes = append(apiRoutes, route)
 		}
@@ -44,15 +48,12 @@ func TestMountControlAPIShape(t *testing.T) {
 		}
 	}
 
-	registered := make(map[string]bool, len(apiRoutes))
-	for _, route := range apiRoutes {
-		registered[route] = true
-	}
-
 	// The provider infix (#451): browsable providers expose global browse
-	// routes; every provider play nests under devices/{id}/providers/.
+	// routes; every provider play nests under devices/{id}/providers/. The
+	// app-wide socket moved from top-level /ws to /api/control/ws.
 	mustExist := []string{
 		"/api/control/version",
+		"/api/control/ws",
 		"/api/control/providers/tunein/search",
 		"/api/control/providers/radiobrowser/search",
 		"/api/control/devices/{id}/providers/tunein/play",
@@ -66,8 +67,10 @@ func TestMountControlAPIShape(t *testing.T) {
 		}
 	}
 
-	// The pre-infix flat paths are gone.
+	// The pre-infix flat paths are gone, and the app-wide socket no longer
+	// sits at top-level /ws.
 	mustNotExist := []string{
+		"/ws",
 		"/api/control/tunein/search",
 		"/api/control/radiobrowser/search",
 		"/api/control/devices/{id}/play-url",

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -44,19 +44,41 @@ func TestMountControlAPIShape(t *testing.T) {
 		}
 	}
 
-	// Spot-check a representative endpoint actually registered.
-	found := false
-
+	registered := make(map[string]bool, len(apiRoutes))
 	for _, route := range apiRoutes {
-		if route == "/api/control/version" {
-			found = true
+		registered[route] = true
+	}
 
-			break
+	// The provider infix (#451): browsable providers expose global browse
+	// routes; every provider play nests under devices/{id}/providers/.
+	mustExist := []string{
+		"/api/control/version",
+		"/api/control/providers/tunein/search",
+		"/api/control/providers/radiobrowser/search",
+		"/api/control/devices/{id}/providers/tunein/play",
+		"/api/control/devices/{id}/providers/radiobrowser/play",
+		"/api/control/devices/{id}/providers/url/play",
+		"/api/control/devices/{id}/providers/tts/play",
+	}
+	for _, want := range mustExist {
+		if !registered[want] {
+			t.Errorf("expected route %q to be registered; got %v", want, apiRoutes)
 		}
 	}
 
-	if !found {
-		t.Errorf("expected /api/control/version to be registered; got %v", apiRoutes)
+	// The pre-infix flat paths are gone.
+	mustNotExist := []string{
+		"/api/control/tunein/search",
+		"/api/control/radiobrowser/search",
+		"/api/control/devices/{id}/play-url",
+		"/api/control/devices/{id}/speak",
+		"/api/control/devices/{id}/tunein/play",
+		"/api/control/devices/{id}/radiobrowser/play",
+	}
+	for _, gone := range mustNotExist {
+		if registered[gone] {
+			t.Errorf("pre-infix route %q should have moved under /providers/", gone)
+		}
 	}
 }
 

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -1,0 +1,61 @@
+package soundtouchweb
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestMountControlAPIShape verifies the issue #451 web API restructure:
+// building the router must not panic (catches any chi route-registration
+// ambiguity), and every web `/api/*` route must live under `/api/control/*`
+// (the post-merge canonical namespace). This is the only test that exercises
+// Mount itself; the handler tests call handlers directly with injected params.
+func TestMountControlAPIShape(t *testing.T) {
+	app := NewWebApp()
+
+	r := chi.NewRouter()
+	app.Mount(r, nil) // must not panic while registering routes
+
+	var apiRoutes []string
+
+	walkErr := chi.Walk(r, func(_, route string, _ http.Handler, _ ...func(http.Handler) http.Handler) error {
+		if strings.HasPrefix(route, "/api/") {
+			apiRoutes = append(apiRoutes, route)
+		}
+
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk routes: %v", walkErr)
+	}
+
+	if len(apiRoutes) == 0 {
+		t.Fatal("no /api/* routes registered")
+	}
+
+	// Invariant: the whole web API is under /api/control/* (no flat /api/devices,
+	// /api/zone, /api/control/{id}/{action}, ... left behind).
+	for _, route := range apiRoutes {
+		if !strings.HasPrefix(route, "/api/control/") {
+			t.Errorf("web API route %q is not under /api/control/ after the #451 restructure", route)
+		}
+	}
+
+	// Spot-check a representative endpoint actually registered.
+	found := false
+
+	for _, route := range apiRoutes {
+		if route == "/api/control/version" {
+			found = true
+
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected /api/control/version to be registered; got %v", apiRoutes)
+	}
+}

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -6,51 +6,51 @@ async function req(url, opts = {}) {
 }
 
 export const api = {
-    devices: () => req('/api/devices'),
-    device: (id) => req(`/api/device/${id}`),
-    discover: () => req('/api/discover', { method: 'POST' }),
-    key: (id, key) => req(`/api/device-key/${id}/${key}`, { method: 'POST' }),
-    volume: (id, level) => req(`/api/device-volume/${id}/${level}`, { method: 'POST' }),
-    bass: (id, level) => req(`/api/control/${id}/bass`, {
+    devices: () => req('/api/control/devices'),
+    device: (id) => req(`/api/control/devices/${id}`),
+    discover: () => req('/api/control/discover', { method: 'POST' }),
+    key: (id, key) => req(`/api/control/devices/${id}/key/${key}`, { method: 'POST' }),
+    volume: (id, level) => req(`/api/control/devices/${id}/volume/${level}`, { method: 'POST' }),
+    bass: (id, level) => req(`/api/control/devices/${id}/action/bass`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ level }),
     }),
-    power: (id) => req(`/api/device-power/${id}`, { method: 'POST' }),
-    recents: (id) => req(`/api/device-recents/${id}`),
-    zone: (id) => req(`/api/zone/${id}`),
-    zoneAdd: (masterId, slaveId) => req(`/api/zone/${masterId}/add/${slaveId}`, { method: 'POST' }),
-    zoneRemove: (masterId, slaveId) => req(`/api/zone/${masterId}/remove/${slaveId}`, { method: 'POST' }),
-    zoneDissolve: (id) => req(`/api/zone/${id}/dissolve`, { method: 'POST' }),
-    zoneLeave: (id) => req(`/api/zone/${id}/leave`, { method: 'POST' }),
-    play: (id, item) => req(`/api/device-play/${id}`, {
+    power: (id) => req(`/api/control/devices/${id}/power`, { method: 'POST' }),
+    recents: (id) => req(`/api/control/devices/${id}/recents`),
+    zone: (id) => req(`/api/control/devices/${id}/zone`),
+    zoneAdd: (masterId, slaveId) => req(`/api/control/devices/${masterId}/zone/add/${slaveId}`, { method: 'POST' }),
+    zoneRemove: (masterId, slaveId) => req(`/api/control/devices/${masterId}/zone/remove/${slaveId}`, { method: 'POST' }),
+    zoneDissolve: (id) => req(`/api/control/devices/${id}/zone/dissolve`, { method: 'POST' }),
+    zoneLeave: (id) => req(`/api/control/devices/${id}/zone/leave`, { method: 'POST' }),
+    play: (id, item) => req(`/api/control/devices/${id}/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    tuneInBrowse: (path) => req(path ? `/api/tunein/navigate/${path}` : '/api/tunein/navigate'),
-    tuneInSearch: (q) => req(`/api/tunein/search?q=${encodeURIComponent(q)}`),
-    tuneInSearchNext: (cursor) => req(`/api/tunein/search/next?cursor=${encodeURIComponent(cursor)}`),
-    control: (id, action, presetId) => req(`/api/control/${id}/${action}?id=${presetId}`),
-    storePreset: (id, slotId) => req(`/api/control/${id}/storepreset?id=${slotId}`),
-    selectSource: (id, source, account) => req(`/api/control/${id}/source?name=${encodeURIComponent(source)}&account=${encodeURIComponent(account || '')}`),
-    tuneInPlay: (deviceId, item) => req(`/api/tunein/play/${deviceId}`, {
+    tuneInBrowse: (path) => req(path ? `/api/control/tunein/navigate/${path}` : '/api/control/tunein/navigate'),
+    tuneInSearch: (q) => req(`/api/control/tunein/search?q=${encodeURIComponent(q)}`),
+    tuneInSearchNext: (cursor) => req(`/api/control/tunein/search/next?cursor=${encodeURIComponent(cursor)}`),
+    control: (id, action, presetId) => req(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
+    storePreset: (id, slotId) => req(`/api/control/devices/${id}/action/storepreset?id=${slotId}`),
+    selectSource: (id, source, account) => req(`/api/control/devices/${id}/action/source?name=${encodeURIComponent(source)}&account=${encodeURIComponent(account || '')}`),
+    tuneInPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/tunein/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    radioBrowserSearch: (q) => req(`/api/radiobrowser/search?q=${encodeURIComponent(q)}`),
-    radioBrowserPlay: (deviceId, item) => req(`/api/radiobrowser/play/${deviceId}`, {
+    radioBrowserSearch: (q) => req(`/api/control/radiobrowser/search?q=${encodeURIComponent(q)}`),
+    radioBrowserPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/radiobrowser/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    playURL: (deviceId, url, name, imageUrl, serviceUrl) => req(`/api/play-url/${deviceId}`, {
+    playURL: (deviceId, url, name, imageUrl, serviceUrl) => req(`/api/control/devices/${deviceId}/play-url`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ url, name, imageUrl, serviceUrl }),
     }),
-    speak: (deviceId, text) => req(`/api/device-speak/${deviceId}`, {
+    speak: (deviceId, text) => req(`/api/control/devices/${deviceId}/speak`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ text }),

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -28,29 +28,29 @@ export const api = {
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    tuneInBrowse: (path) => req(path ? `/api/control/tunein/navigate/${path}` : '/api/control/tunein/navigate'),
-    tuneInSearch: (q) => req(`/api/control/tunein/search?q=${encodeURIComponent(q)}`),
-    tuneInSearchNext: (cursor) => req(`/api/control/tunein/search/next?cursor=${encodeURIComponent(cursor)}`),
+    tuneInBrowse: (path) => req(path ? `/api/control/providers/tunein/navigate/${path}` : '/api/control/providers/tunein/navigate'),
+    tuneInSearch: (q) => req(`/api/control/providers/tunein/search?q=${encodeURIComponent(q)}`),
+    tuneInSearchNext: (cursor) => req(`/api/control/providers/tunein/search/next?cursor=${encodeURIComponent(cursor)}`),
     control: (id, action, presetId) => req(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
     storePreset: (id, slotId) => req(`/api/control/devices/${id}/action/storepreset?id=${slotId}`),
     selectSource: (id, source, account) => req(`/api/control/devices/${id}/action/source?name=${encodeURIComponent(source)}&account=${encodeURIComponent(account || '')}`),
-    tuneInPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/tunein/play`, {
+    tuneInPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/providers/tunein/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    radioBrowserSearch: (q) => req(`/api/control/radiobrowser/search?q=${encodeURIComponent(q)}`),
-    radioBrowserPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/radiobrowser/play`, {
+    radioBrowserSearch: (q) => req(`/api/control/providers/radiobrowser/search?q=${encodeURIComponent(q)}`),
+    radioBrowserPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/providers/radiobrowser/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
-    playURL: (deviceId, url, name, imageUrl, serviceUrl) => req(`/api/control/devices/${deviceId}/play-url`, {
+    playURL: (deviceId, url, name, imageUrl, serviceUrl) => req(`/api/control/devices/${deviceId}/providers/url/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ url, name, imageUrl, serviceUrl }),
     }),
-    speak: (deviceId, text) => req(`/api/control/devices/${deviceId}/speak`, {
+    speak: (deviceId, text) => req(`/api/control/devices/${deviceId}/providers/tts/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ text }),

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -91,7 +91,7 @@ function App() {
             .catch(err => console.error('Failed to fetch version:', err));
 
         const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
-        const ws = new WebSocket(`${protocol}//${location.host}/ws`);
+        const ws = new WebSocket(`${protocol}//${location.host}/api/control/ws`);
         let reconnectTimer;
 
         ws.onmessage = (event) => {

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -81,7 +81,7 @@ function App() {
     };
 
     useEffect(() => {
-        fetch('/api/version')
+        fetch('/api/control/version')
             .then(res => res.json())
             .then(resp => {
                 if (resp.success) {


### PR DESCRIPTION
## What

Migrates `soundtouch-web`'s HTTP API in place to the shape it will have after being folded into `soundtouch-service` (issue #451), so that merge becomes a near-additive mount rather than a disruptive reshuffle.

This is a **direct migration** (no dual-mount, no deprecation middleware): `-web`'s only client is its own bundled frontend, so a browser reload picks up the new paths. The careful dual-mount + deprecation approach is reserved for the central `-service`.

## Steps (one commit each)

1. **Nest the control API under `/api/control/*`** (`e43ad08`)
   Device-scoped actions nest under `/api/control/devices/{id}/...`, so every direct child of `/api/control` is a literal namespace and routing never depends on chi's static-over-param precedence. Adds `mount_test.go`, the first test that exercises `Mount()`: it walks the registered routes and asserts no registration panic plus the invariant that every web `/api/*` route lives under `/api/control/*`.
2. **Group content sources under a `/providers` infix** (`79ad8b7`)
   tunein, radiobrowser, playurl and tts become content "providers". Browsable providers expose global browse routes (`/api/control/providers/{tunein,radiobrowser}/...`); every provider plays on a device via a uniform verb (`POST /api/control/devices/{id}/providers/{tunein,radiobrowser,url,tts}/play`, where `url` was `play-url` and `tts` was `speak`). The generic `POST /devices/{id}/play` stays the low-level ContentItem primitive.
3. **Serve the SPA under `/app/*`** (`7ed951c`)
   The whole web UI moves under one `/app` subtree. The bare root `/` redirects into the app for now; when `-web` folds into `-service`, `/` instead serves a landing page (admin vs app). Pure routing change: the client navigates via component state and references assets absolutely, so no frontend edits were needed.
4. **Move the app-wide socket to `/api/control/ws`** (`7b8b037`)
   The event stream (device list, discovery status, status updates) is the read half of the control surface, so it joins the rest of the web API (the per-device socket already lived at `/api/control/devices/{id}/ws`).

## Result

`-web`'s entire HTTP surface now lives under two clean subtrees:

- `/api/control/*` (API: version, ws, discover, devices/{id}/..., providers/...)
- `/app/*` (SPA)

plus shared `/static/*`, `/health`, and `/` (redirect placeholder for the future landing page).

## Testing

- `go build ./...`, full `go test ./...`, and `golangci-lint` clean at every commit.
- New `mount_test.go` asserts the route shape (provider infix present, pre-infix flat paths gone, SPA under `/app`, socket at `/api/control/ws`) and that `Mount()` registers without panic.
- The Docker `.http` suite is unaffected (it exercises `-service`).

Refs #451. Builds on the merge-plan doc in #468; the next step is folding `-web` into `-service` (additive mount behind the opt-in flag).
