### PR TITLE
feat(service): #451 Stage 2 (device removal, landing chooser, discovery/sync perf)

### DIFF
--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1175,6 +1175,7 @@ func setupRouter(server *handlers.Server, stockholmHandler *stockholm.Handler, w
 	r.Use(server.RecordMiddleware)
 
 	r.Get("/", server.HandleRoot)
+	r.Get("/admin", server.HandleAdmin)
 	r.Get("/health", server.HandleHealth)
 	r.Get("/favicon.ico", func(w http.ResponseWriter, r *http.Request) {
 		// The favicon lives in the embedded web/img bundle, not under

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1125,6 +1125,13 @@ func newEmbeddedWebApp(server *handlers.Server, serverURL string, ds *datastore.
 	// UI "discover" runs the service's sweep, not a second mDNS stack.
 	webApp.TriggerDiscovery = server.DiscoverDevices
 
+	// A removal from the player UI cascades to the datastore (the single
+	// source of truth), so the device does not reappear on the next re-sync.
+	webApp.RemoveDeviceHook = func(deviceID string) error {
+		_, err := server.RemoveDeviceByID(deviceID)
+		return err
+	}
+
 	// Keep the UI registry live as the service discovers or devices are added.
 	server.SetDevicesChangedHook(func() {
 		webApp.SeedExtraDevices()

--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -34,6 +34,7 @@ GET      /accounts/{account}/devices/{device}/presets                 handlers.(
 GET      /accounts/{account}/devices/{device}/recents                 handlers.(*Server).HandleUnsupported-fm
 GET      /accounts/{account}/full                                     handlers.(*Server).HandleUnsupported-fm
 GET      /accounts/{account}/sources                                  handlers.(*Server).HandleUnsupported-fm
+GET      /admin                                                       handlers.(*Server).HandleAdmin-fm
 GET      /api/control/devices/                                        soundtouchweb.(*WebApp).HandleAPIDevices-fm
 GET      /api/control/devices/{id}/                                   soundtouchweb.(*WebApp).HandleAPIDevice-fm
 GET      /api/control/devices/{id}/action/{action}                    soundtouchweb.(*WebApp).HandleAPIControl-fm

--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -4,6 +4,7 @@ DELETE   /accounts/{account}/devices/{device}                         handlers.(
 DELETE   /accounts/{account}/group                                    handlers.(*Server).HandleUnsupported-fm
 DELETE   /accounts/{account}/group/                                   handlers.(*Server).HandleUnsupported-fm
 DELETE   /accounts/{account}/group/{groupId}                          handlers.(*Server).HandleUnsupported-fm
+DELETE   /api/control/devices/{id}/                                   soundtouchweb.(*WebApp).HandleDeleteDevice-fm
 DELETE   /api/setup/devices/{deviceId}                                handlers.(*Server).HandleRemoveDevice-fm
 DELETE   /api/setup/dns-discoveries                                   handlers.(*Server).HandleClearDNSDiscoveries-fm
 DELETE   /api/setup/interactions/sessions                             handlers.(*Server).HandleCleanupSessions-fm

--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -2627,6 +2627,15 @@ type Settings struct {
 	// is passed through verbatim; AfterTouch does not validate the
 	// individual format tokens.
 	TuneInStreamFormats string `json:"tunein_stream_formats,omitempty"`
+
+	// DefaultLanding selects what the root path "/" serves to a browser:
+	//   "chooser" (or empty) — the neutral landing page that links to the
+	//                          player and the admin/setup console;
+	//   "app"               — redirect straight to the player UI (/app);
+	//   "admin"             — redirect straight to the admin console (/admin).
+	// API/speaker clients (non-HTML Accept) always get the version JSON
+	// regardless of this setting.
+	DefaultLanding string `json:"default_landing,omitempty"`
 }
 
 // GetSettings retrieves the global service settings.

--- a/pkg/service/handlers/handlers_device_remove_test.go
+++ b/pkg/service/handlers/handlers_device_remove_test.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+// TestRemoveDeviceByID verifies the extracted removal helper deletes the
+// device from the datastore, fires the devices-changed hook (so the
+// embedded web UI re-syncs), and reports not-found without firing the
+// hook when no matching device exists.
+func TestRemoveDeviceByID(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	server := NewServer(ds, nil, "http://127.0.0.1:8000", false, false, false)
+
+	const (
+		account  = "1000001"
+		deviceID = "DEVICEID01"
+	)
+
+	if err := ds.SaveDeviceInfo(account, deviceID, &models.ServiceDeviceInfo{
+		DeviceID:  deviceID,
+		Name:      "Test Speaker",
+		IPAddress: "192.0.2.10",
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	var hookFired int
+
+	server.SetDevicesChangedHook(func() { hookFired++ })
+
+	found, err := server.RemoveDeviceByID(deviceID)
+	if err != nil {
+		t.Fatalf("RemoveDeviceByID: %v", err)
+	}
+
+	if !found {
+		t.Fatal("RemoveDeviceByID reported the device as not found")
+	}
+
+	if hookFired != 1 {
+		t.Errorf("devices-changed hook fired %d times; want 1", hookFired)
+	}
+
+	devices, err := ds.ListAllDevices()
+	if err != nil {
+		t.Fatalf("ListAllDevices: %v", err)
+	}
+
+	for i := range devices {
+		if devices[i].DeviceID == deviceID {
+			t.Error("device still present in datastore after removal")
+		}
+	}
+
+	// A second removal finds nothing and must not fire the hook again.
+	found, err = server.RemoveDeviceByID(deviceID)
+	if err != nil {
+		t.Fatalf("RemoveDeviceByID (second call): %v", err)
+	}
+
+	if found {
+		t.Error("RemoveDeviceByID reported a removed device as found")
+	}
+
+	if hookFired != 1 {
+		t.Errorf("devices-changed hook fired %d times after no-op removal; want 1", hookFired)
+	}
+}

--- a/pkg/service/handlers/handlers_landing_test.go
+++ b/pkg/service/handlers/handlers_landing_test.go
@@ -76,6 +76,25 @@ func TestHandleRootRedirects(t *testing.T) {
 	}
 }
 
+// TestHandleRootChooserOverride: "?chooser" forces the chooser even when a
+// default redirect is configured, so the hub stays reachable.
+func TestHandleRootChooserOverride(t *testing.T) {
+	for _, landing := range []string{"app", "admin"} {
+		server := newLandingServer(t, landing)
+
+		rec := httptest.NewRecorder()
+		server.HandleRoot(rec, htmlGet("/?chooser"))
+
+		if rec.Code != http.StatusOK {
+			t.Errorf("landing=%q with ?chooser: status = %d; want 200 (no redirect)", landing, rec.Code)
+		}
+
+		if !strings.Contains(rec.Body.String(), `href="/admin"`) {
+			t.Errorf("landing=%q with ?chooser: body is not the chooser", landing)
+		}
+	}
+}
+
 // TestHandleRootJSONIgnoresLanding: API/speaker clients (non-HTML Accept)
 // always get the version JSON, never a landing redirect, regardless of
 // the configured default.

--- a/pkg/service/handlers/handlers_landing_test.go
+++ b/pkg/service/handlers/handlers_landing_test.go
@@ -1,0 +1,114 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
+)
+
+func newLandingServer(t *testing.T, landing string) *Server {
+	t.Helper()
+
+	ds := datastore.NewDataStore(t.TempDir())
+	if landing != "" {
+		if err := ds.SaveSettings(datastore.Settings{
+			ServerURL:      "http://127.0.0.1:8000",
+			DefaultLanding: landing,
+		}); err != nil {
+			t.Fatalf("SaveSettings: %v", err)
+		}
+	}
+
+	return NewServer(ds, nil, "http://127.0.0.1:8000", false, false, false)
+}
+
+func htmlGet(path string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	req.Header.Set("Accept", "text/html")
+
+	return req
+}
+
+// TestHandleRootChooser: with no configured default, a browser at "/"
+// gets the neutral chooser linking to both surfaces.
+func TestHandleRootChooser(t *testing.T) {
+	server := newLandingServer(t, "")
+
+	rec := httptest.NewRecorder()
+	server.HandleRoot(rec, htmlGet("/"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+
+	body := rec.Body.String()
+	for _, want := range []string{`href="/app"`, `href="/admin"`, "Player"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("chooser body missing %q", want)
+		}
+	}
+
+	// The chooser is not the admin console.
+	if strings.Contains(body, "tab-settings") {
+		t.Error("chooser unexpectedly served the admin console")
+	}
+}
+
+// TestHandleRootRedirects: default_landing app/admin redirects "/" to the
+// matching surface for browsers.
+func TestHandleRootRedirects(t *testing.T) {
+	for landing, want := range map[string]string{"app": "/app", "admin": "/admin"} {
+		server := newLandingServer(t, landing)
+
+		rec := httptest.NewRecorder()
+		server.HandleRoot(rec, htmlGet("/"))
+
+		if rec.Code != http.StatusFound {
+			t.Errorf("landing=%q: status = %d; want 302", landing, rec.Code)
+		}
+
+		if got := rec.Header().Get("Location"); got != want {
+			t.Errorf("landing=%q: Location = %q; want %q", landing, got, want)
+		}
+	}
+}
+
+// TestHandleRootJSONIgnoresLanding: API/speaker clients (non-HTML Accept)
+// always get the version JSON, never a landing redirect, regardless of
+// the configured default.
+func TestHandleRootJSONIgnoresLanding(t *testing.T) {
+	server := newLandingServer(t, "app")
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Accept", "application/json")
+
+	rec := httptest.NewRecorder()
+	server.HandleRoot(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200 (not a redirect)", rec.Code)
+	}
+
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("Content-Type = %q; want application/json", ct)
+	}
+}
+
+// TestHandleAdminServesConsole: /admin serves the admin console itself.
+func TestHandleAdminServesConsole(t *testing.T) {
+	server := newLandingServer(t, "")
+
+	rec := httptest.NewRecorder()
+	server.HandleAdmin(rec, htmlGet("/admin"))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200", rec.Code)
+	}
+
+	if !strings.Contains(rec.Body.String(), "tab-settings") {
+		t.Error("admin body did not contain the console markup")
+	}
+}

--- a/pkg/service/handlers/handlers_media.go
+++ b/pkg/service/handlers/handlers_media.go
@@ -117,15 +117,20 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// HTML branch: a browser hitting "/". Honour the configured default
-	// landing surface, otherwise serve the neutral chooser. The admin
-	// console itself now lives at /admin (served by HandleAdmin).
-	switch s.defaultLanding() {
-	case "app":
-		http.Redirect(w, r, "/app", http.StatusFound)
-		return
-	case "admin":
-		http.Redirect(w, r, "/admin", http.StatusFound)
-		return
+	// landing surface, otherwise serve the neutral chooser. A "?chooser"
+	// query forces the chooser even when a default redirect is set, so the
+	// hub (and through it the admin console) stays reachable: the "home"
+	// links on the player and admin point here. The admin console itself
+	// lives at /admin (served by HandleAdmin).
+	if !r.URL.Query().Has("chooser") {
+		switch s.defaultLanding() {
+		case "app":
+			http.Redirect(w, r, "/app", http.StatusFound)
+			return
+		case "admin":
+			http.Redirect(w, r, "/admin", http.StatusFound)
+			return
+		}
 	}
 
 	w.Header().Set("Content-Type", "text/html")

--- a/pkg/service/handlers/handlers_media.go
+++ b/pkg/service/handlers/handlers_media.go
@@ -13,6 +13,9 @@ import (
 //go:embed web/index.html
 var indexHTML []byte
 
+//go:embed web/landing.html
+var landingHTML []byte
+
 //go:embed web/css/* web/js/* web/img/favicon-braille* web/img/favicon*
 var webFS embed.FS
 
@@ -113,8 +116,41 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// HTML branch: a browser hitting "/". Honour the configured default
+	// landing surface, otherwise serve the neutral chooser. The admin
+	// console itself now lives at /admin (served by HandleAdmin).
+	switch s.defaultLanding() {
+	case "app":
+		http.Redirect(w, r, "/app", http.StatusFound)
+		return
+	case "admin":
+		http.Redirect(w, r, "/admin", http.StatusFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/html")
+	_, _ = w.Write(landingHTML)
+}
+
+// HandleAdmin serves the admin / setup console. It used to live at "/";
+// the chooser landing page took that spot, so the console moved here.
+// Its assets (/web/*) and APIs (/setup, /mgmt) are absolute, so the page
+// works unchanged at the new path.
+func (s *Server) HandleAdmin(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html")
 	_, _ = w.Write(indexHTMLVersioned)
+}
+
+// defaultLanding returns the configured root-path behaviour for browsers
+// ("chooser", "app", or "admin"), defaulting to "chooser" when unset or
+// unreadable.
+func (s *Server) defaultLanding() string {
+	persisted, err := s.ds.GetSettings()
+	if err != nil || persisted.DefaultLanding == "" {
+		return "chooser"
+	}
+
+	return persisted.DefaultLanding
 }
 
 // HandleWeb returns a handler for serving web resources.

--- a/pkg/service/handlers/handlers_setup.go
+++ b/pkg/service/handlers/handlers_setup.go
@@ -189,6 +189,8 @@ func (s *Server) HandleGetSettings(w http.ResponseWriter, _ *http.Request) {
 
 	dnsRunning, actualBind := s.GetDNSRunning()
 
+	defaultLanding := s.defaultLanding()
+
 	var serverURLResolvedIP, serverURLResolveError string
 
 	if ip, err := s.resolveServerURLIP(serverURL); err == nil {
@@ -266,6 +268,7 @@ func (s *Server) HandleGetSettings(w http.ResponseWriter, _ *http.Request) {
 		"tts_language":                  ttsLanguage,
 		"tts_voice":                     ttsVoice,
 		"tts_volume":                    ttsVolume,
+		"default_landing":               defaultLanding,
 	}); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 		return
@@ -296,9 +299,19 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		TTSVoice            string         `json:"tts_voice"`
 		TTSVolume           int            `json:"tts_volume"`
 		TLSExtraHosts       *[]string      `json:"tls_extra_hosts"`
+		DefaultLanding      string         `json:"default_landing"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Normalise + validate the landing choice. Empty means "chooser".
+	defaultLanding := strings.ToLower(strings.TrimSpace(settings.DefaultLanding))
+	switch defaultLanding {
+	case "", "chooser", "app", "admin":
+	default:
+		http.Error(w, "Invalid default_landing: must be chooser, app, or admin", http.StatusBadRequest)
 		return
 	}
 
@@ -420,6 +433,7 @@ func (s *Server) HandleUpdateSettings(w http.ResponseWriter, r *http.Request) {
 		TTSVoice:            s.ttsVoice,
 		TTSVolume:           s.ttsVolume,
 		TLSExtraHosts:       resolvedTLSExtraHosts,
+		DefaultLanding:      defaultLanding,
 	})
 
 	dnsEnabled := s.dnsEnabled

--- a/pkg/service/handlers/handlers_setup.go
+++ b/pkg/service/handlers/handlers_setup.go
@@ -101,6 +101,34 @@ func (s *Server) HandleGetDiscoveryStatus(w http.ResponseWriter, _ *http.Request
 	}
 }
 
+// RemoveDeviceByID removes the device with the given device ID (MAC) from
+// the datastore, searching across all accounts. It returns whether a
+// matching device was found. On a successful removal it notifies
+// observers (e.g. the embedded web UI) so they re-sync — the symmetric
+// counterpart to the notify in HandleAddManualDevice.
+func (s *Server) RemoveDeviceByID(deviceID string) (bool, error) {
+	devices, err := s.ds.ListAllDevices()
+	if err != nil {
+		return false, err
+	}
+
+	for i := range devices {
+		if devices[i].DeviceID == deviceID {
+			if err := s.ds.RemoveDevice(devices[i].AccountID, devices[i].DeviceID); err != nil {
+				return false, err
+			}
+
+			// Let any observer (e.g. the embedded web UI) re-sync from the
+			// datastore so the removal propagates to the player UI.
+			s.notifyDevicesChanged()
+
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // HandleRemoveDevice removes a device from the datastore.
 func (s *Server) HandleRemoveDevice(w http.ResponseWriter, r *http.Request) {
 	deviceId := chi.URLParam(r, "deviceId")
@@ -109,27 +137,10 @@ func (s *Server) HandleRemoveDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Find which account this device belongs to.
-	devices, err := s.ds.ListAllDevices()
+	found, err := s.RemoveDeviceByID(deviceId)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
-	}
-
-	var found bool
-
-	for i := range devices {
-		if devices[i].DeviceID == deviceId {
-			err = s.ds.RemoveDevice(devices[i].AccountID, devices[i].DeviceID)
-			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-				return
-			}
-
-			found = true
-
-			break
-		}
 	}
 
 	if !found {

--- a/pkg/service/handlers/web/css/style.css
+++ b/pkg/service/handlers/web/css/style.css
@@ -1,4 +1,33 @@
 body { font-family: sans-serif; margin: 20px; }
+
+/* Shared accent bar (matches the app navbar and the landing page). It
+   breaks out of the body's 20px margin to sit full-bleed at the top. */
+.topbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    height: 52px;
+    padding: 0 1.25rem;
+    margin: -20px -20px 16px;
+    background: #1a1a1a;
+    color: #fff;
+}
+.topbar .brand { display: flex; align-items: center; gap: .5rem; text-decoration: none; color: inherit; }
+.topbar .brand img { width: 24px; height: 24px; filter: brightness(0) invert(1); }
+.topbar .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
+.topbar .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: .02em; }
+.topbar .brand-subtitle { font-size: .7rem; font-weight: 400; opacity: .7; }
+.topbar .bar-links a {
+    color: #fff;
+    font-size: .85rem;
+    opacity: .85;
+    text-decoration: none;
+    padding: .35rem .5rem;
+    border-radius: 4px;
+}
+.topbar .bar-links a:hover { opacity: 1; background: rgba(255, 255, 255, .12); }
+@media (max-width: 480px) { .topbar .brand-subtitle { display: none; } }
 table { border-collapse: collapse; width: 100%; }
 th, td { border: 1px solid #ddd; padding: 8px; text-align: left; }
 th { background-color: #f2f2f2; }

--- a/pkg/service/handlers/web/css/style.css
+++ b/pkg/service/handlers/web/css/style.css
@@ -18,7 +18,11 @@ body { font-family: sans-serif; margin: 20px; }
 .topbar .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
 .topbar .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: .02em; }
 .topbar .brand-subtitle { font-size: .7rem; font-weight: 400; opacity: .7; }
+.topbar .bar-links { display: flex; align-items: center; gap: .25rem; }
 .topbar .bar-links a {
+    display: inline-flex;
+    align-items: center;
+    gap: .3rem;
     color: #fff;
     font-size: .85rem;
     opacity: .85;

--- a/pkg/service/handlers/web/css/style.css
+++ b/pkg/service/handlers/web/css/style.css
@@ -14,7 +14,8 @@ body { font-family: sans-serif; margin: 20px; }
     color: #fff;
 }
 .topbar .brand { display: flex; align-items: center; gap: .5rem; text-decoration: none; color: inherit; }
-.topbar .brand img { width: 24px; height: 24px; filter: brightness(0) invert(1); }
+/* Keep the braille mark in its brand colours; the rest of the bar stays monochrome. */
+.topbar .brand img { width: 24px; height: 24px; }
 .topbar .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
 .topbar .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: .02em; }
 .topbar .brand-subtitle { font-size: .7rem; font-weight: 400; opacity: .7; }

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
 <header class="topbar">
-    <a class="brand" href="/" title="AfterTouch home">
+    <a class="brand" href="/?chooser" title="AfterTouch home">
         <img src="/web/img/favicon-braille.svg" alt=""/>
         <span class="brand-text">
             <span class="brand-name">AfterTouch</span>

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -8,18 +8,20 @@
     <link rel="stylesheet" href="/web/css/style.css"/>
 </head>
 <body>
-<h1><img src="/web/img/favicon-braille.svg" alt="AfterTouch Logo" class="logo"/>AfterTouch</h1>
-<p style="margin-top: -10px; font-style: italic; color: #666">
-    Bose SoundTouch Toolkit
-</p>
-<p style="margin-top: -4px">
-    <a href="/app" style="font-weight: bold">🎵 Open the Player (Web UI) →</a>
-    <span style="font-size: 0.85em; color: #666; margin-left: 8px">
-        Control playback, volume, presets, zones, and browse TuneIn / RadioBrowser.
-    </span>
-</p>
-<p style="margin-top: 2px; font-size: 0.85em; color: #888">
-    This page is the admin / setup console (migration, settings, diagnostics).
+<header class="topbar">
+    <a class="brand" href="/" title="AfterTouch home">
+        <img src="/web/img/favicon-braille.svg" alt=""/>
+        <span class="brand-text">
+            <span class="brand-name">AfterTouch</span>
+            <span class="brand-subtitle">Bose SoundTouch Toolkit</span>
+        </span>
+    </a>
+    <nav class="bar-links">
+        <a href="/app">Open the Player &rarr;</a>
+    </nav>
+</header>
+<p style="margin: 0 0 16px; font-size: 0.9em; color: #888">
+    Admin &amp; Setup console: migration, settings, accounts, and diagnostics.
 </p>
 
 <div class="tabs">
@@ -173,6 +175,18 @@
             <span style="font-size: 0.8em; color: #666">(Standard services URL)</span>
             <div id="target-domain-resolved" style="font-size: 0.85em; margin-top: 4px; min-height: 1.2em"></div>
             <div id="https-443-status" style="font-size: 0.85em; margin-top: 4px; min-height: 1.2em"></div>
+        </div>
+        <div style="margin-bottom: 20px">
+            <label for="default-landing">Landing page (<code>/</code>):</label>
+            <select id="default-landing" style="margin-left: 4px">
+                <option value="chooser">Chooser (pick Player or Admin)</option>
+                <option value="app">Go straight to the Player</option>
+                <option value="admin">Go straight to Admin &amp; Setup</option>
+            </select>
+            <div style="font-size: 0.85em; color: #666; margin-top: 4px;">
+                What a browser sees at the root URL. The Player and Admin pages
+                stay reachable at <code>/app</code> and <code>/admin</code> either way.
+            </div>
         </div>
         <div style="margin-bottom: 20px">
             <strong>TLS extra hosts:</strong>

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -17,6 +17,13 @@
         </span>
     </a>
     <nav class="bar-links">
+        <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener" title="Documentation">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+            </svg>
+            Docs
+        </a>
         <a href="/app">Open the Player &rarr;</a>
     </nav>
 </header>

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -515,6 +515,32 @@ async function updateSettings() {
     }
 }
 
+// LIVE_INFO_CONCURRENCY caps how many live /info probes run at once. The
+// browser allows ~6 connections per origin over HTTP/1.1; staying below
+// that leaves sockets free so a navigation (or other request) is never
+// stuck behind a batch of slow/offline-device probes.
+const LIVE_INFO_CONCURRENCY = 3;
+
+// mapLimit runs fn over items with at most `limit` concurrent invocations,
+// resolving when all have settled. fn may be async; its rejections are
+// swallowed so one failure does not stop the rest.
+async function mapLimit(items, limit, fn) {
+    let next = 0;
+    const worker = async () => {
+        while (next < items.length) {
+            const item = items[next++];
+            try {
+                await fn(item);
+            } catch (_) {
+                /* individual probe failures are non-fatal */
+            }
+        }
+    };
+    await Promise.all(
+        Array.from({ length: Math.min(limit, items.length) }, worker),
+    );
+}
+
 async function fetchDevices() {
     try {
         const response = await fetch("/api/setup/devices");
@@ -584,8 +610,14 @@ async function fetchDevices() {
             if (currentMigrationVal) migrationSelector.value = currentMigrationVal;
             if (eventSelector && currentEventVal) eventSelector.value = currentEventVal;
 
-            // Asynchronously fetch live info for each device
-            devices.forEach((d) => updateDeviceInfo(d.device_id, d.ip_address));
+            // Refresh each device's live /info, but cap how many run at
+            // once. A browser only opens ~6 connections per origin over
+            // HTTP/1.1; an offline speaker holds its /info request until the
+            // timeout, so probing every device at once can starve the pool
+            // and make the whole page (including navigating away) wait for
+            // those requests to clear. Capping below the limit keeps sockets
+            // free for navigation and other requests.
+            mapLimit(devices, LIVE_INFO_CONCURRENCY, (d) => updateDeviceInfo(d.device_id, d.ip_address));
             fetchSpotifyStatus();
         }
 

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -811,7 +811,7 @@ async function fetchVersion() {
                 const shortCommit = data.commit.substring(0, 7);
                 commitStr = `<a href="${data.commit_url}" target="_blank" style="color: inherit; text-decoration: underline;">${shortCommit}</a>`;
             }
-            info.innerHTML = `AfterTouch ${versionStr} (${commitStr}) - ${data.date}`;
+            info.innerHTML = `AfterTouch ${versionStr} (${commitStr}) • ${data.date}`;
         }
     } catch (error) {
         console.error("Failed to fetch version info", error);

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -1726,7 +1726,7 @@ document.addEventListener("DOMContentLoaded", async () => {
     const deviceCount = await fetchDevices();
     // Only sweep automatically on a cold start (no devices known yet). When
     // devices are already in the store, rely on the cached list plus the
-    // periodic sweep and the explicit Discover button — re-probing offline
+    // periodic sweep and the explicit Discover button. Re-probing offline
     // speakers on every admin page load was slow and surprising.
     if (deviceCount === 0 && cfg?.discovery_enabled !== false) {
         triggerDiscovery();
@@ -4145,14 +4145,6 @@ async function applyCustomPlan() {
         if (applyBtn) applyBtn.disabled = false;
     }
 }
-
-document.addEventListener("DOMContentLoaded", async () => {
-    fetchDevices();
-    const cfg = await fetchSettings();
-    if (cfg?.discovery_enabled !== false) {
-        triggerDiscovery();
-    }
-});
 
 // ---------------------------------------------------------------------------
 // Health tab

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -322,6 +322,9 @@ async function fetchSettings() {
         if (settings.discovery_enabled !== undefined) {
             document.getElementById("discovery-enabled").checked = settings.discovery_enabled;
         }
+        if (settings.default_landing) {
+            document.getElementById("default-landing").value = settings.default_landing;
+        }
         if (settings.dns_enabled !== undefined) {
             document.getElementById("dns-enabled").checked = settings.dns_enabled;
         }
@@ -460,6 +463,7 @@ async function updateLoggingSettings() {
 async function updateSettings() {
     const settings = {
         server_url: document.getElementById("target-domain").value,
+        default_landing: document.getElementById("default-landing").value,
         discovery_interval: document.getElementById("discovery-interval").value,
         discovery_enabled: document.getElementById("discovery-enabled").checked,
         dns_enabled: document.getElementById("dns-enabled").checked,

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -588,8 +588,11 @@ async function fetchDevices() {
             devices.forEach((d) => updateDeviceInfo(d.device_id, d.ip_address));
             fetchSpotifyStatus();
         }
+
+        return devices.length;
     } catch (error) {
         document.getElementById("device-list").textContent = "Error loading devices: " + error;
+        return 0;
     }
 }
 
@@ -1719,11 +1722,15 @@ function formatXML(xml) {
 
 document.addEventListener("DOMContentLoaded", async () => {
     const cfg = await fetchSettings();
-    if (cfg?.discovery_enabled !== false) {
+    fetchVersion();
+    const deviceCount = await fetchDevices();
+    // Only sweep automatically on a cold start (no devices known yet). When
+    // devices are already in the store, rely on the cached list plus the
+    // periodic sweep and the explicit Discover button — re-probing offline
+    // speakers on every admin page load was slow and surprising.
+    if (deviceCount === 0 && cfg?.discovery_enabled !== false) {
         triggerDiscovery();
     }
-    fetchVersion();
-    await fetchDevices();
 
     const hash = window.location.hash.slice(1);
     const [tabId, extra] = hash.split('?');

--- a/pkg/service/handlers/web/landing.html
+++ b/pkg/service/handlers/web/landing.html
@@ -163,7 +163,7 @@
 </head>
 <body>
     <header class="topbar">
-        <a class="brand" href="/" title="AfterTouch home">
+        <a class="brand" href="/?chooser" title="AfterTouch home">
             <img src="/web/img/favicon-braille.svg" alt=""/>
             <span class="brand-text">
                 <span class="brand-name">AfterTouch</span>

--- a/pkg/service/handlers/web/landing.html
+++ b/pkg/service/handlers/web/landing.html
@@ -70,14 +70,6 @@
         .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
         .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
         .brand-subtitle { font-size: 0.7rem; font-weight: 400; opacity: 0.7; }
-        .bar-links a {
-            font-size: 0.85rem;
-            opacity: 0.8;
-            padding: 0.35rem 0.5rem;
-            border-radius: 4px;
-            transition: opacity 0.15s, background 0.15s;
-        }
-        .bar-links a:hover { opacity: 1; background: rgba(127, 127, 127, 0.18); }
 
         /* ── Chooser ─────────────────────────────────────────────────── */
         main {
@@ -148,17 +140,28 @@
             padding: 0.1rem 0.5rem;
         }
 
-        /* ── Footer (version line, like the app and admin) ───────────── */
+        /* Prominent docs link, distinct from the two destination rows. */
+        .docs-link {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            margin-top: 1.5rem;
+            font-size: 0.95rem;
+            color: var(--text-dim);
+            transition: color 0.15s;
+        }
+        .docs-link:hover { color: var(--text); }
+        .docs-link svg { flex-shrink: 0; }
+
+        /* ── Footer (version line, identical to the app and admin) ────── */
         footer {
-            max-width: 32rem;
-            margin: 0 auto;
-            padding: 1.5rem;
+            padding: 1.5rem 1rem;
+            text-align: center;
             font-size: 0.8rem;
             color: var(--text-dim);
         }
         footer a { text-decoration: underline; text-underline-offset: 2px; }
         footer a:hover { color: var(--text); }
-        .dot { opacity: 0.5; padding: 0 0.15rem; }
     </style>
 </head>
 <body>
@@ -170,9 +173,6 @@
                 <span class="brand-subtitle">Bose SoundTouch Toolkit</span>
             </span>
         </a>
-        <nav class="bar-links">
-            <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener">Documentation</a>
-        </nav>
     </header>
 
     <main>
@@ -196,12 +196,18 @@
                 <span class="arrow" aria-hidden="true">&rarr;</span>
             </a>
         </nav>
+
+        <a class="docs-link" href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+            </svg>
+            Documentation
+        </a>
     </main>
 
     <footer>
         <span id="version-info">AfterTouch</span>
-        <span class="dot">&middot;</span>
-        <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener">Documentation</a>
     </footer>
 
     <script>

--- a/pkg/service/handlers/web/landing.html
+++ b/pkg/service/handlers/web/landing.html
@@ -1,0 +1,237 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>AfterTouch</title>
+    <meta name="description" content="AfterTouch — a local replacement for the Bose SoundTouch cloud. Open the player or the admin console."/>
+    <link rel="icon" href="/web/img/favicon-braille.svg" type="image/svg+xml"/>
+    <style>
+        :root {
+            /* Tinted neutrals (OKLCH), a hair warm so the page reads calm.
+               One live-green accent marks the everyday player. The accent
+               bar mirrors the app navbar (dark bar / light text). */
+            --bg:        oklch(0.972 0.004 95);
+            --surface:   oklch(0.995 0.003 95);
+            --border:    oklch(0.905 0.006 95);
+            --text:      oklch(0.255 0.012 95);
+            --text-dim:  oklch(0.520 0.012 95);
+            --hover:     oklch(0.955 0.006 95);
+            --live:      oklch(0.640 0.150 150);
+            --accent:    oklch(0.220 0.010 95);
+            --accent-fg: oklch(0.980 0.003 95);
+            --radius:    12px;
+            --logo-filter: brightness(0) invert(1);
+        }
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg:        oklch(0.175 0.005 95);
+                --surface:   oklch(0.215 0.006 95);
+                --border:    oklch(0.305 0.008 95);
+                --text:      oklch(0.925 0.008 95);
+                --text-dim:  oklch(0.660 0.012 95);
+                --hover:     oklch(0.255 0.008 95);
+                --live:      oklch(0.720 0.150 150);
+                --accent:    oklch(0.860 0.006 95);
+                --accent-fg: oklch(0.200 0.005 95);
+                --logo-filter: none;
+            }
+        }
+
+        *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+        html, body { height: 100%; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            font-size: 15px;
+            background: var(--bg);
+            color: var(--text);
+            line-height: 1.5;
+            -webkit-font-smoothing: antialiased;
+            display: flex;
+            flex-direction: column;
+            min-height: 100%;
+        }
+        a { color: inherit; text-decoration: none; }
+
+        /* ── Shared accent bar (mirrors the app navbar) ──────────────── */
+        .topbar {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            height: 52px;
+            padding: 0 1.25rem;
+            background: var(--accent);
+            color: var(--accent-fg);
+        }
+        .brand { display: flex; align-items: center; gap: 0.5rem; }
+        .brand img { width: 24px; height: 24px; filter: var(--logo-filter); }
+        .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
+        .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
+        .brand-subtitle { font-size: 0.7rem; font-weight: 400; opacity: 0.7; }
+        .bar-links a {
+            font-size: 0.85rem;
+            opacity: 0.8;
+            padding: 0.35rem 0.5rem;
+            border-radius: 4px;
+            transition: opacity 0.15s, background 0.15s;
+        }
+        .bar-links a:hover { opacity: 1; background: rgba(127, 127, 127, 0.18); }
+
+        /* ── Chooser ─────────────────────────────────────────────────── */
+        main {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            width: 100%;
+            max-width: 32rem;
+            margin: 0 auto;
+            padding: 2rem 1.5rem;
+        }
+        .lead {
+            font-size: 1.05rem;
+            color: var(--text-dim);
+            margin-bottom: 1.75rem;
+            max-width: 28rem;
+        }
+
+        nav.dest-list {
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            background: var(--surface);
+            overflow: hidden;
+        }
+        .dest {
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: center;
+            gap: 0.2rem 1rem;
+            padding: 1.15rem 1.25rem;
+            transition: background 0.18s cubic-bezier(0.22, 1, 0.36, 1);
+        }
+        .dest + .dest { border-top: 1px solid var(--border); }
+        .dest:hover { background: var(--hover); }
+        .dest:focus-visible { outline: 2px solid var(--live); outline-offset: -2px; }
+
+        .dest .label {
+            display: flex;
+            align-items: baseline;
+            gap: 0.55rem;
+            font-size: 1.15rem;
+            font-weight: 600;
+        }
+        .dest .desc { grid-column: 1; font-size: 0.88rem; color: var(--text-dim); }
+        .dest .arrow {
+            grid-row: 1 / span 2;
+            grid-column: 2;
+            font-size: 1.2rem;
+            color: var(--text-dim);
+            transition: transform 0.22s cubic-bezier(0.22, 1, 0.36, 1), color 0.18s;
+        }
+        .dest:hover .arrow { transform: translateX(4px); }
+        /* The player is the everyday surface: its arrow carries the live
+           accent so the eye lands there first. */
+        .dest--player:hover .arrow { color: var(--live); }
+
+        /* The console is the privileged surface: a key glyph and a quiet
+           tag mark it as setup / diagnostics rather than daily use. */
+        .tag {
+            font-size: 0.7rem;
+            font-weight: 500;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+            color: var(--text-dim);
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 0.1rem 0.5rem;
+        }
+
+        /* ── Footer (version line, like the app and admin) ───────────── */
+        footer {
+            max-width: 32rem;
+            margin: 0 auto;
+            padding: 1.5rem;
+            font-size: 0.8rem;
+            color: var(--text-dim);
+        }
+        footer a { text-decoration: underline; text-underline-offset: 2px; }
+        footer a:hover { color: var(--text); }
+        .dot { opacity: 0.5; padding: 0 0.15rem; }
+    </style>
+</head>
+<body>
+    <header class="topbar">
+        <a class="brand" href="/" title="AfterTouch home">
+            <img src="/web/img/favicon-braille.svg" alt=""/>
+            <span class="brand-text">
+                <span class="brand-name">AfterTouch</span>
+                <span class="brand-subtitle">Bose SoundTouch Toolkit</span>
+            </span>
+        </a>
+        <nav class="bar-links">
+            <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener">Documentation</a>
+        </nav>
+    </header>
+
+    <main>
+        <p class="lead">
+            Your SoundTouch speakers, kept playing on your own network
+            after the Bose cloud shutdown. Where to?
+        </p>
+
+        <nav class="dest-list" aria-label="Choose a surface">
+            <a class="dest dest--player" href="/app">
+                <span class="label">Player</span>
+                <span class="desc">Playback, volume, presets, zones, and TuneIn / RadioBrowser.</span>
+                <span class="arrow" aria-hidden="true">&rarr;</span>
+            </a>
+            <a class="dest dest--admin" href="/admin">
+                <span class="label">
+                    Admin &amp; Setup
+                    <span class="tag">console</span>
+                </span>
+                <span class="desc">Migrate speakers, settings, accounts, and diagnostics.</span>
+                <span class="arrow" aria-hidden="true">&rarr;</span>
+            </a>
+        </nav>
+    </main>
+
+    <footer>
+        <span id="version-info">AfterTouch</span>
+        <span class="dot">&middot;</span>
+        <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener">Documentation</a>
+    </footer>
+
+    <script>
+        // Mirror the version line the app and admin footers show. Same
+        // /api/setup/version payload, kept to a tiny vanilla fetch so the
+        // landing page carries no framework.
+        (async function () {
+            try {
+                const data = await (await fetch('/api/setup/version')).json();
+                if (!data || !data.version) return;
+                let v = data.version;
+                if (data.release_url) {
+                    v = `<a href="${data.release_url}" target="_blank" rel="noopener">${data.version}</a>`;
+                }
+                let line = `AfterTouch ${v}`;
+                if (data.commit && data.commit !== 'unknown') {
+                    const short = data.commit.substring(0, 7);
+                    const c = data.commit_url
+                        ? `<a href="${data.commit_url}" target="_blank" rel="noopener">${short}</a>`
+                        : short;
+                    line += ` (${c})`;
+                }
+                if (data.date && data.date !== 'unknown') {
+                    line += ` &bull; ${data.date}`;
+                }
+                document.getElementById('version-info').innerHTML = line;
+            } catch (e) {
+                /* leave the static "AfterTouch" fallback in place */
+            }
+        })();
+    </script>
+</body>
+</html>

--- a/pkg/service/handlers/web/landing.html
+++ b/pkg/service/handlers/web/landing.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>AfterTouch</title>
-    <meta name="description" content="AfterTouch — a local replacement for the Bose SoundTouch cloud. Open the player or the admin console."/>
+    <meta name="description" content="AfterTouch: a local replacement for the Bose SoundTouch cloud. Open the player or the admin console."/>
     <link rel="icon" href="/web/img/favicon-braille.svg" type="image/svg+xml"/>
     <style>
         :root {

--- a/pkg/service/handlers/web/landing.html
+++ b/pkg/service/handlers/web/landing.html
@@ -21,7 +21,6 @@
             --accent:    oklch(0.220 0.010 95);
             --accent-fg: oklch(0.980 0.003 95);
             --radius:    12px;
-            --logo-filter: brightness(0) invert(1);
         }
         @media (prefers-color-scheme: dark) {
             :root {
@@ -34,7 +33,6 @@
                 --live:      oklch(0.720 0.150 150);
                 --accent:    oklch(0.860 0.006 95);
                 --accent-fg: oklch(0.200 0.005 95);
-                --logo-filter: none;
             }
         }
 
@@ -66,7 +64,8 @@
             color: var(--accent-fg);
         }
         .brand { display: flex; align-items: center; gap: 0.5rem; }
-        .brand img { width: 24px; height: 24px; filter: var(--logo-filter); }
+        /* Keep the braille mark in its brand colours; the bar stays monochrome. */
+        .brand img { width: 24px; height: 24px; }
         .brand-text { display: flex; flex-direction: column; line-height: 1.1; }
         .brand-name { font-size: 1.1rem; font-weight: 600; letter-spacing: 0.02em; }
         .brand-subtitle { font-size: 0.7rem; font-weight: 400; opacity: 0.7; }

--- a/pkg/service/setup/setup.go
+++ b/pkg/service/setup/setup.go
@@ -178,11 +178,26 @@ func NewManager(serverURL string, ds *datastore.DataStore, cm *certmanager.Certi
 		NewSession: func(deviceIP, deviceID string, stepTimeout time.Duration) (StateMachine, error) {
 			return DialSession(deviceIP, deviceID, SessionConfig{StepTimeout: stepTimeout})
 		},
-		HTTPGet:      http.Get,
+		// Bound the speaker GETs (/info, /presets, /recents, /sources,
+		// inspect, peer probes). The default http.Get uses
+		// http.DefaultClient, which has no timeout, so an offline speaker
+		// hangs the caller for the full OS-level TCP timeout (~30 s). That
+		// is fine for a one-off, but the admin device list refreshes every
+		// device's live /info on each load, so a few offline speakers used
+		// to stall the page for 30 s each. A healthy speaker answers in well
+		// under a second on the LAN; liveDeviceHTTPTimeout fails the dead
+		// ones fast instead.
+		HTTPGet:      (&http.Client{Timeout: liveDeviceHTTPTimeout}).Get,
 		MgmtUsername: "admin",
 		MgmtPassword: "change_me!",
 	}
 }
+
+// liveDeviceHTTPTimeout bounds the plain HTTP GETs the Manager makes to a
+// speaker's :8090 endpoints. Generous enough for a healthy speaker on a
+// busy LAN, short enough that an offline speaker fails quickly rather than
+// holding a request (and a browser connection slot) for ~30 s.
+const liveDeviceHTTPTimeout = 5 * time.Second
 
 // DeviceInfoXML represents the XML structure from :8090/info
 type DeviceInfoXML struct {

--- a/pkg/service/soundtouchweb/discovery.go
+++ b/pkg/service/soundtouchweb/discovery.go
@@ -3,6 +3,7 @@ package soundtouchweb
 import (
 	"context"
 	"log"
+	"sync"
 	"time"
 
 	"github.com/gesellix/bose-soundtouch/pkg/client"
@@ -95,18 +96,34 @@ func (app *WebApp) AddDeviceByHost(host string, port int, source string) {
 // (if set) via AddDeviceByHost. Idempotent: already-known hosts are skipped.
 // Used by the embedded build to surface the service datastore's devices even
 // when network discovery is disabled; a no-op for standalone soundtouch-web.
+//
+// Hosts are probed concurrently: AddDeviceByHost makes a blocking /info call
+// (up to its 10 s timeout) for each unknown host, so an offline speaker in the
+// datastore would otherwise stall the whole seed for 10 s, serially. Fanning
+// out bounds the cost to roughly a single timeout regardless of how many
+// devices are offline. AddDeviceByHost is registry-safe under concurrency.
 func (app *WebApp) SeedExtraDevices() {
 	if app.ExtraDeviceHosts == nil {
 		return
 	}
+
+	var wg sync.WaitGroup
 
 	for _, host := range app.ExtraDeviceHosts() {
 		if host == "" {
 			continue
 		}
 
-		app.AddDeviceByHost(host, 8090, "service-store")
+		wg.Add(1)
+
+		go func(h string) {
+			defer wg.Done()
+
+			app.AddDeviceByHost(h, 8090, "service-store")
+		}(host)
 	}
+
+	wg.Wait()
 }
 
 // DiscoverDevices refreshes the device registry. When TriggerDiscovery is set

--- a/pkg/service/soundtouchweb/discovery.go
+++ b/pkg/service/soundtouchweb/discovery.go
@@ -78,8 +78,13 @@ func (app *WebApp) AddDeviceByHost(host string, port int, source string) {
 		ticker := time.NewTicker(30 * time.Second)
 		defer ticker.Stop()
 
-		for range ticker.C {
-			app.UpdateDeviceStatus(host, conn)
+		for {
+			select {
+			case <-ticker.C:
+				app.UpdateDeviceStatus(host, conn)
+			case <-conn.Done():
+				return
+			}
 		}
 	}()
 

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -63,6 +63,13 @@ type WebApp struct {
 	// soundtouch-web leaves it nil and runs its own sweep.
 	TriggerDiscovery func(ctx context.Context)
 
+	// RemoveDeviceHook, when set, removes a device from the backing store by
+	// its device ID (MAC). The embedded build wires it to the service's
+	// datastore removal so a removal from the player UI also clears the
+	// persisted device; standalone soundtouch-web leaves it nil (no store, so
+	// removal only prunes the in-memory registry).
+	RemoveDeviceHook func(deviceID string) error
+
 	discoveryStatus atomic.Value // stores *webtypes.DiscoveryStatus
 }
 
@@ -108,8 +115,9 @@ func (app *WebApp) GetDevice(id string) (*webtypes.DeviceConnection, bool) {
 // DeviceSnapshot returns a list of (id, *DeviceConnection) pairs taken
 // under a single read lock. Callers can iterate the result without
 // holding any registry lock. Devices added or removed after the call
-// are not reflected; the pointers themselves remain valid because
-// nothing deletes from the underlying map today.
+// are not reflected. A pointer captured here stays valid even if the
+// device is later removed (RemoveDevice only detaches it from the map
+// and stops its goroutines), so iterating a stale snapshot is safe.
 func (app *WebApp) DeviceSnapshot() []DeviceEntry {
 	app.devicesMu.RLock()
 	defer app.devicesMu.RUnlock()
@@ -163,6 +171,27 @@ func (app *WebApp) TouchDevice(id string) bool {
 	existing.LastSeen = time.Now()
 
 	return true
+}
+
+// RemoveDevice removes the device registered under id and stops its
+// background goroutines (status poller + WebSocket reconnect loop) via
+// conn.Close. Returns true if id was present. Close runs outside the
+// registry lock because it performs network I/O (WebSocket disconnect).
+func (app *WebApp) RemoveDevice(id string) bool {
+	app.devicesMu.Lock()
+
+	conn, ok := app.devices[id]
+	if ok {
+		delete(app.devices, id)
+	}
+
+	app.devicesMu.Unlock()
+
+	if ok {
+		conn.Close()
+	}
+
+	return ok
 }
 
 // HandleAPIDevices returns all devices as JSON
@@ -224,6 +253,52 @@ func (app *WebApp) HandleAPIDevice(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// HandleDeleteDevice removes a device from the registry and, in the
+// embedded build, from the service datastore. The registry is keyed by
+// host/IP (the {id} URL param); the datastore is keyed by device ID
+// (MAC), so we resolve one to the other via the connection's DeviceInfo
+// before cascading. A device still live on the network is re-discovered
+// on the next sweep — removal is "remove now", not a permanent ban.
+func (app *WebApp) HandleDeleteDevice(w http.ResponseWriter, r *http.Request) {
+	host := chi.URLParam(r, "id")
+	if host == "" {
+		app.sendError(w, "Device ID required", http.StatusBadRequest)
+		return
+	}
+
+	conn, exists := app.GetDevice(host)
+	if !exists {
+		app.sendError(w, "Device not found", http.StatusNotFound)
+		return
+	}
+
+	// Cascade to the backing store (embedded build only). Standalone
+	// soundtouch-web has no datastore and leaves the hook nil, so removal
+	// only prunes the in-memory registry below.
+	if app.RemoveDeviceHook != nil {
+		deviceID := ""
+		if conn.DeviceInfo != nil {
+			deviceID = conn.DeviceInfo.DeviceID
+		}
+
+		if err := app.RemoveDeviceHook(deviceID); err != nil {
+			log.Printf("Failed to remove device %s from store: %v", sanitizeLog(host), err)
+			app.sendError(w, "Failed to remove device from store", http.StatusBadGateway)
+
+			return
+		}
+	}
+
+	app.RemoveDevice(host)
+	app.BroadcastDeviceList()
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true}); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}
 }

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -63,6 +63,7 @@ func (app *WebApp) MountWeb(r chi.Router, discoveryService *discovery.UnifiedDis
 
 			r.Route("/{id}", func(r chi.Router) {
 				r.Get("/", app.HandleAPIDevice)
+				r.Delete("/", app.HandleDeleteDevice)
 				r.Post("/key/{key}", app.HandleDeviceKey)
 				r.Post("/volume/{volume}", app.HandleDirectVolumeControl)
 				r.Post("/power", app.HandleDevicePower)

--- a/pkg/service/soundtouchweb/registry_test.go
+++ b/pkg/service/soundtouchweb/registry_test.go
@@ -117,6 +117,81 @@ func TestDeviceSnapshotAndCount(t *testing.T) {
 	}
 }
 
+func TestRemoveDevice(t *testing.T) {
+	app := NewWebApp()
+
+	if app.RemoveDevice("missing") {
+		t.Error("RemoveDevice returned true for unknown id")
+	}
+
+	conn := newRegistryDevice("first")
+	app.AddDevice("host-1", conn)
+
+	if !app.RemoveDevice("host-1") {
+		t.Fatal("RemoveDevice returned false for known id")
+	}
+
+	if _, ok := app.GetDevice("host-1"); ok {
+		t.Error("device still present after RemoveDevice")
+	}
+
+	if got := app.DeviceCount(); got != 0 {
+		t.Errorf("DeviceCount after removal = %d; want 0", got)
+	}
+
+	// Removing the same id again is a no-op.
+	if app.RemoveDevice("host-1") {
+		t.Error("RemoveDevice returned true on second removal")
+	}
+
+	// The connection's done channel must be closed so its background
+	// goroutines (status poll, WebSocket reconnect) stop.
+	select {
+	case <-conn.Done():
+	default:
+		t.Error("RemoveDevice did not close the connection's Done channel")
+	}
+}
+
+// TestRemoveDeviceConcurrent runs adds and removes of the same ids from
+// many goroutines under `go test -race` to confirm the registry stays
+// race-free when removal is in the mix.
+func TestRemoveDeviceConcurrent(t *testing.T) {
+	app := NewWebApp()
+
+	const (
+		workers      = 16
+		opsPerWorker = 200
+	)
+
+	var wg sync.WaitGroup
+
+	wg.Add(workers * 2)
+
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				id := fmt.Sprintf("w%d-%d", worker, i)
+				app.AddDevice(id, newRegistryDevice(id))
+			}
+		}(w)
+	}
+
+	for w := 0; w < workers; w++ {
+		go func(worker int) {
+			defer wg.Done()
+
+			for i := 0; i < opsPerWorker; i++ {
+				app.RemoveDevice(fmt.Sprintf("w%d-%d", worker, i))
+			}
+		}(w)
+	}
+
+	wg.Wait()
+}
+
 // TestRegistryConcurrent exercises the registry from many goroutines
 // at once. Before the introduction of devicesMu this would either
 // panic with "fatal error: concurrent map read and map write" or be

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -149,7 +149,8 @@ img { display: block; max-width: 100%; }
 .nav-logo {
     width: 24px;
     height: 24px;
-    filter: var(--nav-icon-filter);
+    /* Keep the braille mark in its brand colours; the mono nav icons below
+       still recolour via --nav-icon-filter, the logo stays the one accent. */
 }
 
 .nav-links {

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -312,8 +312,35 @@ img { display: block; max-width: 100%; }
 }
 .device-card:hover { box-shadow: 0 4px 12px rgba(0,0,0,.12); transform: translateY(-1px); }
 
-.device-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: .25rem; }
+.device-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: .25rem; gap: .5rem; }
 .device-name { font-weight: 600; font-size: .95rem; }
+.device-header-right { display: flex; align-items: center; gap: .5rem; flex-shrink: 0; }
+
+/* Quiet remove affordance: invisible until the card is hovered, then dim,
+   warming to red only on its own hover. Keeps the grid relaxed. */
+.device-remove {
+    border: 0;
+    background: none;
+    padding: 0;
+    width: 1.1rem;
+    height: 1.1rem;
+    line-height: 1;
+    font-size: .8rem;
+    color: var(--text-dim);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity .15s, color .15s;
+}
+.device-card:hover .device-remove { opacity: .55; }
+.device-remove:hover { opacity: 1; color: var(--offline); }
+.device-remove:focus-visible { opacity: 1; outline: 2px solid var(--offline); outline-offset: 2px; }
+
+.device-list-note {
+    margin: .9rem .15rem 0;
+    font-size: .78rem;
+    color: var(--text-dim);
+    line-height: 1.4;
+}
 .device-type { font-size: .8rem; color: var(--text-dim); margin-bottom: .5rem; display: flex; gap: .4rem; flex-wrap: wrap; }
 .device-ip { color: var(--text); font-family: monospace; font-weight: 500; }
 

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -8,6 +8,7 @@ async function req(url, opts = {}) {
 export const api = {
     devices: () => req('/api/control/devices'),
     device: (id) => req(`/api/control/devices/${id}`),
+    removeDevice: (id) => req(`/api/control/devices/${id}`, { method: 'DELETE' }),
     discover: () => req('/api/control/discover', { method: 'POST' }),
     key: (id, key) => req(`/api/control/devices/${id}/key/${key}`, { method: 'POST' }),
     volume: (id, level) => req(`/api/control/devices/${id}/volume/${level}`, { method: 'POST' }),

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -170,7 +170,7 @@ function App() {
     return html`
         <div class="app">
             <nav class="navbar">
-                <a class="brand" href="/" title="AfterTouch home">
+                <a class="brand" href="/?chooser" title="AfterTouch home">
                     <img src="/app/static/img/logo.svg" alt="AfterTouch" class="nav-logo" />
                     <div class="brand-text">
                         <span class="brand-name">AfterTouch</span>

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -217,6 +217,12 @@ function App() {
                     <button class="btn-icon" onClick=${discover} title="Discover">
                         <img src="/app/static/img/knob-mono.svg" alt="Discover" class="nav-discover-icon ${isDiscovering ? 'buzzing' : ''}" />
                     </button>
+                    <a href="https://gesellix.github.io/Bose-SoundTouch/" target="_blank" rel="noopener" title="Documentation">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                            <path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/>
+                            <path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/>
+                        </svg>
+                    </a>
                 </div>
             </nav>
 

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -170,7 +170,7 @@ function App() {
     return html`
         <div class="app">
             <nav class="navbar">
-                <a class="brand" href="#" onClick=${(e) => { e.preventDefault(); navigate('devices'); }}>
+                <a class="brand" href="/" title="AfterTouch home">
                     <img src="/app/static/img/logo.svg" alt="AfterTouch" class="nav-logo" />
                     <div class="brand-text">
                         <span class="brand-name">AfterTouch</span>

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -148,6 +148,25 @@ function App() {
         await api.discover();
     }
 
+    async function removeDevice(id) {
+        const name = devices[id]?.info?.name || id;
+        if (!confirm(`Remove "${name}"?\n\nThis clears it from AfterTouch. A device still online may reappear after the next discovery scan.`)) {
+            return;
+        }
+        // Optimistically drop it; the server's devices broadcast reconciles.
+        setDevices(prev => {
+            const next = { ...prev };
+            delete next[id];
+            return next;
+        });
+        try {
+            const resp = await api.removeDevice(id);
+            showToast(resp?.success ? `Removed "${name}"` : (resp?.error || 'Failed to remove device'));
+        } catch (err) {
+            showToast('Failed to remove device');
+        }
+    }
+
     return html`
         <div class="app">
             <nav class="navbar">
@@ -209,6 +228,7 @@ function App() {
                         isDiscovering=${isDiscovering}
                         onSelect=${(id) => navigate('device', id)}
                         onDiscover=${discover}
+                        onRemove=${removeDevice}
                     />
                 ` : page === 'device' ? html`
                     <${DeviceDetail}

--- a/pkg/service/soundtouchweb/static/js/components/DeviceList.js
+++ b/pkg/service/soundtouchweb/static/js/components/DeviceList.js
@@ -3,7 +3,7 @@ import htm from 'htm';
 
 const html = htm.bind(h);
 
-function DeviceCard({ id, device, onSelect }) {
+function DeviceCard({ id, device, onSelect, onRemove }) {
     const { info, status } = device;
     const np = status?.nowPlaying;
     const isPlaying = np?.PlayStatus === 'PLAY_STATE';
@@ -13,7 +13,12 @@ function DeviceCard({ id, device, onSelect }) {
         <div class="device-card" onClick=${() => onSelect(id)}>
             <div class="device-header">
                 <span class="device-name">${info?.name || id}</span>
-                <span class="device-indicator ${status?.isConnected ? 'online' : 'offline'}"></span>
+                <span class="device-header-right">
+                    <span class="device-indicator ${status?.isConnected ? 'online' : 'offline'}"></span>
+                    <button class="device-remove" title="Remove this device"
+                            aria-label="Remove this device"
+                            onClick=${(e) => { e.stopPropagation(); onRemove(id); }}>✕</button>
+                </span>
             </div>
             <div class="device-type">
                 ${info?.type || ''}
@@ -31,7 +36,7 @@ function DeviceCard({ id, device, onSelect }) {
     `;
 }
 
-export function DeviceList({ devices, isDiscovering, onSelect, onDiscover }) {
+export function DeviceList({ devices, isDiscovering, onSelect, onDiscover, onRemove }) {
     const entries = Object.entries(devices);
 
     return html`
@@ -48,9 +53,13 @@ export function DeviceList({ devices, isDiscovering, onSelect, onDiscover }) {
             : html`
                 <div class="device-grid" key="grid">
                     ${entries.map(([id, device]) => html`
-                        <${DeviceCard} key=${id} id=${id} device=${device} onSelect=${onSelect} />
+                        <${DeviceCard} key=${id} id=${id} device=${device} onSelect=${onSelect} onRemove=${onRemove} />
                     `)}
-                </div>`
+                </div>
+                <p class="device-list-note" key="note">
+                    Removing a device clears it here. One that is still online may
+                    reappear after the next discovery scan.
+                </p>`
         }
         </div>
     `;

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -167,6 +167,13 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 	var prevSource string
 
 	for {
+		// Stop if the device was removed from the registry (conn.Close()).
+		select {
+		case <-conn.Done():
+			return
+		default:
+		}
+
 		wsClient := conn.Client.NewWebSocketClient(nil)
 
 		// Setup event handlers. Each handler funnels its change through
@@ -213,7 +220,10 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 
 		if err := wsClient.Connect(); err != nil {
 			log.Printf("Failed to connect WebSocket for device %s: %v (retrying in %s)", sanitizeLog(deviceID), err, backoff)
-			time.Sleep(backoff)
+
+			if sleepOrDone(conn, backoff) {
+				return
+			}
 
 			backoff *= 2
 			if backoff > maxBackoff {
@@ -248,12 +258,30 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 		})
 
 		log.Printf("WebSocket disconnected for device %s — reconnecting in %s", sanitizeLog(deviceID), backoff)
-		time.Sleep(backoff)
+
+		if sleepOrDone(conn, backoff) {
+			return
+		}
 
 		backoff *= 2
 		if backoff > maxBackoff {
 			backoff = maxBackoff
 		}
+	}
+}
+
+// sleepOrDone waits for d to elapse or for the connection to be closed,
+// whichever comes first. It returns true if the connection was closed
+// (the caller should stop), false if the timer fired normally.
+func sleepOrDone(conn *webtypes.DeviceConnection, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return false
+	case <-conn.Done():
+		return true
 	}
 }
 

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -2,6 +2,7 @@
 package webtypes
 
 import (
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -45,6 +46,13 @@ type DeviceConnection struct {
 	LastSeen   time.Time
 
 	status atomic.Pointer[DeviceStatus]
+
+	// done is closed by Close when the device is removed from the
+	// registry, signalling its background goroutines (the status poller
+	// and the WebSocket reconnect loop) to exit. closeOnce keeps Close
+	// idempotent.
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 // DeviceStatus represents the current device state
@@ -66,6 +74,7 @@ func NewDeviceConnection(c *client.Client, info *models.DeviceInfo) *DeviceConne
 		Client:     c,
 		DeviceInfo: info,
 		LastSeen:   time.Now(),
+		done:       make(chan struct{}),
 	}
 	conn.status.Store(&DeviceStatus{
 		IsConnected:  false,
@@ -82,6 +91,28 @@ func NewDeviceConnection(c *client.Client, info *models.DeviceInfo) *DeviceConne
 // connections built via NewDeviceConnection.
 func (c *DeviceConnection) Status() *DeviceStatus {
 	return c.status.Load()
+}
+
+// Done returns a channel that is closed when the connection is removed
+// from the registry. The per-device status poller and WebSocket
+// reconnect loop select on it to stop instead of running for the life
+// of the process.
+func (c *DeviceConnection) Done() <-chan struct{} {
+	return c.done
+}
+
+// Close signals the connection's background goroutines to stop and best-
+// effort disconnects the WebSocket so a blocked reconnect loop wakes
+// promptly. Idempotent; safe to call on a connection that never started
+// any goroutine (e.g. a test connection with a nil Client).
+func (c *DeviceConnection) Close() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+
+		if c.WebSocket != nil {
+			_ = c.WebSocket.Disconnect()
+		}
+	})
 }
 
 // SetStatus atomically replaces the entire status. Use sparingly —


### PR DESCRIPTION
Stage 2 of #451 (folding `soundtouch-web` into `soundtouch-service`). Stacked on #470; base is its branch and should retarget to `main` once #470 merges. Three threads.

## Live device removal
The merge was asymmetric: manual adds propagated to the player UI, removals did not.
- New `DELETE /api/control/devices/{id}` (`HandleDeleteDevice`): resolves the registry's host key to the device ID, cascades to the datastore via a new `RemoveDeviceHook`, prunes the in-memory entry, and broadcasts.
- `Server.RemoveDeviceByID` extracted from `HandleRemoveDevice` and now fires `notifyDevicesChanged`, so the admin Devices tab removal also propagates to the player.
- `WebApp.RemoveDevice` stops the per-device poll + WebSocket goroutines via a new done-channel + `Close()` on `DeviceConnection` (they previously ran for the process lifetime).
- Player UI: a quiet hover Remove control, confirm dialog, and an honest note that a still-online device may reappear after the next scan. No ignore-list.

## Landing chooser + shared chrome
- `/` is now a lean chooser routing to the Player (`/app`) or the Admin and Setup console (`/admin`); API/speaker clients still get version JSON from `/`.
- The admin console moved to `/admin` (`HandleAdmin`).
- New persisted `default_landing` setting (chooser|app|admin) redirects `/` when set; `\?chooser` always forces the chooser so the hub stays reachable, and the "home" brand links point there.
- Shared accent bar and a single version-line footer across all three surfaces; the braille mark stays in brand colours as the one accent.
- Documentation: a prominent in-body link on the chooser, reused as a small docs button in the player navbar and admin header.

## Discovery / sync performance (found while testing the merged UI)
- `SeedExtraDevices` probes datastore hosts concurrently, so offline speakers cost roughly one timeout instead of 10s each, serially.
- The admin no longer re-sweeps on every load: the on-load auto-discovery is gated to a cold start, and a duplicate `DOMContentLoaded` trigger was removed.
- `Manager.HTTPGet` is bounded to a 5s timeout (was the no-timeout `http.Get`), so offline speakers fail fast.
- The admin's per-device live `/info` refresh is capped at 3 concurrent requests, so it never starves the browser's per-origin connection pool (which was blocking navigation away from `/admin`).

## Verification
- `make check` (incl. the Docker http-client suite) and `make lint` are green.
- New tests: registry `RemoveDevice` (+concurrent), `Server.RemoveDeviceByID`, and the landing redirect / `\?chooser` / admin handlers.
- Manual: all three surfaces verified (light + dark), removal end-to-end (datastore dir gone, no leftover polling), `default_landing` redirects, and the docs links.

## Deferred
Standalone `soundtouch-web` binary deprecation, light/dark on the admin, mobile polish, a removal ignore-list, and a batched single-request `/admin` device-status refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)