### PR TITLE
docs: troubleshoot on-device install 'certificate is not yet valid' (stuck clock) (#403)

### DIFF
--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -154,6 +154,46 @@ logread -f | grep -v '127.0.0.1:'
 
 > **Note on the firmware-internal placeholder sources.** The `<sourceItem source="SPOTIFY" sourceAccount="SpotifyConnectUserName" ...>`, `SpotifyAlexaUserName`, `UPNP/UPnPUserName`, `STORED_MUSIC_MEDIA_RENDERER/StoredMusicUserName`, and `QPLAY/QPlay{1,2}UserName` entries that appear in `/sources` even on a broken or unpaired speaker are *firmware-synthesized*. They show up regardless of AfterTouch's source list — their `status="UNAVAILABLE"` does not indicate an AfterTouch problem. Use the three checks above to diagnose the actual cause.
 
+### ❌ On-device install fails with `curl: (60) ... certificate is not yet valid`
+
+**Symptoms:**
+
+- Running the on-device installer over SSH (`curl -sSL .../install.sh | sh`)
+  fails immediately, before anything is downloaded:
+
+  ```
+  curl: (60) SSL certificate problem: certificate is not yet valid
+  ```
+
+- The same error appears for *any* HTTPS fetch from the speaker (GitHub,
+  `raw.githubusercontent.com`, …).
+
+**Cause:**
+
+The speaker's clock is set in the past. SoundTouch speakers have no
+battery-backed clock and rely on NTP, which is no longer reliable after the Bose
+cloud shutdown, so the clock can fall back to a date years ago. TLS validation
+then rejects the (recently issued) server certificate as "not yet valid" — its
+validity period starts *after* the speaker's notion of "now". This is the same
+stuck-clock condition behind several TuneIn / TLS failures (see issue #345).
+
+**Fix:**
+
+Set the speaker's clock to roughly the current time over SSH, then re-run the
+installer:
+
+```bash
+# On the speaker, over SSH. Replace with the current UTC date/time —
+# it only needs to be close enough to fall inside the certificate's validity
+# window, not exact.
+date -u -s "2026-06-27 12:00:00"
+```
+
+Then re-run the on-device install one-liner. Once AfterTouch is installed and
+running, its **`speaker_clock` health check** (with a `set_clock` quick-fix)
+keeps the speaker's clock corrected, so this is a one-time hurdle to get the
+installer through.
+
 ### ❌ Speaker logs `Curl 7, http 0` and AfterTouch sees no HTTP requests
 
 **Symptoms:**


### PR DESCRIPTION
Adds a troubleshooting entry for the failure reported in #403: the on-device
installer dies with `curl: (60) ... certificate is not yet valid` before it can
download anything. Refs #403.

## Why

"Not yet valid" means the speaker's clock is set *before* the server
certificate's validity window, so TLS rejects an otherwise valid certificate.
SoundTouch speakers have no battery-backed clock and depend on NTP, which is no
longer reliable after the Bose cloud shutdown, so the clock can fall back to a
date years in the past; every HTTPS fetch from the speaker then fails the same
way (the same stuck-clock class as #345). The installer's own `curl | sh`
bootstrap can't self-heal because the failure happens while fetching the script.

The original report was never diagnosed in the thread (which moved on to a
separate CA-bundle discussion), so this documents the actual cause and fix.

## What

New "On-device install fails with `certificate is not yet valid`" entry under
Connection Issues in the troubleshooting guide: symptom, cause, and the fix (set
the speaker's clock over SSH with `date -u -s`, then re-run the installer), with
a note that the `speaker_clock` health check keeps it corrected afterward.

Docs only; markdown-link-check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)