### PR TITLE
fix(setup/ui): treat passive-observer no-inbound as a non-blocking warning (refs #471)

### DIFF
--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -3184,6 +3184,7 @@ function setPreflightItemStatus(li, status, message) {
     if (status === "running") { icon = "⟳"; color = "#1976d2"; suffix = " — running…"; }
     else if (status === "ok")  { icon = "✅"; color = "green";   suffix = " — passed"; }
     else if (status === "skip") { icon = "—"; color = "#666";    suffix = message ? ` — ${message}` : " — skipped"; }
+    else if (status === "warn") { icon = "⚠️"; color = "#ed6c02"; suffix = message ? ` — ${message}` : " — warning"; }
     else                       { icon = "❌"; color = "red";     suffix = message ? ` — ${message}` : " — failed"; }
     li.innerText = `${icon} ${li.dataset.name}${suffix}`;
     li.style.color = color;
@@ -3272,7 +3273,7 @@ async function checkPeerReachability(deviceId) {
         }
         if (result.error) return {status: "fail", message: result.error.split("\n")[0]};
         if (result.result && result.result.reached === false) {
-            return {status: "fail", message: "no inbound from device before timeout"};
+            return {status: "warn", message: "no inbound seen within the wait window — usually just timing (the update daemon dials out on its own slow schedule; a reboot after Apply validates it), not a port or config problem. Safe to proceed."};
         }
         return {status: "fail", message: "probe failed"};
     } catch (e) {
@@ -3386,9 +3387,11 @@ function awaitPreflightDecision(results) {
     summary.replaceChildren();
 
     if (failed === 0) {
-        summary.innerText = `✅ ${passed} of ${results.length} checks passed` +
-            (skipped > 0 ? ` (${skipped} skipped)` : "");
-        summary.style.color = "green";
+        const warned = results.filter(r => r.status === "warn").length;
+        let extras = skipped > 0 ? ` (${skipped} skipped)` : "";
+        if (warned > 0) extras += ` (${warned} warning${warned === 1 ? "" : "s"})`;
+        summary.innerText = `✅ ${passed} of ${results.length} checks passed${extras}`;
+        summary.style.color = warned > 0 ? "#ed6c02" : "green";
         actions.replaceChildren();
         // Auto-proceed: caller adds a brief delay so the user sees the
         // green frame before Apply kicks off.
@@ -3508,9 +3511,11 @@ function renderPreflightPreviewSummary(results) {
     if (!summary || !actions) return;
 
     if (failed === 0) {
-        summary.innerText = `✅ Pre-flight passed — ${passed} of ${results.length} checks`
-            + (skipped > 0 ? ` (${skipped} skipped)` : "");
-        summary.style.color = "green";
+        const warned = results.filter(r => r.status === "warn").length;
+        let extras = skipped > 0 ? ` (${skipped} skipped)` : "";
+        if (warned > 0) extras += ` (${warned} warning${warned === 1 ? "" : "s"})`;
+        summary.innerText = `✅ Pre-flight passed — ${passed} of ${results.length} checks${extras}`;
+        summary.style.color = warned > 0 ? "#ed6c02" : "green";
     } else {
         summary.innerText = `❌ Pre-flight: ${failed} of ${results.length} checks failed`;
         summary.style.color = "red";


### PR DESCRIPTION
## What

The migration pre-flight "Reachability check (passive observer)" reported a timed-out "no inbound from device" as a hard **failure**, so the panel showed "N of M checks failed" and forced a "Proceed Anyway". That outcome is usually just timing: the speaker's swUpdate daemon dials out on its own slow schedule, and a reboot after Apply validates the fan-out. A reporter on #471 (Leeto001, v0.112.0) hit this and wrongly suspected custom service ports were the cause.

## Change

- Introduce a proper non-blocking `warn` status in the pre-flight item renderer (amber, does not count toward the failed total).
- Downgrade the passive-observer no-inbound case from `fail` to `warn`, with a message that explains the timing and states plainly that it is not a port or config problem and is safe to proceed.
- The pre-flight summaries now surface a warning count alongside passed/skipped and keep auto-proceeding. Genuine probe errors (probe failed, request error) still `fail`.

Frontend-only (`pkg/service/handlers/web/js/script.js`, go:embed'd). `node --check` and `go build ./...` pass. (The player/admin UIs have no JS test harness yet; that gap is tracked separately.)

## Context

Follow-up from a review of #471 after the v0.112.0 enable-ssh changes. The other two items from that review (a cosmetic `rw` shell-noise line in the persist step, and intermittent command injection on some firmware) are intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
