### PR TITLE
fix(admin): soften missing-account.json placeholder notice

### DIFF
--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -901,7 +901,7 @@ async function fetchAccountDetails(accountId) {
         if (metadataEl) {
             const warningNotice = data.account.is_placeholder ?
                 `<div style="background: #fff3cd; color: #856404; padding: 10px; border: 1px solid #ffeeba; border-radius: 4px; margin-bottom: 10px; font-size: 0.85em;">
-                    <strong>Notice:</strong> Account data (account.json) was not found in the expected location for this account ID.
+                    <strong>Notice:</strong> This account hasn't saved any custom settings yet (language, provider preferences). Defaults are in effect — they'll be saved once you change something below.
                 </div>` : "";
 
             metadataEl.innerHTML = `


### PR DESCRIPTION
## Summary
- The "6. Local Account" tab shows a placeholder-account notice worded like a file-corruption error ("...was not found in the expected location for this account ID"), which alarmed the reporter in #360.
- Confirmed the placeholder state (`IsPlaceholder` in `GetAccountInfo`, `pkg/service/datastore/datastore.go`) is expected and harmless: every consumer already handles it safely, and it self-heals the first time language or provider settings are saved for the account.
- Reworded the notice to explain the actual (benign) state instead of implying something's broken, and dropped the internal `account.json` filename from user-facing text.

Fixes #360

## Test plan
- [ ] Open the AfterTouch admin UI, select an account that has never saved language/provider settings, confirm the "6. Local Account" tab shows the new wording
- [ ] Change the language dropdown for that account, confirm the notice disappears and doesn't reappear on reload