### PR TITLE
security(docker): run the player/web images as non-root (refs #451)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,10 @@ ENV PORT=8080
 
 EXPOSE 8080
 
+# The player is stateless and binds an unprivileged port, so it has no reason
+# to run as root. mDNS/SSDP discovery uses unprivileged multicast.
+USER nobody
+
 ENTRYPOINT ["/app/soundtouch-player"]
 
 # soundtouch-web image: transitional alias of soundtouch-player. Built from the
@@ -97,5 +101,7 @@ COPY --from=builder /soundtouch-player /app/soundtouch-web
 ENV PORT=8080
 
 EXPOSE 8080
+
+USER nobody
 
 ENTRYPOINT ["/app/soundtouch-web"]


### PR DESCRIPTION
The `soundtouch-player` image (and its transitional `soundtouch-web` alias) ran as root for no reason. The player is stateless, binds an unprivileged port (`:8080`), and its mDNS/SSDP discovery uses unprivileged multicast, so it has nothing that needs root. Drop both image stages to `USER nobody`.

Verified locally: the image builds, runs as uid 65534 (nobody), binds `:8080` (`GET /` → 302), and runs mDNS discovery without root.

## Not changed: the soundtouch-service image
Left running as root for now, on purpose:
- It persists to `/app/data`, commonly a host-mounted volume whose UID ownership we can't assume; a non-root service would need that dir chowned to the chosen UID (a one-time migration for existing deployments).
- Its optional built-in DNS server binds the privileged `:53` (when DNS Discovery is enabled), which a non-root process can't do without `--cap-add=NET_BIND_SERVICE` + a file capability, or moving DNS to a high port with a published mapping.

That's a more careful, semi-breaking change and is best handled separately with a clear data-dir/UID note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)