### PR TITLE
feat(cli): setup enable-ssh — bootstrap SSH via the #471 port-17000 envswitch trick

### DIFF
--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -564,6 +564,14 @@ func setupEnableSSHCmd() *cli.Command {
 				Name:  "no-persist",
 				Usage: "Skip persisting the remote_services marker (SSH would not survive a reboot)",
 			},
+			&cli.StringFlag{
+				Name:  "authorized-key",
+				Usage: "Opt-in hardening: install this SSH public key for root (key auth instead of the empty-password login). Pass the key text, e.g. --authorized-key \"$(cat id_ed25519.pub)\"",
+			},
+			&cli.BoolFlag{
+				Name:  "close-17000",
+				Usage: "Opt-in hardening: block port 17000 from the LAN (firewall rule applied now + persisted); loopback access is kept",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			cfg := GetClientConfig(c)
@@ -630,13 +638,46 @@ func setupEnableSSHCmd() *cli.Command {
 				}
 			}
 
+			if key := c.String("authorized-key"); key != "" {
+				fmt.Println("Installing authorized_keys for root (key auth)...")
+
+				klogs, kerr := m.InstallAuthorizedKey(cfg.Host, key)
+				if klogs != "" {
+					fmt.Print(klogs)
+				}
+
+				if kerr != nil {
+					PrintError(kerr.Error())
+					return kerr
+				}
+			}
+
+			closed17000 := c.Bool("close-17000")
+			if closed17000 {
+				fmt.Println("Closing port 17000 to the LAN (loopback kept)...")
+
+				clogs, cerr := m.Close17000(cfg.Host)
+				if clogs != "" {
+					fmt.Print(clogs)
+				}
+
+				if cerr != nil {
+					PrintError(cerr.Error())
+					return cerr
+				}
+			}
+
 			PrintSuccess("Done — SSH enabled on " + cfg.Host + ". From here, the usual migration / CA-install / inspect commands work.")
 
 			if placeholder {
 				fmt.Println("No --service-url was given, so the speaker's boseurls now point at a placeholder; run your migration next to set the real service URLs.")
 			}
 
-			fmt.Println("Note: port 17000 is left open and root login is unchanged (securing/closing 17000 is opt-in, not done here).")
+			if closed17000 {
+				fmt.Println("Port 17000 is now blocked from the LAN (loopback kept).")
+			} else {
+				fmt.Println("Note: port 17000 is left open (opt-in --close-17000 to block it from the LAN).")
+			}
 
 			return nil
 		},

--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -48,6 +48,7 @@ func setupCommand() *cli.Command {
 			setupWaitAPCmd(),
 			setupWaitOnlineCmd(),
 			setupSSHCheckCmd(),
+			setupEnableSSHCmd(),
 			setupRemoteServicesCmd(),
 			setupInstallCACmd(),
 			setupMigrateCmd(),
@@ -531,6 +532,111 @@ func setupSSHCheckCmd() *cli.Command {
 			_ = conn.Close()
 
 			PrintSuccess("Port 22 is open — SSH is reachable.")
+
+			return nil
+		},
+	}
+}
+
+func setupEnableSSHCmd() *cli.Command {
+	return &cli.Command{
+		Name: "enable-ssh",
+		Usage: "Bootstrap SSH on a speaker with no prior access via the port-17000 envswitch trick (#471), " +
+			"then restore clean URLs and persist it",
+		Before: RequireHost,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "service-url",
+				Usage: "AfterTouch service base URL to point the speaker at (e.g. https://192.0.2.10:8443). " +
+					"Optional: enabling SSH does not need a live server (the injection fires when the speaker " +
+					"parses its boseurls), so you can omit this now and set the real URLs later via migration",
+			},
+			&cli.DurationFlag{
+				Name:  "wait",
+				Value: 90 * time.Second,
+				Usage: "How long to wait for sshd (:22) after the envswitch injection (it runs on the speaker's next boseurls check, ~60s)",
+			},
+			&cli.BoolFlag{
+				Name:  "no-reset-urls",
+				Usage: "Skip restoring clean boseurls after SSH is up (leaves the injected marge URL in place)",
+			},
+			&cli.BoolFlag{
+				Name:  "no-persist",
+				Usage: "Skip persisting the remote_services marker (SSH would not survive a reboot)",
+			},
+		},
+		Action: func(c *cli.Context) error {
+			cfg := GetClientConfig(c)
+			m := setup.NewManager("", nil, nil)
+
+			// The URL is only the vehicle for the command injection; the
+			// SSH-enable fires when the speaker parses its boseurls, whether
+			// or not anything answers there. When the user has no service URL
+			// yet, use a clearly-placeholder value and tell them to set the
+			// real URLs during migration.
+			serviceURL := c.String("service-url")
+			placeholder := serviceURL == ""
+
+			if placeholder {
+				serviceURL = "https://aftertouch.invalid"
+			}
+
+			fmt.Printf("Enabling SSH on %s via telnet :17000 (runs on the speaker's next boseurls check, up to ~60s)...\n", cfg.Host)
+
+			logs, err := m.EnableSSHViaTelnet(cfg.Host, serviceURL)
+			if logs != "" {
+				fmt.Print(logs)
+			}
+
+			if err != nil {
+				PrintError(err.Error())
+				return err
+			}
+
+			fmt.Printf("Waiting up to %s for sshd (:22) to come up...\n", c.Duration("wait"))
+
+			if err := setup.WaitForSSHPort(cfg.Host, c.Duration("wait")); err != nil {
+				PrintError(err.Error())
+				return err
+			}
+
+			PrintSuccess("SSH is up on " + cfg.Host)
+
+			if !c.Bool("no-reset-urls") {
+				fmt.Println("Restoring clean boseurls (so the marge URL is usable again)...")
+
+				rlogs, rerr := m.ResetBoseURLs(cfg.Host, serviceURL)
+				if rlogs != "" {
+					fmt.Print(rlogs)
+				}
+
+				if rerr != nil {
+					PrintError(rerr.Error())
+					return rerr
+				}
+			}
+
+			if !c.Bool("no-persist") {
+				fmt.Println("Persisting the remote_services marker (SSH survives reboot)...")
+
+				plogs, perr := m.EnsureRemoteServices(cfg.Host)
+				if plogs != "" {
+					fmt.Print(plogs)
+				}
+
+				if perr != nil {
+					PrintError(perr.Error())
+					return perr
+				}
+			}
+
+			PrintSuccess("Done — SSH enabled on " + cfg.Host + ". From here, the usual migration / CA-install / inspect commands work.")
+
+			if placeholder {
+				fmt.Println("No --service-url was given, so the speaker's boseurls now point at a placeholder; run your migration next to set the real service URLs.")
+			}
+
+			fmt.Println("Note: port 17000 is left open and root login is unchanged (securing/closing 17000 is opt-in, not done here).")
 
 			return nil
 		},

--- a/pkg/service/setup/enable_ssh.go
+++ b/pkg/service/setup/enable_ssh.go
@@ -78,6 +78,93 @@ func (m *Manager) setBoseURLsViaTelnet(deviceIP, marge, swUpdate string) (string
 	return logs.String(), nil
 }
 
+// fwScript is the speaker's persistent iptables script; appending here makes a
+// rule survive reboot (it is re-applied on boot).
+const fwScript = "/etc/init.d/Firewalls/update_iptables"
+
+// block17000Marker guards the appended rule so Close17000 is idempotent.
+const block17000Marker = "# Block 17000 (added by AfterTouch)"
+
+// Close17000 blocks the port-17000 diagnostic shell from the LAN over SSH:
+// it persists an iptables rule in the firewall script (idempotent, keyed on
+// block17000Marker) and applies the rule immediately, keeping loopback access.
+// Opt-in — the caller decides whether to harden. Needs SSH already enabled.
+func (m *Manager) Close17000(deviceIP string) (string, error) {
+	if m.NewSSH == nil {
+		return "", errors.New("ssh not configured: Manager.NewSSH is nil")
+	}
+
+	persist := "grep -q '" + block17000Marker + "' " + fwScript + " 2>/dev/null || cat >> " + fwScript + " <<'AFTEREOF'\n\n" +
+		block17000Marker + "\n" +
+		"iptables -I INPUT -p tcp --dport 17000 -j DROP\n" +
+		"iptables -I INPUT -p tcp --dport 17000 -i lo -j ACCEPT\n" +
+		"AFTEREOF"
+
+	steps := []struct{ desc, cmd string }{
+		{"remount / read-write", "mount / -o rw,remount"},
+		{"persist firewall rule", persist},
+		{"apply firewall rule now", "iptables -I INPUT -p tcp --dport 17000 -j DROP; iptables -I INPUT -p tcp --dport 17000 -i lo -j ACCEPT"},
+	}
+
+	return m.runSSHSteps(deviceIP, steps)
+}
+
+// InstallAuthorizedKey installs an SSH public key for root so access no longer
+// relies on the empty-password login. Opt-in. Needs SSH already enabled.
+func (m *Manager) InstallAuthorizedKey(deviceIP, publicKey string) (string, error) {
+	if m.NewSSH == nil {
+		return "", errors.New("ssh not configured: Manager.NewSSH is nil")
+	}
+
+	key := strings.TrimSpace(publicKey)
+	if key == "" {
+		return "", errors.New("public key is empty")
+	}
+
+	c := m.NewSSH(deviceIP)
+
+	var logs strings.Builder
+
+	if out, err := c.Run("mount / -o rw,remount && mkdir -p -m 700 /home/root/.ssh"); err != nil {
+		fmt.Fprintf(&logs, "→ prepare /home/root/.ssh\n%s\n", strings.TrimSpace(out))
+		return logs.String(), fmt.Errorf("prepare /home/root/.ssh: %w", err)
+	}
+
+	if err := c.UploadContent([]byte(key+"\n"), "/home/root/.ssh/authorized_keys"); err != nil {
+		return logs.String(), fmt.Errorf("upload authorized_keys: %w", err)
+	}
+
+	if out, err := c.Run("chmod 600 /home/root/.ssh/authorized_keys"); err != nil {
+		fmt.Fprintf(&logs, "→ chmod authorized_keys\n%s\n", strings.TrimSpace(out))
+		return logs.String(), fmt.Errorf("chmod authorized_keys: %w", err)
+	}
+
+	logs.WriteString("Installed authorized_keys for root.\n")
+
+	return logs.String(), nil
+}
+
+// runSSHSteps runs an ordered list of shell commands over a single-shot SSH
+// client, aborting on the first failure. Commands MUST be service-controlled
+// literals, never built from untrusted HTTP input.
+func (m *Manager) runSSHSteps(deviceIP string, steps []struct{ desc, cmd string }) (string, error) {
+	c := m.NewSSH(deviceIP)
+
+	var logs strings.Builder
+
+	for _, s := range steps {
+		out, err := c.Run(s.cmd)
+
+		fmt.Fprintf(&logs, "→ %s\n%s\n", s.desc, strings.TrimSpace(out))
+
+		if err != nil {
+			return logs.String(), fmt.Errorf("%s: %w", s.desc, err)
+		}
+	}
+
+	return logs.String(), nil
+}
+
 // WaitForSSHPort polls TCP :22 on the speaker until it accepts a connection or
 // timeout elapses. Used after EnableSSHViaTelnet, since sshd starts only when
 // the speaker next reads its boseurls (up to ~60s later).

--- a/pkg/service/setup/enable_ssh.go
+++ b/pkg/service/setup/enable_ssh.go
@@ -1,0 +1,101 @@
+package setup
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+)
+
+// remoteServicesInjection is appended to the marge URL in the envswitch
+// command. When the speaker next reads its boseurls (within ~60s), the device
+// runs these shell commands: it touches the remote_services marker and starts
+// sshd. This is the #471 bootstrap — it enables SSH on firmware with no prior
+// SSH access and without a USB recovery stick. The whole marge value is
+// double-quoted in the telnet command because it now contains spaces and
+// semicolons.
+const remoteServicesInjection = ";touch /tmp/remote_services;/etc/init.d/sshd start"
+
+// EnableSSHViaTelnet bootstraps SSH on a speaker over its port-17000 shell by
+// setting boseurls to an injected value (see remoteServicesInjection). It needs
+// no existing SSH and no USB recovery. The injected commands run on the
+// speaker's next boseurls check (up to ~60s), so callers should WaitForSSHPort
+// afterwards, then ResetBoseURLs (to restore a usable marge URL) and
+// EnsureRemoteServices (to persist SSH across reboots).
+//
+// serviceURL is the AfterTouch service base the speaker should point at
+// (e.g. https://192.0.2.10:8443). It must not contain a double quote.
+func (m *Manager) EnableSSHViaTelnet(deviceIP, serviceURL string) (string, error) {
+	return m.setBoseURLsViaTelnet(deviceIP, serviceURL+remoteServicesInjection, serviceURL+"/update")
+}
+
+// ResetBoseURLs restores clean boseurls (no injected commands) after SSH has
+// been enabled, so the speaker's marge URL is usable again.
+func (m *Manager) ResetBoseURLs(deviceIP, serviceURL string) (string, error) {
+	return m.setBoseURLsViaTelnet(deviceIP, serviceURL, serviceURL+"/update")
+}
+
+// setBoseURLsViaTelnet runs `envswitch boseurls set "<marge>" "<swUpdate>"`
+// over the port-17000 shell. Both arguments are double-quoted so values
+// containing spaces or semicolons (the SSH-enable injection) survive the
+// device's command parser.
+func (m *Manager) setBoseURLsViaTelnet(deviceIP, marge, swUpdate string) (string, error) {
+	if m.NewTelnet == nil {
+		return "", errors.New("telnet not configured: Manager.NewTelnet is nil")
+	}
+
+	if strings.Contains(marge, `"`) || strings.Contains(swUpdate, `"`) {
+		return "", errors.New("boseurls values must not contain a double quote")
+	}
+
+	var logs strings.Builder
+
+	t := m.NewTelnet(deviceIP)
+	if err := t.Dial(); err != nil {
+		return logs.String(), fmt.Errorf("telnet dial %s:17000: %w", deviceIP, err)
+	}
+
+	defer func() { _ = t.Close() }()
+
+	if banner, _ := t.Probe(); banner != "" {
+		fmt.Fprintf(&logs, "Telnet banner: %q\n", strings.TrimSpace(banner))
+	}
+
+	cmd := `envswitch boseurls set "` + marge + `" "` + swUpdate + `"`
+
+	resp, err := t.SendCommand(cmd)
+	if err != nil {
+		return logs.String(), fmt.Errorf("telnet command %q failed: %w", cmd, err)
+	}
+
+	fmt.Fprintf(&logs, "→ %s\n%s\n", cmd, strings.TrimRight(resp, "\r\n"))
+
+	if isCommandNotFound(resp) {
+		return logs.String(), fmt.Errorf("device rejected %q (firmware does not expose envswitch)", cmd)
+	}
+
+	return logs.String(), nil
+}
+
+// WaitForSSHPort polls TCP :22 on the speaker until it accepts a connection or
+// timeout elapses. Used after EnableSSHViaTelnet, since sshd starts only when
+// the speaker next reads its boseurls (up to ~60s later).
+func WaitForSSHPort(deviceIP string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	addr := net.JoinHostPort(deviceIP, "22")
+
+	for {
+		conn, err := net.DialTimeout("tcp", addr, 3*time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+
+		if time.Now().After(deadline) {
+			return fmt.Errorf("ssh (:22) on %s not reachable within %s: %w", deviceIP, timeout, err)
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+}

--- a/pkg/service/setup/enable_ssh_test.go
+++ b/pkg/service/setup/enable_ssh_test.go
@@ -1,6 +1,9 @@
 package setup
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEnableSSHViaTelnet_BuildsInjectedCommand(t *testing.T) {
 	const svc = "https://192.0.2.10:8443"
@@ -41,5 +44,63 @@ func TestSetBoseURLs_RejectsDoubleQuote(t *testing.T) {
 
 	if _, err := m.EnableSSHViaTelnet("192.0.2.10", `https://x"evil`); err == nil {
 		t.Fatal("expected an error when the service URL contains a double quote")
+	}
+}
+
+func TestClose17000_RunsFirewallSteps(t *testing.T) {
+	var ran []string
+
+	m := &Manager{NewSSH: func(string) SSHClient {
+		return &mockSSH{runFunc: func(cmd string) (string, error) {
+			ran = append(ran, cmd)
+			return "", nil
+		}}
+	}}
+
+	if _, err := m.Close17000("192.0.2.10"); err != nil {
+		t.Fatalf("Close17000: %v", err)
+	}
+
+	joined := strings.Join(ran, "\n")
+	for _, want := range []string{
+		"mount / -o rw,remount",
+		block17000Marker,
+		"iptables -I INPUT -p tcp --dport 17000 -j DROP",
+		"--dport 17000 -i lo -j ACCEPT",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("Close17000 commands missing %q\nran:\n%s", want, joined)
+		}
+	}
+}
+
+func TestInstallAuthorizedKey_UploadsKey(t *testing.T) {
+	m := &Manager{NewSSH: func(string) SSHClient {
+		return &mockSSH{runFunc: func(string) (string, error) { return "", nil }}
+	}}
+
+	if _, err := m.InstallAuthorizedKey("192.0.2.10", "  ssh-ed25519 AAAATEST comment  "); err != nil {
+		t.Fatalf("InstallAuthorizedKey: %v", err)
+	}
+	// A fresh mockSSH is created per NewSSH call, so re-run against a captured
+	// one to assert the upload.
+	var captured *mockSSH
+
+	m.NewSSH = func(string) SSHClient {
+		captured = &mockSSH{runFunc: func(string) (string, error) { return "", nil }}
+		return captured
+	}
+
+	if _, err := m.InstallAuthorizedKey("192.0.2.10", "ssh-ed25519 AAAATEST comment"); err != nil {
+		t.Fatalf("InstallAuthorizedKey: %v", err)
+	}
+
+	got, ok := captured.uploaded["/home/root/.ssh/authorized_keys"]
+	if !ok {
+		t.Fatal("authorized_keys was not uploaded")
+	}
+
+	if strings.TrimSpace(string(got)) != "ssh-ed25519 AAAATEST comment" {
+		t.Errorf("uploaded key = %q", string(got))
 	}
 }

--- a/pkg/service/setup/enable_ssh_test.go
+++ b/pkg/service/setup/enable_ssh_test.go
@@ -1,0 +1,45 @@
+package setup
+
+import "testing"
+
+func TestEnableSSHViaTelnet_BuildsInjectedCommand(t *testing.T) {
+	const svc = "https://192.0.2.10:8443"
+
+	want := `envswitch boseurls set "https://192.0.2.10:8443;touch /tmp/remote_services;/etc/init.d/sshd start" "https://192.0.2.10:8443/update"`
+
+	f := &fakeTelnet{responses: map[string]string{want: "OK\n"}}
+	m := newFakeTelnetManager(f)
+
+	if _, err := m.EnableSSHViaTelnet("192.0.2.10", svc); err != nil {
+		t.Fatalf("EnableSSHViaTelnet: %v", err)
+	}
+
+	if len(f.commands) != 1 || f.commands[0] != want {
+		t.Errorf("sent %q\n want %q", f.commands, want)
+	}
+}
+
+func TestResetBoseURLs_BuildsCleanCommand(t *testing.T) {
+	const svc = "https://192.0.2.10:8443"
+
+	want := `envswitch boseurls set "https://192.0.2.10:8443" "https://192.0.2.10:8443/update"`
+
+	f := &fakeTelnet{responses: map[string]string{want: "OK\n"}}
+	m := newFakeTelnetManager(f)
+
+	if _, err := m.ResetBoseURLs("192.0.2.10", svc); err != nil {
+		t.Fatalf("ResetBoseURLs: %v", err)
+	}
+
+	if len(f.commands) != 1 || f.commands[0] != want {
+		t.Errorf("sent %q\n want %q", f.commands, want)
+	}
+}
+
+func TestSetBoseURLs_RejectsDoubleQuote(t *testing.T) {
+	m := newFakeTelnetManager(&fakeTelnet{})
+
+	if _, err := m.EnableSSHViaTelnet("192.0.2.10", `https://x"evil`); err == nil {
+		t.Fatal("expected an error when the service URL contains a double quote")
+	}
+}


### PR DESCRIPTION
**Draft** — the code is built and unit-tested, but the flow has **not yet been exercised against a real speaker** (it changes device state: starts sshd, rewrites boseurls, optionally edits the firewall). Marking ready after a live run.

First iteration of foob61451's #471: enable SSH on a speaker that has **no prior SSH access and without a USB recovery stick**, then fall into the migration / CA-install flow we already have. Built in `soundtouch-cli` first (cheapest to iterate); the future `soundtouch-app` can reuse the same `setup.Manager` methods.

## `soundtouch-cli setup enable-ssh --host <ip> [--service-url <url>]`
Flow: inject `envswitch` over telnet `:17000` → wait for `:22` → restore clean boseurls → persist the `remote_services` marker.

- **`EnableSSHViaTelnet`** sends `envswitch boseurls set "<url>;touch /tmp/remote_services;/etc/init.d/sshd start" "<url>/update"` over the existing telnet client. The injected shell commands run when the speaker next *parses* its boseurls (~60s), starting sshd.
- The URL is only the vehicle for the injection, so **`--service-url` is optional** — no live server is needed; omit it (a placeholder is used) and set the real URLs later via migration.
- **`WaitForSSHPort`** polls `:22`; persistence reuses the existing **`EnsureRemoteServices`**.

## Opt-in hardening (off by default)
- **`--close-17000`** (`Close17000`): persists an idempotent iptables rule in `/etc/init.d/Firewalls/update_iptables` and applies it now; loopback kept.
- **`--authorized-key`** (`InstallAuthorizedKey`): installs a root SSH key so access isn't the empty-password login.

Closing 17000 is deliberately opt-in (not default).

## Reuse / tests
Almost entirely orchestration of existing packages (`pkg/telnet`, `pkg/ssh`, `EnsureRemoteServices`). Unit tests pin the exact injected/reset command strings, the double-quote guard, the firewall command sequence, and the key upload. `go build`, `make lint`, and the setup/cli tests are green.

## Test plan (before un-drafting)
Run against a spare/known speaker on the LAN:
`soundtouch-cli setup enable-ssh --host <ip>` → confirm `:22` comes up within ~60s, then `ssh root@<ip>` works and the usual migration/CA commands proceed. Then re-test with `--close-17000` and `--authorized-key`.

Refs #471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)