### PR TITLE
Improvements from #517: CA re-install fix, play_info DNS docs, Docker persistence

### DIFF
--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -485,6 +485,12 @@ func main() {
 
 			if persisted.ServerURL == "" {
 				log.Printf("Creating default settings.json in %s", sanitizeLog(config.dataDir))
+				log.Printf("Data directory %s looks empty (first run). If you did NOT expect this "+
+					"(e.g. after recreating a Docker container), your previous settings, datastore and "+
+					"CA were not persisted; mount a persistent volume at the data dir (Docker: "+
+					"-v <volume>:/app/data) so device state and the CA survive restarts. A lost CA "+
+					"forces re-migrating speakers and re-trusting the new CA.",
+					sanitizeLog(config.dataDir))
 				persisted = createDefaultSettings(ds, config)
 			}
 

--- a/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -66,12 +66,27 @@ docker run -d \
   --name aftertouch \
   --network host \
   -e SERVER_URL=http://192.0.2.10:8000 \
-  -v aftertouch-data:/data \
+  -v aftertouch-data:/app/data \
   ghcr.io/gesellix/bose-soundtouch:latest
 ```
 
 Replace `192.0.2.10` with the host machine's LAN IP. The `--network host` flag
 is required so AfterTouch can reach the speakers and respond to mDNS discovery.
+
+> **Persist the data directory.** The container stores everything stateful under
+> `/app/data` (`DATA_DIR`): the datastore, `settings.json`, and the service CA.
+> Mount a volume there (`-v <volume>:/app/data`, as above) or this state is lost
+> when the container is recreated. Losing the CA forces you to re-migrate every
+> speaker and re-trust the new CA, so back this volume up before upgrading.
+
+> **Windows / macOS (Docker Desktop):** `--network host` does not work the same
+> way as on Linux, so publish the ports explicitly instead, e.g.
+> `-p 8000:8000 -p 8443:8443`. mDNS discovery across the Docker Desktop network
+> boundary is unreliable; add speakers by IP in the Devices tab. If you also use
+> DNS interception (so the speaker resolves Bose hostnames to AfterTouch), you
+> additionally need to publish the DNS port (`-p 53:53/udp -p 53:53/tcp`) and
+> make AfterTouch reachable on `:443` (the hardcoded Bose hosts are plain HTTPS),
+> e.g. `-p 443:8443`. Keep the same `-v <volume>:/app/data` mount.
 
 ---
 

--- a/docs/content/docs/reference/API-ENDPOINTS.md
+++ b/docs/content/docs/reference/API-ENDPOINTS.md
@@ -338,6 +338,19 @@ Configures the clock display.
 ### POST /speaker ✅ **Implemented**
 Plays TTS messages or URL content for notifications (ST-10 Series only).
 
+> **Requires DNS interception.** Before playing a `play_info` notification the
+> speaker validates the `app_key` by calling `GET /v1/auth` against a hardcoded
+> Bose host (`audionotification.api.bosecm.com`, on some firmware the
+> `...dev...` variant). After the cloud shutdown that host no longer exists, so
+> unless the speaker resolves Bose hostnames through AfterTouch (DNS server +
+> the `/etc/resolv.conf` hook, so `*.api.bosecm.com` points at AfterTouch, which
+> answers `/v1/auth`), the request hangs and returns
+> `ALLEGROWEBSERVER_TIMEOUT` (error `1046`) after ~60s. If you cannot use DNS
+> interception, play the clip via the `LOCAL_INTERNET_RADIO` path instead (the
+> "radio" method used by the web player's TTS): it needs no `app_key` and no DNS
+> redirection, but it replaces the current source rather than ducking and
+> resuming it.
+
 **TTS Request XML:**
 ```xml
 <play_info>

--- a/pkg/service/health/checks_dns_speaker_usage.go
+++ b/pkg/service/health/checks_dns_speaker_usage.go
@@ -100,7 +100,10 @@ func runDNSSpeakerUsageCheck(
 				"Bose hostnames. It may simply not have played a TuneIn stream since the " +
 				"last restart, or it may be using a different DNS resolver. " +
 				"Click 'Test DNS path' to run an active probe that sends a silent " +
-				"notification and waits for the speaker to call back through AfterTouch's DNS.",
+				"notification and waits for the speaker to call back through AfterTouch's DNS. " +
+				"The same DNS path is required for TTS / `/speaker` `play_info` notifications: " +
+				"the speaker validates the app_key against a hardcoded Bose host, so without " +
+				"DNS interception those requests time out with ALLEGROWEBSERVER_TIMEOUT (1046).",
 			QuickFixes: []QuickFix{probeDNSPathQuickFix},
 		})
 	}

--- a/pkg/service/setup/setup.go
+++ b/pkg/service/setup/setup.go
@@ -807,56 +807,60 @@ func applyURLOverrides(cfg *PrivateCfg, options map[string]string) {
 	}
 }
 
-// checkCACertTrusted checks if the local CA certificate is already in
-// the device's trust store. The CALabel grep works regardless of whether
-// Manager.Crypto is configured — only the secondary "match cert payload"
-// fallback needs it. CLI callers without Crypto can therefore still
-// detect a previously-trusted CA.
+// checkCACertTrusted decides whether the device already trusts *this* service's
+// CA.
+//
+// When the service CA is available (Manager.Crypto set), the certificate
+// *payload* is authoritative: a previous migration may have left our label
+// (CALabel) in the bundle even though the actual CA has since changed — e.g. the
+// service CA was regenerated after its data dir was recreated without a
+// persistent volume. Matching the label alone would then falsely report the
+// device as trusted and skip re-installing the new CA, leaving the speaker
+// unable to validate TLS to the service (the symptom seen in #517). So we match
+// the current CA's payload and deliberately ignore the (possibly stale) label.
+//
+// Only when the CA can't be read (e.g. a CLI caller without Crypto) do we fall
+// back to the label, which is the best signal available there.
 func (m *Manager) checkCACertTrusted(summary *MigrationSummary, deviceIP string) {
 	client := m.NewSSH(deviceIP)
 	bundlePath := "/etc/pki/tls/certs/ca-bundle.crt"
 
-	// Primary check: our injected label.
-	output, err := client.Run(fmt.Sprintf("grep -F %q %s", CALabel, bundlePath))
-	if err == nil && strings.Contains(output, CALabel) {
-		summary.CACertTrusted = true
-		return
-	}
+	if m.Crypto != nil {
+		if certData, ok := m.firstCACertBodyLine(); ok {
+			// Payload present -> trusted; absent -> not trusted (re-install),
+			// regardless of a possibly-stale label.
+			if _, err := client.Run(fmt.Sprintf("grep -F %q %s", certData, bundlePath)); err == nil {
+				summary.CACertTrusted = true
+			}
 
-	// Secondary check (only when Manager.Crypto is configured): match
-	// the actual cert payload — covers older injections that lack the
-	// label.
-	if m.Crypto == nil {
-		return
-	}
-
-	caCertPEM, err := os.ReadFile(m.Crypto.GetCACertPath())
-	if err != nil {
-		return
-	}
-
-	// We look for the first part of the certificate (e.g. the first 64 chars of the base64 data)
-	// to see if it's already in the bundle.
-	lines := strings.Split(string(caCertPEM), "\n")
-
-	var certData string
-
-	for _, line := range lines {
-		if !strings.Contains(line, "BEGIN CERTIFICATE") && !strings.Contains(line, "END CERTIFICATE") && line != "" {
-			certData = line
-			break
+			return
 		}
 	}
 
-	if certData == "" {
-		return
-	}
-
-	// Use grep to check for the certificate data in the bundle
-	_, err = client.Run(fmt.Sprintf("grep -F %q %s", certData, bundlePath))
-	if err == nil {
+	// Fallback for callers without the CA at hand: match our injected label.
+	output, err := client.Run(fmt.Sprintf("grep -F %q %s", CALabel, bundlePath))
+	if err == nil && strings.Contains(output, CALabel) {
 		summary.CACertTrusted = true
 	}
+}
+
+// firstCACertBodyLine returns the first base64 body line of the service CA
+// certificate, used as a cheap fingerprint to check whether this exact CA is
+// already present in a device's trust bundle. Returns false when the cert can't
+// be read or has no body line.
+func (m *Manager) firstCACertBodyLine() (string, bool) {
+	caCertPEM, err := os.ReadFile(m.Crypto.GetCACertPath())
+	if err != nil {
+		return "", false
+	}
+
+	for _, line := range strings.Split(string(caCertPEM), "\n") {
+		if line != "" && !strings.Contains(line, "BEGIN CERTIFICATE") && !strings.Contains(line, "END CERTIFICATE") {
+			return line, true
+		}
+	}
+
+	return "", false
 }
 
 // MigrateSpeaker configures the speaker at the given IP to use this service.

--- a/pkg/service/setup/setup_test.go
+++ b/pkg/service/setup/setup_test.go
@@ -453,6 +453,67 @@ func TestCheckCACertTrusted(t *testing.T) {
 	}
 }
 
+// TestCheckCACertTrustedStaleLabel is the #517 regression: a previous
+// migration's CALabel survived a service-CA regeneration, so the label is in the
+// bundle but the *current* CA payload is not. The device must then be treated as
+// NOT trusting the new CA (so the migration re-installs it), instead of being
+// falsely skipped on the stale label.
+func TestCheckCACertTrustedStaleLabel(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "ca-trust-stale")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	cm := certmanager.NewCertificateManager(filepath.Join(tempDir, "certs"))
+	if err := cm.EnsureCA(); err != nil {
+		t.Fatalf("Failed to ensure CA: %v", err)
+	}
+
+	m := NewManager("http://localhost:8000", nil, cm)
+	m.NewSSH = func(_ string) SSHClient {
+		return &mockSSH{
+			runFunc: func(command string) (string, error) {
+				// Stale label is still present...
+				if strings.Contains(command, CALabel) {
+					return CALabel, nil
+				}
+				// ...but the current CA payload is not in the bundle.
+				return "", fmt.Errorf("not found")
+			},
+		}
+	}
+
+	summary := &MigrationSummary{}
+	m.checkCACertTrusted(summary, "192.0.2.10")
+	if summary.CACertTrusted {
+		t.Error("stale label without a matching CA payload must not count as trusted (should re-install)")
+	}
+}
+
+// TestCheckCACertTrustedNoCryptoFallback verifies that when the service CA is
+// not available (e.g. a CLI caller without Crypto), the injected label remains
+// the trust signal.
+func TestCheckCACertTrustedNoCryptoFallback(t *testing.T) {
+	m := NewManager("http://localhost:8000", nil, nil)
+	m.NewSSH = func(_ string) SSHClient {
+		return &mockSSH{
+			runFunc: func(command string) (string, error) {
+				if strings.Contains(command, CALabel) {
+					return CALabel, nil
+				}
+				return "", fmt.Errorf("not found")
+			},
+		}
+	}
+
+	summary := &MigrationSummary{}
+	m.checkCACertTrusted(summary, "192.0.2.10")
+	if !summary.CACertTrusted {
+		t.Error("without Crypto, a present label should count as trusted")
+	}
+}
+
 func TestTestConnection(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "test-connection")
 	if err != nil {


### PR DESCRIPTION
Improvements prompted by #517 (`/speaker` `<play_info>` timeout). The reporter
self-resolved, but the thread surfaced one real bug and several doc/UX gaps. Refs
#517 (kept open pending the reporter's confirmation that the wording/changes
help).

## Root cause (for context)

`play_info` makes the speaker validate the `app_key` via `GET /v1/auth` against a
hardcoded Bose host (`audionotification(dev).api.bosecm.com`). After the cloud
shutdown that host is unresolvable, so without DNS interception the call retries
and `/speaker` times out with `ALLEGROWEBSERVER_TIMEOUT` (1046). AfterTouch
already answers `/v1/auth` and intercepts those hosts, so it works once DNS is in
place. No code change needed for that path; the changes below address the bug and
the gaps the report exposed.

## Changes (3 commits)

1. **fix(setup): re-install the CA when it was regenerated, not just label-matched.**
   `checkCACertTrusted` matched only the static `# AfterTouch` label, so after a
   service-CA regeneration (recreated container / fresh data dir) the stale label
   made the migration skip re-installing the new CA, leaving the speaker unable to
   validate TLS. Now compares the actual cert payload and re-installs on mismatch;
   label fallback only when the CA can't be read (CLI without Crypto). + regression
   tests.

2. **docs(api,health): note `/speaker` play_info needs DNS interception.**
   API reference documents the DNS requirement, the 1046 symptom, and the no-DNS
   `LOCAL_INTERNET_RADIO` alternative. The "Test DNS path" health check now mentions
   that TTS/play_info depends on the same DNS path.

3. **fix(docs,service): persist the Docker data dir at `/app/data` + warn when empty.**
   The walkthrough mounted the volume at `/data`, but the image's `DATA_DIR` is
   `/app/data`, so the documented `docker run` never actually persisted the
   datastore/settings/CA. Corrected the path, documented what lives there and the
   cost of losing it, added a Windows/macOS Docker Desktop note, and the service now
   logs a notice on startup when the data dir looks empty.

## Testing

- `go build ./...`, `go vet`, package tests (`setup`, `health`, `soundtouch-service`),
  `gofmt`, and `markdown-link-check` on the changed docs all pass.

## Note

The Windows/Docker-Desktop `:443`/`:53` port guidance in change 3 is reasoned from
the architecture (hardcoded Bose hosts are plain HTTPS on 443), not hardware-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)