### PR TITLE
deps: bump Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.27rc2-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
 
 # Declare automatic platform ARGs to make them available in build stage
 # See https://docs.docker.com/reference/dockerfile#automatic-platform-args-in-the-global-scope

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -35,7 +35,7 @@ services:
       start_period: 3s
 
   spotify-mock:
-    image: golang:1.26.4-alpine
+    image: golang:1.26.5-alpine
     container_name: spotify-mock
     working_dir: /app
     volumes:
@@ -53,7 +53,7 @@ services:
       start_period: 3s
 
   amazon-mock:
-    image: golang:1.26.4-alpine
+    image: golang:1.26.5-alpine
     container_name: amazon-mock
     working_dir: /app
     volumes:
@@ -71,7 +71,7 @@ services:
       start_period: 3s
 
   tunein-mock:
-    image: golang:1.26.4-alpine
+    image: golang:1.26.5-alpine
     container_name: tunein-mock
     working_dir: /app
     volumes:

--- a/examples/navigation-station-demo/go.mod
+++ b/examples/navigation-station-demo/go.mod
@@ -1,8 +1,8 @@
 module navigation-station-demo
 
-go 1.26.4
+go 1.26.5
 
-require github.com/gesellix/bose-soundtouch v0.107.0
+require github.com/gesellix/bose-soundtouch v0.118.0
 
 require github.com/gorilla/websocket v1.5.3 // indirect
 

--- a/examples/preset-management/go.mod
+++ b/examples/preset-management/go.mod
@@ -1,8 +1,8 @@
 module preset-management-example
 
-go 1.26.4
+go 1.26.5
 
-require github.com/gesellix/bose-soundtouch v0.107.0
+require github.com/gesellix/bose-soundtouch v0.118.0
 
 require github.com/gorilla/websocket v1.5.3 // indirect
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gesellix/bose-soundtouch
 
-go 1.26.4
+go 1.26.5
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
## Summary

- Bump the Go toolchain from 1.26.4 to 1.26.5 in `go.mod` and both example modules (`examples/navigation-station-demo`, `examples/preset-management`).
- Bump the CI mock images (`spotify-mock`, `amazon-mock`, `tunein-mock`) in `docker-compose.ci.yml` from `golang:1.26.4-alpine` to `golang:1.26.5-alpine`.
- Switch the `Dockerfile` builder image from `golang:1.27rc2-alpine` (a release candidate) back to a stable release, `golang:1.26.5-alpine`, matching the toolchain.

The example `go.mod`s also pick up a bundled `bose-soundtouch` dependency bump (v0.107.0 → v0.118.0).

CI workflows read `go-version-file: go.mod`, so they inherit 1.26.5 automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)