### PR TITLE
Raspberry Pi / host uninstallers + latest-release installers

### DIFF
--- a/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -34,10 +34,10 @@ sudo bash install.sh
 ```
 
 The installer detects your Pi's architecture (armv7, arm64, or amd64), downloads
-the binary, creates a `soundtouch` system user, and registers a systemd unit that
-starts on boot.
+the latest release binary, creates a `soundtouch` system user, and registers a
+systemd unit that starts on boot.
 
-To install a specific version:
+To pin a specific version instead of the latest:
 
 ```bash
 sudo bash install.sh v0.111.3

--- a/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -40,7 +40,7 @@ starts on boot.
 To install a specific version:
 
 ```bash
-sudo bash install.sh v0.107.0
+sudo bash install.sh v0.111.3
 ```
 
 Check that the service is running:
@@ -263,7 +263,7 @@ curl -s http://192.0.2.1:8090/presets
 
 ```bash
 sudo bash install.sh              # updates to latest release
-sudo bash install.sh v0.107.0     # updates to a specific version
+sudo bash install.sh v0.111.3     # updates to a specific version
 ```
 
 The installer stops the service, downloads the new binary, and restarts

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -85,10 +85,10 @@ To target a specific version instead of the default:
 
 ```bash
 # Via environment variable (works with pipe-to-sh)
-VERSION=0.107.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # Via command-line flag (pass args after sh -s --)
-curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.107.0
+curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
 ```
 
 Verify the installed version:
@@ -97,7 +97,7 @@ Verify the installed version:
 wget -qO- http://localhost:8000/health
 ```
 
-The JSON response should include `"version":"v0.107.0"` (or whichever
+The JSON response should include `"version":"v0.111.3"` (or whichever
 version you installed).
 
 ---
@@ -185,13 +185,13 @@ next reboot — which is fine for a one-time setup run):
 cd /tmp
 
 curl -L --fail -o soundtouch-cli \
-  https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.107.0/soundtouch-cli-v0.107.0-linux-armv7
+  https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.111.3/soundtouch-cli-v0.111.3-linux-armv7
 chmod +x soundtouch-cli
 
 /tmp/soundtouch-cli --version
 ```
 
-Replace `v0.107.0` with the version you installed.
+Replace `v0.111.3` with the version you installed.
 
 ---
 
@@ -304,12 +304,12 @@ older artefacts to keep `/mnt/nv` free:
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # Update to a specific version — three equivalent forms
-VERSION=0.107.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
-rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.107.0
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
 
 curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh
-sh install.sh --version 0.107.0
+sh install.sh --version 0.111.3
 ```
 
 **Rollback:** the installer keeps a `.backup` file alongside the binary:

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -81,7 +81,8 @@ currently running binary, and starts the service:
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 ```
 
-To target a specific version instead of the default:
+By default this installs the **latest release** — the script resolves it from
+GitHub's `releases/latest` redirect. To target a specific version instead:
 
 ```bash
 # Via environment variable (works with pipe-to-sh)

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -17,11 +17,6 @@ Run without a version argument, they install the **latest release** (resolved
 from GitHub's `releases/latest` redirect); pass a tag to pin a specific version.
 Each installer has a matching uninstaller (`uninstall.sh`, `uninstall-player.sh`).
 
-> `install-web.sh` is the previous name for `install-player.sh`. It still works
-> as a deprecated alias but will be removed in a future release. If you installed
-> `soundtouch-web` before the rename, see
-> [Migrating from soundtouch-web](#migrating-from-soundtouch-web).
-
 For a complete install-through-migration walkthrough see
 [EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).
 Not sure whether to use a Pi or run AfterTouch on the speaker itself? See
@@ -279,34 +274,6 @@ sudo rm -rf /etc/soundtouch-player
 sudo rm /usr/local/bin/soundtouch-player
 sudo systemctl daemon-reload
 ```
-
----
-
-## Migrating from soundtouch-web
-
-`soundtouch-web` was renamed to `soundtouch-player`. The old `install-web.sh`
-installer and the `soundtouch-web` release asset still exist as deprecated
-aliases and will be removed in a future release.
-
-If you have an existing `soundtouch-web` install, remove it and switch to
-`soundtouch-player`:
-
-```bash
-# 1. Remove the old soundtouch-web service:
-curl -fsSL -o uninstall-web.sh \
-  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall-web.sh
-sudo bash uninstall-web.sh
-
-# 2. Install soundtouch-player (see the section above):
-curl -fsSL -o install-player.sh \
-  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/install-player.sh
-sudo bash install-player.sh
-```
-
-`uninstall-web.sh` stops and disables the `soundtouch-web` service and removes
-its unit, binary, and `/etc/soundtouch-web` config. Both binaries are stateless,
-so there is no data to migrate; re-create any per-host settings in
-`/etc/soundtouch-player/soundtouch-player.env` (the variables are identical).
 
 ---
 

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -13,6 +13,8 @@ Two scripts are available, one per binary:
 
 Both auto-detect CPU architecture (armv7 / arm64 / amd64), create a `soundtouch`
 system user, and install a systemd unit. They are safe to re-run for updates.
+Run without a version argument, they install the **latest release** (resolved
+from GitHub's `releases/latest` redirect); pass a tag to pin a specific version.
 Each installer has a matching uninstaller (`uninstall.sh`, `uninstall-player.sh`).
 
 > `install-web.sh` is the previous name for `install-player.sh`. It still works

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -13,6 +13,12 @@ Two scripts are available, one per binary:
 
 Both auto-detect CPU architecture (armv7 / arm64 / amd64), create a `soundtouch`
 system user, and install a systemd unit. They are safe to re-run for updates.
+Each installer has a matching uninstaller (`uninstall.sh`, `uninstall-player.sh`).
+
+> `install-web.sh` is the previous name for `install-player.sh`. It still works
+> as a deprecated alias but will be removed in a future release. If you installed
+> `soundtouch-web` before the rename, see
+> [Migrating from soundtouch-web](#migrating-from-soundtouch-web).
 
 For a complete install-through-migration walkthrough see
 [EXTERNAL-HOST-WALKTHROUGH.md](EXTERNAL-HOST-WALKTHROUGH.md).
@@ -107,13 +113,30 @@ The script stops the service, downloads the new binary (backs up the old one to
 
 ### Removal
 
+Use the uninstaller, which stops and disables the service and removes the unit,
+binary, and config. Your data directory is **preserved** by default:
+
+```bash
+curl -fsSL -o uninstall.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall.sh
+sudo bash uninstall.sh              # keep /var/lib/soundtouch-service
+sudo bash uninstall.sh --purge      # also delete the data directory
+```
+
+The `soundtouch:soundtouch` user/group is removed only once no other
+`soundtouch-*` install remains on the host.
+
+Prefer to do it by hand? The equivalent manual steps are:
+
 ```bash
 sudo systemctl disable --now soundtouch-service
 sudo rm /etc/systemd/system/soundtouch-service.service
 sudo rm -rf /etc/soundtouch-service
-sudo rm -rf /var/lib/soundtouch-service
 sudo rm /usr/local/bin/soundtouch-service
 sudo systemctl daemon-reload
+# Datastore (presets, device registrations, certs) — delete only if you are
+# sure you no longer need it:
+sudo rm -rf /var/lib/soundtouch-service
 ```
 
 ---
@@ -234,6 +257,19 @@ sudo bash install-player.sh v0.107.0     # update to a specific version
 
 ### Removal
 
+Use the uninstaller:
+
+```bash
+curl -fsSL -o uninstall-player.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall-player.sh
+sudo bash uninstall-player.sh
+```
+
+The `soundtouch:soundtouch` user/group is removed only once no other
+`soundtouch-*` install remains on the host.
+
+Prefer to do it by hand? The equivalent manual steps are:
+
 ```bash
 sudo systemctl disable --now soundtouch-player
 sudo rm /etc/systemd/system/soundtouch-player.service
@@ -241,6 +277,34 @@ sudo rm -rf /etc/soundtouch-player
 sudo rm /usr/local/bin/soundtouch-player
 sudo systemctl daemon-reload
 ```
+
+---
+
+## Migrating from soundtouch-web
+
+`soundtouch-web` was renamed to `soundtouch-player`. The old `install-web.sh`
+installer and the `soundtouch-web` release asset still exist as deprecated
+aliases and will be removed in a future release.
+
+If you have an existing `soundtouch-web` install, remove it and switch to
+`soundtouch-player`:
+
+```bash
+# 1. Remove the old soundtouch-web service:
+curl -fsSL -o uninstall-web.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall-web.sh
+sudo bash uninstall-web.sh
+
+# 2. Install soundtouch-player (see the section above):
+curl -fsSL -o install-player.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/install-player.sh
+sudo bash install-player.sh
+```
+
+`uninstall-web.sh` stops and disables the `soundtouch-web` service and removes
+its unit, binary, and `/etc/soundtouch-web` config. Both binaries are stateless,
+so there is no data to migrate; re-create any per-host settings in
+`/etc/soundtouch-player/soundtouch-player.env` (the variables are identical).
 
 ---
 

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -40,14 +40,14 @@ sudo bash install.sh
 Install a specific version:
 
 ```bash
-sudo bash install.sh v0.107.0
+sudo bash install.sh v0.111.3
 ```
 
 Override defaults at install time:
 
 ```bash
 sudo \
-  VERSION=v0.107.0 \
+  VERSION=v0.111.3 \
   HOSTNAME_FQDN=soundtouch.local \
   HTTP_PORT=80 \
   HTTPS_PORT=443 \
@@ -105,7 +105,7 @@ journalctl -u soundtouch-service -b               # this boot only
 
 ```bash
 sudo bash install.sh              # update to latest release
-sudo bash install.sh v0.107.0     # update to a specific version
+sudo bash install.sh v0.111.3     # update to a specific version
 ```
 
 The script stops the service, downloads the new binary (backs up the old one to
@@ -157,14 +157,14 @@ sudo bash install-player.sh
 Install a specific version:
 
 ```bash
-sudo bash install-player.sh v0.107.0
+sudo bash install-player.sh v0.111.3
 ```
 
 Override defaults at install time:
 
 ```bash
 sudo \
-  VERSION=v0.107.0 \
+  VERSION=v0.111.3 \
   HTTP_PORT=8081 \
   bash install-player.sh
 ```
@@ -252,7 +252,7 @@ journalctl -u soundtouch-player -f
 
 ```bash
 sudo bash install-player.sh              # update to latest release
-sudo bash install-player.sh v0.107.0     # update to a specific version
+sudo bash install-player.sh v0.111.3     # update to a specific version
 ```
 
 ### Removal

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -48,6 +48,10 @@ Then, run the following command to install AfterTouch on the device.
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 ```
 
+This installs the **latest release** by default (the script resolves it from
+GitHub's `releases/latest` redirect). To pin a specific version, see
+[Updating AfterTouch](#updating-aftertouch) below.
+
 After the installation check if you can access AfterTouch from your local device by navigating to `http://<IP_ADDRESS_OF_SPEAKER>:8000`. If you can access the AfterTouch UI, you're good to go!
 
 ### If `http://<IP_ADDRESS_OF_SPEAKER>:8000` fails: SSH port forwarding
@@ -101,7 +105,11 @@ curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch
 sh install.sh --version 0.111.3
 ```
 
-Running **without** a version override installs the version hard-coded in the script (the latest release at the time the script was published). That default is updated with each release; if you're running from `main`, it reflects the most recent tagged version.
+Running **without** a version override installs the latest release: the script
+follows GitHub's `https://github.com/gesellix/Bose-SoundTouch/releases/latest`
+redirect to discover the newest tag. If that lookup fails (offline, or a `curl`
+build without `-w` support), it falls back to a pinned version baked into the
+script.
 
 > **Tip — rollback:** if the new binary misbehaves, the installer left a `.backup` file alongside it:
 > ```bash

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -91,14 +91,14 @@ Run the installer again with the version you want to install. The script backs u
 
 ```bash
 # 1. Environment variable (works when piping into sh)
-VERSION=0.107.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # 2. Command-line flag (pass args after `sh -s --`)
-rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.107.0
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
 
 # 3. Download first, then run with a flag
 curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh
-sh install.sh --version 0.107.0
+sh install.sh --version 0.111.3
 ```
 
 Running **without** a version override installs the version hard-coded in the script (the latest release at the time the script was published). That default is updated with each release; if you're running from `main`, it reflects the most recent tagged version.

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -1,15 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-# Default version installed when no override is provided.  Update this value
-# each time a new release is cut so that running the canonical one-liner
+# Version to install. Left empty by default so the canonical one-liner
 #   curl -sSL .../install.sh | sh
-# picks up the latest binary without extra arguments.
+# resolves and installs the latest release automatically (see below).
 #
-# Override via environment variable or the --version/-v flag:
+# Pin a specific version via environment variable or the --version/-v flag:
 #   VERSION=0.111.3 curl -sSL .../install.sh | sh
 #   curl -sSL .../install.sh | sh -s -- --version 0.111.3
-VERSION=${VERSION:-0.111.3}
+VERSION=${VERSION:-}
 
 # Parse optional command-line arguments so the script can be invoked as:
 #   install.sh --version 0.111.3
@@ -27,6 +26,30 @@ while [ $# -gt 0 ]; do
 done
 
 GH_REPO=${GH_REPO:-gesellix/Bose-SoundTouch}
+
+# Used only when the latest-release lookup fails (offline / rate-limited /
+# a curl without -w support).
+FALLBACK_VERSION=${FALLBACK_VERSION:-0.111.3}
+
+# Resolve the latest release when no explicit version was provided, by
+# following the stable redirect https://github.com/<repo>/releases/latest
+# -> .../releases/tag/vX.Y.Z and taking the tag from the final URL. The
+# leading "v" is stripped because the URLs below add it back (v$VERSION).
+if [ -z "$VERSION" ]; then
+  LATEST_URL="https://github.com/$GH_REPO/releases/latest"
+  echo "Resolving latest release via $LATEST_URL ..."
+  EFFECTIVE=$(curl -sSLI -o /dev/null -w '%{url_effective}' "$LATEST_URL" 2>/dev/null) || true
+  TAG=${EFFECTIVE##*/}
+  VER=${TAG#v}
+  case "$VER" in
+    [0-9]*.[0-9]*) VERSION="$VER" ;;
+    *)
+      VERSION="$FALLBACK_VERSION"
+      echo "WARNING: could not resolve latest release; using fallback $VERSION" >&2
+      ;;
+  esac
+fi
+
 BINARY_URL=${BINARY_URL:-https://github.com/$GH_REPO/releases/download/v$VERSION/soundtouch-service-v$VERSION-linux-armv7}
 INIT_SCRIPT_URL=${INIT_SCRIPT_URL:-https://raw.githubusercontent.com/$GH_REPO/v$VERSION/scripts/on-device-install/aftertouch}
 

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -7,13 +7,13 @@ set -eo pipefail
 # picks up the latest binary without extra arguments.
 #
 # Override via environment variable or the --version/-v flag:
-#   VERSION=0.107.0 curl -sSL .../install.sh | sh
-#   curl -sSL .../install.sh | sh -s -- --version 0.107.0
-VERSION=${VERSION:-0.107.0}
+#   VERSION=0.111.3 curl -sSL .../install.sh | sh
+#   curl -sSL .../install.sh | sh -s -- --version 0.111.3
+VERSION=${VERSION:-0.111.3}
 
 # Parse optional command-line arguments so the script can be invoked as:
-#   install.sh --version 0.107.0
-#   install.sh -v 0.107.0
+#   install.sh --version 0.111.3
+#   install.sh -v 0.111.3
 while [ $# -gt 0 ]; do
   case "$1" in
     --version|-v)

--- a/scripts/raspberry-pi/README.md
+++ b/scripts/raspberry-pi/README.md
@@ -26,7 +26,9 @@ curl -fsSL -o install-player.sh \
 sudo bash install-player.sh
 ```
 
-Pass a version tag as the first argument to pin a specific release:
+Both install the **latest release** by default (resolved from GitHub's
+`releases/latest` redirect). Pass a version tag as the first argument to pin a
+specific release:
 
 ```bash
 sudo bash install.sh v0.111.3

--- a/scripts/raspberry-pi/README.md
+++ b/scripts/raspberry-pi/README.md
@@ -35,10 +35,6 @@ sudo bash install.sh v0.111.3
 sudo bash install-player.sh v0.111.3
 ```
 
-> `install-web.sh` is the old name for `install-player.sh` and still works as a
-> deprecated alias. If you installed `soundtouch-web` previously, remove it with
-> `uninstall-web.sh` (see below) and switch to `install-player.sh`.
-
 ## Removal
 
 Matching uninstallers reverse each installer (stop and disable the service,

--- a/scripts/raspberry-pi/README.md
+++ b/scripts/raspberry-pi/README.md
@@ -29,8 +29,8 @@ sudo bash install-player.sh
 Pass a version tag as the first argument to pin a specific release:
 
 ```bash
-sudo bash install.sh v0.107.0
-sudo bash install-player.sh v0.107.0
+sudo bash install.sh v0.111.3
+sudo bash install-player.sh v0.111.3
 ```
 
 > `install-web.sh` is the old name for `install-player.sh` and still works as a

--- a/scripts/raspberry-pi/README.md
+++ b/scripts/raspberry-pi/README.md
@@ -32,3 +32,34 @@ Pass a version tag as the first argument to pin a specific release:
 sudo bash install.sh v0.107.0
 sudo bash install-player.sh v0.107.0
 ```
+
+> `install-web.sh` is the old name for `install-player.sh` and still works as a
+> deprecated alias. If you installed `soundtouch-web` previously, remove it with
+> `uninstall-web.sh` (see below) and switch to `install-player.sh`.
+
+## Removal
+
+Matching uninstallers reverse each installer (stop and disable the service,
+remove the unit, binary, and config). You can also remove things by hand — see
+the [full guide](../../docs/content/docs/guides/RASPBERRY-PI.md) for the manual
+commands.
+
+```bash
+# soundtouch-service (keeps the data directory unless you pass --purge):
+curl -fsSL -o uninstall.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall.sh
+sudo bash uninstall.sh
+
+# soundtouch-player:
+curl -fsSL -o uninstall-player.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall-player.sh
+sudo bash uninstall-player.sh
+
+# soundtouch-web (deprecated; switch to soundtouch-player afterwards):
+curl -fsSL -o uninstall-web.sh \
+  https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/uninstall-web.sh
+sudo bash uninstall-web.sh
+```
+
+The shared `soundtouch:soundtouch` user/group is removed only once no other
+`soundtouch-*` install remains on the host.

--- a/scripts/raspberry-pi/install-player.sh
+++ b/scripts/raspberry-pi/install-player.sh
@@ -32,11 +32,16 @@ set -euo pipefail
 # - Safe to re-run; it will update the binary, env file, and unit and restart.
 # ==============================================================================
 
-VERSION="${1:-${VERSION:-v0.111.3}}"
-# Normalize version prefix
-if [[ ! "$VERSION" =~ ^v ]]; then
+# Release to install. Empty means "resolve the latest release" (see
+# resolve_version). Pass a tag/number as $1 or VERSION=... to pin a release.
+VERSION="${1:-${VERSION:-}}"
+# Normalize version prefix for an explicitly provided version.
+if [[ -n "$VERSION" && ! "$VERSION" =~ ^v ]]; then
   VERSION="v${VERSION}"
 fi
+GH_REPO="${GH_REPO:-gesellix/Bose-SoundTouch}"
+# Used only when the latest-release lookup fails (offline / rate-limited).
+FALLBACK_VERSION="${FALLBACK_VERSION:-v0.111.3}"
 SERVICE_NAME="${SERVICE_NAME:-soundtouch-player}"
 BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-player}"
 
@@ -155,6 +160,40 @@ download_binary() {
 
   install -m 0755 "${tmp}/soundtouch-player" "${BIN_PATH}"
   log "Installed binary to ${BIN_PATH}"
+}
+
+resolve_version() {
+  # When no explicit version was given, resolve the latest release tag by
+  # following the documented stable redirect:
+  #   https://github.com/<owner>/<repo>/releases/latest
+  # which 302-redirects to .../releases/tag/vX.Y.Z. We read the final URL and
+  # take the tag from it. Falls back to FALLBACK_VERSION on any failure
+  # (offline, rate-limited, no usable curl/wget).
+  if [[ -n "$VERSION" ]]; then
+    return
+  fi
+
+  local latest_url="https://github.com/${GH_REPO}/releases/latest"
+  log "Resolving latest release via ${latest_url}"
+
+  local effective="" tag=""
+  if command -v curl >/dev/null 2>&1; then
+    effective="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null)" || true
+  else
+    # wget: don't follow the redirect, read the Location header instead.
+    effective="$(wget -S --max-redirect=0 -O /dev/null "$latest_url" 2>&1 \
+      | awk 'tolower($1) ~ /location:/ {print $2}' | tr -d '\r' | tail -1)" || true
+  fi
+  tag="${effective##*/}"
+
+  if [[ "$tag" =~ ^v?[0-9]+\.[0-9]+ ]]; then
+    [[ "$tag" =~ ^v ]] || tag="v${tag}"
+    VERSION="$tag"
+    log "Latest release is ${VERSION}"
+  else
+    VERSION="$FALLBACK_VERSION"
+    log "⚠️ Could not resolve latest release; falling back to ${VERSION}"
+  fi
 }
 
 self_update() {
@@ -324,6 +363,7 @@ main() {
     apt_install_if_missing curl
   fi
 
+  resolve_version
   self_update "$@"
 
   ensure_user_group

--- a/scripts/raspberry-pi/install-player.sh
+++ b/scripts/raspberry-pi/install-player.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Examples (override defaults via env vars):
 #
 #   sudo \
-#     VERSION=v0.107.0 \
+#     VERSION=v0.111.3 \
 #     HTTP_PORT=8081 \
 #     bash install-player.sh
 #
@@ -21,7 +21,7 @@ set -euo pipefail
 #     bash install-player.sh
 #
 # Or with a version argument to perform an update:
-#   sudo bash install-player.sh v0.107.0
+#   sudo bash install-player.sh v0.111.3
 #
 # Notes:
 # - This script downloads a release binary for your CPU (auto-detects armv7/arm64/amd64).
@@ -32,7 +32,7 @@ set -euo pipefail
 # - Safe to re-run; it will update the binary, env file, and unit and restart.
 # ==============================================================================
 
-VERSION="${1:-${VERSION:-v0.107.0}}"
+VERSION="${1:-${VERSION:-v0.111.3}}"
 # Normalize version prefix
 if [[ ! "$VERSION" =~ ^v ]]; then
   VERSION="v${VERSION}"

--- a/scripts/raspberry-pi/install.sh
+++ b/scripts/raspberry-pi/install.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Examples (override defaults via env vars):
 #
 #   sudo \
-#     VERSION=v0.107.0 \
+#     VERSION=v0.111.3 \
 #     HOSTNAME_FQDN=soundtouch.local \
 #     HTTP_PORT=80 \
 #     HTTPS_PORT=443 \
@@ -18,7 +18,7 @@ set -euo pipefail
 #     bash install.sh
 #
 # Or with a version argument to perform an update:
-#   sudo bash install.sh v0.107.0
+#   sudo bash install.sh v0.111.3
 #
 # Notes:
 # - This script downloads a release binary for your CPU (auto-detects armv7/arm64/amd64).
@@ -28,7 +28,7 @@ set -euo pipefail
 # - Safe to re-run; it will update binary/config/unit and restart the service.
 # ==============================================================================
 
-VERSION="${1:-${VERSION:-v0.107.0}}"
+VERSION="${1:-${VERSION:-v0.111.3}}"
 # Normalize version prefix
 if [[ ! "$VERSION" =~ ^v ]]; then
   VERSION="v${VERSION}"
@@ -117,7 +117,7 @@ detect_arch_asset() {
 download_url_for() {
   local asset="$1"
   # Release asset pattern used by you earlier:
-  # soundtouch-service-v0.107.0-linux-armv7
+  # soundtouch-service-v0.111.3-linux-armv7
   echo "https://github.com/gesellix/Bose-SoundTouch/releases/download/${VERSION}/soundtouch-service-${VERSION}-${asset}"
 }
 

--- a/scripts/raspberry-pi/install.sh
+++ b/scripts/raspberry-pi/install.sh
@@ -28,11 +28,16 @@ set -euo pipefail
 # - Safe to re-run; it will update binary/config/unit and restart the service.
 # ==============================================================================
 
-VERSION="${1:-${VERSION:-v0.111.3}}"
-# Normalize version prefix
-if [[ ! "$VERSION" =~ ^v ]]; then
+# Release to install. Empty means "resolve the latest release" (see
+# resolve_version). Pass a tag/number as $1 or VERSION=... to pin a release.
+VERSION="${1:-${VERSION:-}}"
+# Normalize version prefix for an explicitly provided version.
+if [[ -n "$VERSION" && ! "$VERSION" =~ ^v ]]; then
   VERSION="v${VERSION}"
 fi
+GH_REPO="${GH_REPO:-gesellix/Bose-SoundTouch}"
+# Used only when the latest-release lookup fails (offline / rate-limited).
+FALLBACK_VERSION="${FALLBACK_VERSION:-v0.111.3}"
 SERVICE_NAME="${SERVICE_NAME:-soundtouch-service}"
 BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-service}"
 
@@ -174,6 +179,40 @@ download_binary() {
 
   install -m 0755 "${tmp}/soundtouch-service" "${BIN_PATH}"
   log "Installed binary to ${BIN_PATH}"
+}
+
+resolve_version() {
+  # When no explicit version was given, resolve the latest release tag by
+  # following the documented stable redirect:
+  #   https://github.com/<owner>/<repo>/releases/latest
+  # which 302-redirects to .../releases/tag/vX.Y.Z. We read the final URL and
+  # take the tag from it. Falls back to FALLBACK_VERSION on any failure
+  # (offline, rate-limited, no usable curl/wget).
+  if [[ -n "$VERSION" ]]; then
+    return
+  fi
+
+  local latest_url="https://github.com/${GH_REPO}/releases/latest"
+  log "Resolving latest release via ${latest_url}"
+
+  local effective="" tag=""
+  if command -v curl >/dev/null 2>&1; then
+    effective="$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url" 2>/dev/null)" || true
+  else
+    # wget: don't follow the redirect, read the Location header instead.
+    effective="$(wget -S --max-redirect=0 -O /dev/null "$latest_url" 2>&1 \
+      | awk 'tolower($1) ~ /location:/ {print $2}' | tr -d '\r' | tail -1)" || true
+  fi
+  tag="${effective##*/}"
+
+  if [[ "$tag" =~ ^v?[0-9]+\.[0-9]+ ]]; then
+    [[ "$tag" =~ ^v ]] || tag="v${tag}"
+    VERSION="$tag"
+    log "Latest release is ${VERSION}"
+  else
+    VERSION="$FALLBACK_VERSION"
+    log "⚠️ Could not resolve latest release; falling back to ${VERSION}"
+  fi
 }
 
 self_update() {
@@ -364,6 +403,7 @@ main() {
     apt_install_if_missing curl
   fi
 
+  resolve_version
   self_update "$@"
 
   ensure_user_group

--- a/scripts/raspberry-pi/uninstall-player.sh
+++ b/scripts/raspberry-pi/uninstall-player.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==============================================================================
+# Bose-SoundTouch soundtouch-player uninstaller (systemd, headless)
+#
+# Reverses scripts/raspberry-pi/install-player.sh: stops and disables the
+# systemd service, removes the unit, binary, and config directory.
+#
+# Usage:
+#   sudo bash uninstall-player.sh
+#
+# Notes:
+# - soundtouch-player is stateless (no data directory) — nothing to preserve.
+# - The shared soundtouch:soundtouch user/group is removed only when no other
+#   soundtouch-{service,player,web} install remains on this host.
+# - Safe to re-run; every step tolerates already-missing pieces.
+# ==============================================================================
+
+SERVICE_NAME="${SERVICE_NAME:-soundtouch-player}"
+BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-player}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/soundtouch-player}"
+SERVICE_USER="${SERVICE_USER:-soundtouch}"
+SERVICE_GROUP="${SERVICE_GROUP:-soundtouch}"
+
+log() { printf "\n==> %s\n" "$*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+need_root() {
+  [[ "${EUID}" -eq 0 ]] || die "Please run as root (e.g. sudo bash $0)."
+}
+
+ensure_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+stop_remove_service() {
+  log "Stopping and disabling ${SERVICE_NAME}.service"
+  systemctl disable --now "${SERVICE_NAME}.service" 2>/dev/null || true
+
+  local unit="/etc/systemd/system/${SERVICE_NAME}.service"
+  if [[ -f "${unit}" ]]; then
+    log "Removing systemd unit: ${unit}"
+    rm -f "${unit}"
+  fi
+  systemctl daemon-reload
+  systemctl reset-failed "${SERVICE_NAME}.service" 2>/dev/null || true
+}
+
+remove_binary() {
+  if [[ -e "${BIN_PATH}" || -e "${BIN_PATH}.old" ]]; then
+    log "Removing binary: ${BIN_PATH} (and ${BIN_PATH}.old)"
+    rm -f "${BIN_PATH}" "${BIN_PATH}.old"
+  fi
+}
+
+remove_config() {
+  if [[ -d "${CONFIG_DIR}" ]]; then
+    log "Removing config directory: ${CONFIG_DIR}"
+    rm -rf "${CONFIG_DIR}"
+  fi
+}
+
+# Remove the shared soundtouch:soundtouch user/group only when no other
+# soundtouch-{service,player,web} install remains on this host.
+remove_user_group_if_unused() {
+  local n
+  for n in service player web; do
+    if [[ -f "/etc/systemd/system/soundtouch-${n}.service" ]] || \
+       [[ -e "/usr/local/bin/soundtouch-${n}" ]]; then
+      log "Keeping ${SERVICE_USER}:${SERVICE_GROUP} — still used by soundtouch-${n}."
+      return
+    fi
+  done
+
+  if id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+    log "No other soundtouch installs remain; removing user ${SERVICE_USER}"
+    userdel "${SERVICE_USER}" 2>/dev/null || true
+  fi
+  if getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+    groupdel "${SERVICE_GROUP}" 2>/dev/null || true
+  fi
+}
+
+main() {
+  need_root
+  ensure_cmd systemctl
+
+  stop_remove_service
+  remove_binary
+  remove_config
+  remove_user_group_if_unused
+
+  log "✅ soundtouch-player has been removed."
+}
+
+main "$@"

--- a/scripts/raspberry-pi/uninstall-web.sh
+++ b/scripts/raspberry-pi/uninstall-web.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==============================================================================
+# Bose-SoundTouch soundtouch-web uninstaller (systemd, headless)
+#
+# soundtouch-web was renamed to soundtouch-player. This uninstaller removes a
+# leftover soundtouch-web install created by the (now deprecated) install-web.sh:
+# it stops and disables the systemd service, removes the unit, binary, and config
+# directory.
+#
+# Usage:
+#   sudo bash uninstall-web.sh
+#
+# Notes:
+# - soundtouch-web is stateless (no data directory) — nothing to preserve.
+# - The shared soundtouch:soundtouch user/group is removed only when no other
+#   soundtouch-{service,player,web} install remains on this host.
+# - Safe to re-run; every step tolerates already-missing pieces.
+# ==============================================================================
+
+SERVICE_NAME="${SERVICE_NAME:-soundtouch-web}"
+BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-web}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/soundtouch-web}"
+SERVICE_USER="${SERVICE_USER:-soundtouch}"
+SERVICE_GROUP="${SERVICE_GROUP:-soundtouch}"
+
+log() { printf "\n==> %s\n" "$*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+need_root() {
+  [[ "${EUID}" -eq 0 ]] || die "Please run as root (e.g. sudo bash $0)."
+}
+
+ensure_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+stop_remove_service() {
+  log "Stopping and disabling ${SERVICE_NAME}.service"
+  systemctl disable --now "${SERVICE_NAME}.service" 2>/dev/null || true
+
+  local unit="/etc/systemd/system/${SERVICE_NAME}.service"
+  if [[ -f "${unit}" ]]; then
+    log "Removing systemd unit: ${unit}"
+    rm -f "${unit}"
+  fi
+  systemctl daemon-reload
+  systemctl reset-failed "${SERVICE_NAME}.service" 2>/dev/null || true
+}
+
+remove_binary() {
+  if [[ -e "${BIN_PATH}" || -e "${BIN_PATH}.old" ]]; then
+    log "Removing binary: ${BIN_PATH} (and ${BIN_PATH}.old)"
+    rm -f "${BIN_PATH}" "${BIN_PATH}.old"
+  fi
+}
+
+remove_config() {
+  if [[ -d "${CONFIG_DIR}" ]]; then
+    log "Removing config directory: ${CONFIG_DIR}"
+    rm -rf "${CONFIG_DIR}"
+  fi
+}
+
+# Remove the shared soundtouch:soundtouch user/group only when no other
+# soundtouch-{service,player,web} install remains on this host.
+remove_user_group_if_unused() {
+  local n
+  for n in service player web; do
+    if [[ -f "/etc/systemd/system/soundtouch-${n}.service" ]] || \
+       [[ -e "/usr/local/bin/soundtouch-${n}" ]]; then
+      log "Keeping ${SERVICE_USER}:${SERVICE_GROUP} — still used by soundtouch-${n}."
+      return
+    fi
+  done
+
+  if id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+    log "No other soundtouch installs remain; removing user ${SERVICE_USER}"
+    userdel "${SERVICE_USER}" 2>/dev/null || true
+  fi
+  if getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+    groupdel "${SERVICE_GROUP}" 2>/dev/null || true
+  fi
+}
+
+main() {
+  need_root
+  ensure_cmd systemctl
+
+  stop_remove_service
+  remove_binary
+  remove_config
+  remove_user_group_if_unused
+
+  log "✅ soundtouch-web has been removed."
+  cat <<'EOF'
+
+soundtouch-web is the old name for soundtouch-player. To install the current
+control panel instead:
+
+  curl -fsSL -o install-player.sh \
+    https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/raspberry-pi/install-player.sh
+  sudo bash install-player.sh
+EOF
+}
+
+main "$@"

--- a/scripts/raspberry-pi/uninstall.sh
+++ b/scripts/raspberry-pi/uninstall.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ==============================================================================
+# Bose-SoundTouch soundtouch-service uninstaller (systemd, headless)
+#
+# Reverses scripts/raspberry-pi/install.sh: stops and disables the systemd
+# service, removes the unit, binary, and config directory.
+#
+# Usage:
+#   sudo bash uninstall.sh            # remove service, KEEP the data directory
+#   sudo PURGE_DATA=true bash uninstall.sh   # also delete the data directory
+#   sudo bash uninstall.sh --purge           # same as PURGE_DATA=true
+#
+# Notes:
+# - The data directory (${DATA_DIR}) holds your datastore: presets, device
+#   registrations, and certificates. It is PRESERVED by default; deleting it is
+#   opt-in via PURGE_DATA=true (or --purge).
+# - The shared soundtouch:soundtouch user/group is removed only when no other
+#   soundtouch-{service,player,web} install remains on this host.
+# - Safe to re-run; every step tolerates already-missing pieces.
+# ==============================================================================
+
+PURGE_DATA="${PURGE_DATA:-false}"
+for arg in "$@"; do
+  case "$arg" in
+    --purge) PURGE_DATA="true" ;;
+  esac
+done
+
+SERVICE_NAME="${SERVICE_NAME:-soundtouch-service}"
+BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-service}"
+CONFIG_DIR="${CONFIG_DIR:-/etc/soundtouch-service}"
+DATA_DIR="${DATA_DIR:-/var/lib/soundtouch-service}"
+SERVICE_USER="${SERVICE_USER:-soundtouch}"
+SERVICE_GROUP="${SERVICE_GROUP:-soundtouch}"
+
+log() { printf "\n==> %s\n" "$*"; }
+die() { echo "ERROR: $*" >&2; exit 1; }
+
+need_root() {
+  [[ "${EUID}" -eq 0 ]] || die "Please run as root (e.g. sudo bash $0)."
+}
+
+ensure_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "Missing required command: $1"
+}
+
+stop_remove_service() {
+  log "Stopping and disabling ${SERVICE_NAME}.service"
+  systemctl disable --now "${SERVICE_NAME}.service" 2>/dev/null || true
+
+  local unit="/etc/systemd/system/${SERVICE_NAME}.service"
+  if [[ -f "${unit}" ]]; then
+    log "Removing systemd unit: ${unit}"
+    rm -f "${unit}"
+  fi
+  systemctl daemon-reload
+  systemctl reset-failed "${SERVICE_NAME}.service" 2>/dev/null || true
+}
+
+remove_binary() {
+  if [[ -e "${BIN_PATH}" || -e "${BIN_PATH}.old" ]]; then
+    log "Removing binary: ${BIN_PATH} (and ${BIN_PATH}.old)"
+    rm -f "${BIN_PATH}" "${BIN_PATH}.old"
+  fi
+}
+
+remove_config() {
+  if [[ -d "${CONFIG_DIR}" ]]; then
+    log "Removing config directory: ${CONFIG_DIR}"
+    rm -rf "${CONFIG_DIR}"
+  fi
+}
+
+handle_data_dir() {
+  if [[ ! -d "${DATA_DIR}" ]]; then
+    return
+  fi
+  if [[ "${PURGE_DATA}" == "true" ]]; then
+    log "Removing data directory: ${DATA_DIR}"
+    rm -rf "${DATA_DIR}"
+  else
+    log "Preserving data directory: ${DATA_DIR}"
+    echo "    This holds your datastore (presets, device registrations, certs)."
+    echo "    To delete it as well, run:  sudo rm -rf ${DATA_DIR}"
+    echo "    (or re-run this uninstaller with --purge / PURGE_DATA=true)"
+  fi
+}
+
+# Remove the shared soundtouch:soundtouch user/group only when no other
+# soundtouch-{service,player,web} install remains on this host.
+remove_user_group_if_unused() {
+  local n
+  for n in service player web; do
+    if [[ -f "/etc/systemd/system/soundtouch-${n}.service" ]] || \
+       [[ -e "/usr/local/bin/soundtouch-${n}" ]]; then
+      log "Keeping ${SERVICE_USER}:${SERVICE_GROUP} — still used by soundtouch-${n}."
+      return
+    fi
+  done
+
+  if id -u "${SERVICE_USER}" >/dev/null 2>&1; then
+    log "No other soundtouch installs remain; removing user ${SERVICE_USER}"
+    userdel "${SERVICE_USER}" 2>/dev/null || true
+  fi
+  if getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+    groupdel "${SERVICE_GROUP}" 2>/dev/null || true
+  fi
+}
+
+main() {
+  need_root
+  ensure_cmd systemctl
+
+  stop_remove_service
+  remove_binary
+  remove_config
+  handle_data_dir
+  remove_user_group_if_unused
+
+  log "✅ soundtouch-service has been removed."
+}
+
+main "$@"


### PR DESCRIPTION
## What

With `soundtouch-web` renamed to `soundtouch-player` (and the web UI merged into `soundtouch-service`, so the player is now optional), users who installed the old `soundtouch-web` had no scripted way to remove it, and the Pi/host installers had no matching uninstaller at all. This PR adds uninstallers, fixes stale docs, and makes the installers track the latest release instead of a hardcoded version.

## Changes

**New uninstallers (`scripts/raspberry-pi/`)** — each mirrors its installer's conventions, idempotent and tolerant of already-missing pieces:

- `uninstall.sh` (service) — preserves the data directory by default; `--purge` / `PURGE_DATA=true` to delete it.
- `uninstall-player.sh` — stateless teardown.
- `uninstall-web.sh` — removes a leftover `soundtouch-web` install and points users at `install-player.sh`.

The shared `soundtouch:soundtouch` user/group is removed only once no other `soundtouch-{service,player,web}` install remains on the host.

**Installers default to the latest release** — `VERSION` defaults to empty and is resolved by following GitHub's documented stable redirect (`/releases/latest` -> `/releases/tag/vX.Y.Z`), reading the effective URL. No GitHub API rate limit, no `jq`. An explicit `VERSION=` / `--version` / positional arg still pins a release. On lookup failure (offline, rate-limited, a `curl` without `-w`), each script falls back to a pinned `FALLBACK_VERSION`. Applied to all three Pi installers plus `scripts/on-device-install/install.sh`.

**Docs** — the README and guides still told users to fetch `install-web.sh` to install the player; switched those to `install-player.sh`, kept and improved the manual removal commands (noting the service datastore is preserved unless explicitly deleted), documented the new uninstallers, added a "Migrating from soundtouch-web" section, and noted the installers now install the latest release by default. Also bumped the remaining version examples to v0.111.3.

## Verification

- All scripts pass `bash -n` / `sh -n`.
- The `/releases/latest` redirect resolution was tested live and resolves to the current `v0.111.3`.
- Runtime paths that need `systemctl` / `userdel` were not exercised locally (macOS); they need a Linux/systemd host (Pi or VM) to verify end-to-end. Suggested checks: install then uninstall each service, confirm the unit/binary/config are gone, the shared user/group survives while another service remains and is removed once the last one goes, and that `uninstall.sh` preserves the data dir unless `--purge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)