### PR TITLE
docs(getting-help): note Discord exists as an on-request last-resort channel

### DIFF
--- a/docs/content/docs/_index.md
+++ b/docs/content/docs/_index.md
@@ -93,5 +93,6 @@ Older planning artefacts ("Enhanced State Management System", "Upstream Service 
 - **Questions & Discussion**: [GitHub Discussions](https://github.com/gesellix/Bose-SoundTouch/discussions)
 - **Documentation**: Check troubleshooting guides first
 - **Community**: Share experiences and help others
+- **Direct chat (last resort)**: There's a small Discord for the rare case where an email exchange or an issue/discussion thread needs real-time back-and-forth. It's not a primary support channel: please start with Issues or Discussions. If a conversation genuinely needs it, ask in your thread and I'll share an invite.
 
 For a complete list of all documents, browse the sections in the sidebar.


### PR DESCRIPTION
## What

Adds one bullet to the **Getting Help** list in `docs/content/docs/_index.md` acknowledging that a small Discord exists for direct, real-time conversation, framed as a last resort.

## Why

The maintainer now runs a Discord but doesn't want it to become a primary support channel. It's only for the rare case where an email exchange or a GitHub issue/discussion thread isn't enough.

## How it's framed

- **No public invite link** anywhere in the repo (it's public). Issues and Discussions remain the first stop; the invite is shared in-thread only when a conversation genuinely needs it.
- Single placement: the docs "Getting Help" list. README, CONTRIBUTING, and the issue-template config are intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)