### PR TITLE
fix(player): Library folder playback + replay, small-screen navbar, grouping device names

### DIFF
--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -1114,6 +1114,19 @@ func (app *WebApp) HandleDeviceRecents(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// storedMusicTypeForReplay derives a STORED_MUSIC ContentItem type from the
+// speaker-native location, which ends with the item kind (e.g. "1$4$2 TRACK"
+// or a container's "… DIR"). Recents don't store the type, and the speaker
+// rejects an empty-type STORED_MUSIC select with INVALID_SOURCE. Falls back to
+// "track" when the location has no kind suffix.
+func storedMusicTypeForReplay(location string) string {
+	if fields := strings.Fields(location); len(fields) >= 2 {
+		return strings.ToLower(fields[len(fields)-1])
+	}
+
+	return "track"
+}
+
 // HandleDevicePlay plays an arbitrary content item on a device. Generic
 // counterpart to HandlePlayTuneIn — used by the Recents panel to replay
 // items the speaker reports under /recents, regardless of their source.
@@ -1151,9 +1164,18 @@ func (app *WebApp) HandleDevicePlay(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Recents don't carry a contentItemType for STORED_MUSIC, and the speaker
+	// rejects an empty-type STORED_MUSIC select with INVALID_SOURCE. The
+	// speaker-native location ends with the item kind (e.g. "1$4$2 TRACK"), so
+	// derive the type from it when the caller didn't supply one.
+	ciType := req.Type
+	if ciType == "" && req.Source == "STORED_MUSIC" {
+		ciType = storedMusicTypeForReplay(req.Location)
+	}
+
 	contentItem := &models.ContentItem{
 		Source:       req.Source,
-		Type:         req.Type,
+		Type:         ciType,
 		Location:     req.Location,
 		ItemName:     req.ItemName,
 		ContainerArt: req.ContainerArt,

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -146,6 +146,37 @@ img { display: block; max-width: 100%; }
     font-family: monospace;
 }
 
+/* Small screens (phones, portrait): the absolutely-centered page title and the
+   right-aligned icon bar share the same space in the fixed-height navbar and
+   collide (#500). Let the navbar wrap into two rows: row 1 keeps the logo with
+   the title beside it (the title fills the remaining width and ellipsizes), and
+   the icon bar drops onto its own full-width row below. */
+@media (max-width: 600px) {
+    .navbar {
+        flex-wrap: wrap;
+        height: auto;
+        min-height: 52px;
+        row-gap: 0.25rem;
+        padding-top: 0.4rem;
+        padding-bottom: 0.4rem;
+    }
+
+    .page-title {
+        position: static;
+        transform: none;
+        flex: 1 1 auto;   /* sit next to the logo and fill the rest of row 1 */
+        width: auto;
+        min-width: 0;     /* allow the title to shrink + ellipsize */
+    }
+
+    .nav-links {
+        order: 1;          /* force the icon bar onto its own row below */
+        width: 100%;
+        justify-content: center;
+        flex-wrap: wrap;
+    }
+}
+
 .nav-logo {
     width: 24px;
     height: 24px;

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -96,10 +96,13 @@ export function Library({ devices }) {
     }
 
     async function playEntry(entry) {
+        // Pass the entry's own type so a folder selects as a container ("dir")
+        // rather than a single track — that lets the speaker queue the folder so
+        // next/previous and auto-advance work, instead of stopping after one item.
         await api.libraryPlay(deviceId, {
             account: server.account,
             location: entry.location,
-            type: 'track',
+            type: entry.type || 'track',
             name: entry.name,
         });
         setPlayingName(entry.name);
@@ -251,10 +254,10 @@ export function Library({ devices }) {
                                     <span class="tunein-item-name">${entry.name}</span>
                                     ${entry.type ? html`<span class="tunein-item-desc">${entry.type}</span>` : null}
                                 </div>
-                                ${entry.playable && !entry.isDir ? html`
+                                ${entry.playable || entry.isDir ? html`
                                     <button
                                         class="tunein-play-btn"
-                                        title="Play on ${devices[deviceId]?.info?.name || deviceId}"
+                                        title="${entry.isDir ? 'Play folder' : 'Play'} on ${devices[deviceId]?.info?.name || deviceId}"
                                         onClick=${(e) => { e.stopPropagation(); playEntry(entry); }}
                                     >▶</button>
                                 ` : null}

--- a/pkg/service/soundtouchweb/static/js/components/Zone.js
+++ b/pkg/service/soundtouchweb/static/js/components/Zone.js
@@ -52,7 +52,7 @@ export function Zone({ deviceId, devices }) {
     const zoneIps = new Set([zone.masterIp, ...(zone.members || []).map(m => m.ip)].filter(Boolean));
     const available = Object.entries(devices || {}).filter(([ip]) => !zoneIps.has(ip));
 
-    const deviceName = (ip) => devices[ip]?.info?.Name ?? ip;
+    const deviceName = (ip) => devices[ip]?.info?.name || ip;
 
     return html`
         <div class="zone-section">
@@ -76,7 +76,7 @@ export function Zone({ deviceId, devices }) {
                     ${(zone.members || []).map(m => html`
                         <div class="zone-member" key=${m.ip}>
                             <span class="zone-badge slave">Member</span>
-                            <span class="zone-member-name">${m.name || m.ip}</span>
+                            <span class="zone-member-name">${m.name || deviceName(m.ip)}</span>
                             <button class="btn-icon zone-remove" title="Remove from zone"
                                 onClick=${() => removeDevice(m.ip)}>✕</button>
                         </div>
@@ -93,7 +93,7 @@ export function Zone({ deviceId, devices }) {
             ${zone.isSlave && html`
                 <div class="zone-row">
                     <span class="zone-badge slave">Member</span>
-                    <span class="zone-member-name">Zone: ${zone.masterName || zone.masterIp}</span>
+                    <span class="zone-member-name">Zone: ${zone.masterName || deviceName(zone.masterIp)}</span>
                     <button class="btn-secondary zone-btn" onClick=${leave}>Leave zone</button>
                 </div>
             `}
@@ -105,7 +105,10 @@ export function Zone({ deviceId, devices }) {
                         <div class="picker-devices">
                             ${available.map(([ip, d]) => html`
                                 <button class="picker-device-btn" key=${ip} onClick=${() => addDevice(ip)}>
-                                    ${d.info?.Name ?? ip}
+                                    <div class="picker-device-info">
+                                        <span class="picker-device-name">${d.info?.name || ip}</span>
+                                        <span class="picker-device-ip">${d.info?.ip_address || ip}</span>
+                                    </div>
                                 </button>
                             `)}
                         </div>

--- a/pkg/service/soundtouchweb/storedmusic_replay_test.go
+++ b/pkg/service/soundtouchweb/storedmusic_replay_test.go
@@ -1,0 +1,26 @@
+package soundtouchweb
+
+import "testing"
+
+// TestStoredMusicTypeForReplay covers deriving the ContentItem type from a
+// STORED_MUSIC recent's location when the stored type is empty. Without a type
+// the speaker rejects the select with INVALID_SOURCE.
+func TestStoredMusicTypeForReplay(t *testing.T) {
+	cases := []struct {
+		location string
+		want     string
+	}{
+		{"1$4$2 TRACK", "track"},
+		{"5:audio5:part13:5521:5 TRACK", "track"},
+		{"1 DIR", "dir"},
+		{"1 CONTAINER", "container"},
+		{"noSuffix", "track"}, // fallback
+		{"", "track"},         // fallback
+	}
+
+	for _, c := range cases {
+		if got := storedMusicTypeForReplay(c.location); got != c.want {
+			t.Errorf("storedMusicTypeForReplay(%q) = %q, want %q", c.location, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Three related player (web UI) fixes, all touching the player frontend and its handler.

## #501 — play a Library folder so Next/Prev work
Playing a DLNA/STORED_MUSIC track via the Library tab only ever queued a single track, so Next/Prev were dead and playback stopped after one track. The Library tab can now play a **folder** (container), which primes the speaker's queue so Next/Prev and auto-advance work.

## STORED_MUSIC replay → INVALID_SOURCE
Replaying a STORED_MUSIC recent could fail with `INVALID_SOURCE` because the ContentItem `type` was empty. `HandleDevicePlay` now derives the type from the recent's location (e.g. `… TRACK` → `track`) when it's missing. Covered by `storedmusic_replay_test.go`.

## #500 — navbar overlap on small screens
On narrow/portrait viewports the player navbar title and icon bar overlapped. The navbar now wraps below ~600px: logo + title on the first row (title ellipsizes), icon bar on its own row.

## #498 — device names in grouping
The grouping/zone UI showed raw IPs instead of device names. It now resolves and shows the friendly device name, falling back to the IP.

## Scope
Player frontend (`Library.js`, `Zone.js`, `app.css`) + its backend handler (`handler.go`) + a regression test. No changes to the core service, client, or playback protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)