### PR TITLE
fix(health): reword sources_xml_diff title to an expectation (refs #493)

### DIFF
--- a/pkg/service/health/checks_sources_diff.go
+++ b/pkg/service/health/checks_sources_diff.go
@@ -41,7 +41,7 @@ type speakerSourcesXML struct {
 func RegisterSourcesXMLDiff(r *Registry, ds *datastore.DataStore) {
 	r.Register(Check{
 		ID:    CheckIDSourcesXMLDiff,
-		Title: "Speaker /sources matches service Sources.xml",
+		Title: "Speaker /sources should match service Sources.xml",
 		Run: func() []Finding {
 			return runSourcesXMLDiff(ds)
 		},


### PR DESCRIPTION
## What

Rewords the `sources_xml_diff` health-check title from

> Speaker /sources matches service Sources.xml

to

> Speaker /sources should match service Sources.xml

## Why

Reported in #493: the title asserts "matches", but the row renders as a **warning** when the speaker and service source lists differ, so "matches" next to a warning reads as a contradiction ("are they not expected to match?"). Phrasing it as the expectation ("should match") reads correctly in both the OK and warning states. The per-finding messages and severities already convey whether the expectation holds and what the differences are.

One-line change; no tests or docs pinned the old string. `go build` + `go test ./pkg/service/health/` pass.

Refs #493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)