### PR TITLE
feat(announcements): support a proper link in announcement banners

### DIFF
--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -2728,6 +2728,7 @@ func (ds *DataStore) SaveSettings(settings Settings) error {
 type UpdateCheckState struct {
 	LastCheckedAt   string `json:"last_checked_at,omitempty"`
 	LastSeenVersion string `json:"last_seen_version,omitempty"`
+	LastReleaseURL  string `json:"last_release_url,omitempty"`
 }
 
 // GetUpdateCheckState retrieves the persisted update-check state. Same

--- a/pkg/service/datastore/datastore_test.go
+++ b/pkg/service/datastore/datastore_test.go
@@ -493,6 +493,7 @@ func TestUpdateCheckState_Persistence(t *testing.T) {
 	state := UpdateCheckState{
 		LastCheckedAt:   "2026-08-09T12:00:00Z",
 		LastSeenVersion: "v0.122.0",
+		LastReleaseURL:  "https://github.com/gesellix/Bose-SoundTouch/releases/tag/v0.122.0",
 	}
 
 	if err := ds.SaveUpdateCheckState(state); err != nil {

--- a/pkg/service/handlers/handlers_announcements.go
+++ b/pkg/service/handlers/handlers_announcements.go
@@ -39,6 +39,16 @@ type Announcement struct {
 	Targets        []string
 	ShowWhile      func(*Server) bool
 	DismissKeyFunc func(*Server) string
+	// LinkText/LinkURL add an optional link alongside Message — e.g. a
+	// release's notes, or a docs page for a future announcement. LinkURLFunc
+	// is the dynamic counterpart of LinkURL (nil = use the static field),
+	// for links whose target depends on live state (e.g. which version was
+	// detected). LinkText has no *Func counterpart: nothing here needs
+	// dynamic link *text*, only a dynamic *URL* — add one only once
+	// something actually needs it, per this project's KISS convention.
+	LinkText    string
+	LinkURL     string
+	LinkURLFunc func(*Server) string
 }
 
 // message returns the effective text: MessageFunc(s) if set, else the
@@ -49,6 +59,16 @@ func (a Announcement) message(s *Server) string {
 	}
 
 	return a.Message
+}
+
+// linkURL returns the effective link URL: LinkURLFunc(s) if set, else the
+// static LinkURL (which may be "" — no link).
+func (a Announcement) linkURL(s *Server) string {
+	if a.LinkURLFunc != nil {
+		return a.LinkURLFunc(s)
+	}
+
+	return a.LinkURL
 }
 
 // dismissKey returns the effective dismissal/DTO id: DismissKeyFunc(s) if
@@ -74,7 +94,9 @@ var announcements = []Announcement{
 		Targets: []string{announcementTargetAdmin},
 		Message: "A future release will require login for this entire admin area by default (today, only " +
 			"Spotify/Amazon linking and the Local Account tab do). You can opt in now in Settings, or " +
-			"dismiss this once you've decided. See issue #419 for details.",
+			"dismiss this once you've decided.",
+		LinkText: "Issue #419",
+		LinkURL:  "https://github.com/gesellix/Bose-SoundTouch/issues/419",
 		ShowWhile: func(s *Server) bool {
 			return s.AdminAreaAuthMode() == ""
 		},
@@ -89,8 +111,11 @@ var announcements = []Announcement{
 		MessageFunc: func(s *Server) string {
 			r := s.UpdateCheckResult()
 
-			return fmt.Sprintf("AfterTouch %s is available (you're on %s). %s",
-				r.LatestVersion, r.CurrentVersion, r.ReleaseURL)
+			return fmt.Sprintf("AfterTouch %s is available (you're on %s).", r.LatestVersion, r.CurrentVersion)
+		},
+		LinkText: "Release notes",
+		LinkURLFunc: func(s *Server) string {
+			return s.UpdateCheckResult().ReleaseURL
 		},
 		// Per-version, not per-family: dismissing the notice for one version
 		// must not silently suppress a later, different version's notice.
@@ -104,9 +129,11 @@ var announcements = []Announcement{
 // deliberately smaller than Announcement (no ShowWhile func, no Targets;
 // the caller already asked for a specific target).
 type announcementDTO struct {
-	ID      string `json:"id"`
-	Message string `json:"message"`
-	Level   string `json:"level"`
+	ID       string `json:"id"`
+	Message  string `json:"message"`
+	Level    string `json:"level"`
+	LinkText string `json:"link_text,omitempty"`
+	LinkURL  string `json:"link_url,omitempty"`
 }
 
 func containsString(haystack []string, needle string) bool {
@@ -138,7 +165,9 @@ func (s *Server) HandleListAnnouncements(w http.ResponseWriter, r *http.Request)
 
 	active := make([]announcementDTO, 0, len(announcements))
 
-	for _, a := range announcements {
+	for i := range announcements {
+		a := &announcements[i]
+
 		if !containsString(a.Targets, target) {
 			continue
 		}
@@ -152,7 +181,13 @@ func (s *Server) HandleListAnnouncements(w http.ResponseWriter, r *http.Request)
 			continue
 		}
 
-		active = append(active, announcementDTO{ID: key, Message: a.message(s), Level: a.Level})
+		active = append(active, announcementDTO{
+			ID:       key,
+			Message:  a.message(s),
+			Level:    a.Level,
+			LinkText: a.LinkText,
+			LinkURL:  a.linkURL(s),
+		})
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -174,8 +209,8 @@ func (s *Server) HandleDismissAnnouncement(w http.ResponseWriter, r *http.Reques
 
 	found := false
 
-	for _, a := range announcements {
-		if a.dismissKey(s) == id {
+	for i := range announcements {
+		if announcements[i].dismissKey(s) == id {
 			found = true
 			break
 		}

--- a/pkg/service/handlers/handlers_announcements_test.go
+++ b/pkg/service/handlers/handlers_announcements_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
@@ -178,6 +179,7 @@ func newServerWithUpdateAvailable(t *testing.T, currentVersion, latestVersion st
 	if err := ds.SaveUpdateCheckState(datastore.UpdateCheckState{
 		LastCheckedAt:   "2026-08-09T00:00:00Z",
 		LastSeenVersion: latestVersion,
+		LastReleaseURL:  "https://example.invalid/releases/" + latestVersion,
 	}); err != nil {
 		t.Fatalf("Failed to seed update-check state: %v", err)
 	}
@@ -209,6 +211,18 @@ func TestHandleListAnnouncements_UpdateAvailable(t *testing.T) {
 			}
 			if found.Message == "" {
 				t.Errorf("target=%s: expected a non-empty dynamic message", target)
+			}
+			// The release URL belongs in the structured link field, not
+			// embedded as text in the message — the message must stay
+			// generic across other future announcements too.
+			if strings.Contains(found.Message, "http") {
+				t.Errorf("target=%s: expected the URL out of Message, got %q", target, found.Message)
+			}
+			if found.LinkURL == "" {
+				t.Errorf("target=%s: expected a non-empty LinkURL", target)
+			}
+			if found.LinkText == "" {
+				t.Errorf("target=%s: expected a non-empty LinkText", target)
 			}
 		}
 	})

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -851,7 +851,7 @@ async function fetchAnnouncements() {
 
         container.innerHTML = announcements.map(a => `
             <div class="announcement-banner announcement-${a.level || "info"}" data-announcement-id="${a.id}" style="display:flex; align-items:flex-start; justify-content:space-between; gap:12px; padding:10px 14px; margin-bottom:10px; border-radius:4px; background:#e7f3ff; border:1px solid #b6d9f7; color:#1a4a6e; font-size:0.9em;">
-                <span>${a.message}</span>
+                <span>${escapeHtml(a.message)}${a.link_url ? ` <a href="${escapeHtml(a.link_url)}" target="_blank" rel="noopener" style="color:inherit; text-decoration:underline;">${escapeHtml(a.link_text || a.link_url)}</a>` : ""}</span>
                 <button onclick="dismissAnnouncement('${a.id}')" title="Dismiss" style="background:none; border:none; cursor:pointer; font-size:1.1em; line-height:1; color:inherit; flex-shrink:0;">&times;</button>
             </div>
         `).join("");

--- a/pkg/service/soundtouchweb/static/js/components/Announcements.js
+++ b/pkg/service/soundtouchweb/static/js/components/Announcements.js
@@ -35,7 +35,10 @@ export function Announcements() {
         <div class="announcements-banner">
             ${announcements.map(a => html`
                 <div class="announcement announcement-${a.level || 'info'}" key=${a.id}>
-                    <span>${a.message}</span>
+                    <span>
+                        ${a.message}
+                        ${a.link_url ? html` <a href=${a.link_url} target="_blank" rel="noopener">${a.link_text || a.link_url}</a>` : null}
+                    </span>
                     <button class="announcement-dismiss" onClick=${() => dismiss(a.id)} title="Dismiss">&times;</button>
                 </div>
             `)}

--- a/pkg/service/updatecheck/updatecheck.go
+++ b/pkg/service/updatecheck/updatecheck.go
@@ -72,6 +72,7 @@ func NewChecker(ds *datastore.DataStore, repo, currentVersion string) *Checker {
 	}
 
 	c.last.LatestVersion = state.LastSeenVersion
+	c.last.ReleaseURL = state.LastReleaseURL
 
 	if ts, parseErr := time.Parse(time.RFC3339, state.LastCheckedAt); parseErr == nil {
 		c.last.CheckedAt = ts
@@ -168,6 +169,7 @@ func (c *Checker) persist(result Result) {
 	_ = c.ds.SaveUpdateCheckState(datastore.UpdateCheckState{
 		LastCheckedAt:   result.CheckedAt.UTC().Format(time.RFC3339),
 		LastSeenVersion: result.LatestVersion,
+		LastReleaseURL:  result.ReleaseURL,
 	})
 }
 

--- a/pkg/service/updatecheck/updatecheck_test.go
+++ b/pkg/service/updatecheck/updatecheck_test.go
@@ -96,6 +96,9 @@ func TestCheckNow_NewerVersionAvailable(t *testing.T) {
 	if persisted.LastSeenVersion != "v1.1.0" {
 		t.Errorf("Expected persisted LastSeenVersion v1.1.0, got %q", persisted.LastSeenVersion)
 	}
+	if persisted.LastReleaseURL != "https://example.invalid/v1.1.0" {
+		t.Errorf("Expected persisted LastReleaseURL to be set, got %q", persisted.LastReleaseURL)
+	}
 }
 
 func TestCheckNow_CurrentVersionIsUpToDate(t *testing.T) {
@@ -257,6 +260,7 @@ func TestNewChecker_SeedsFromPersistedState(t *testing.T) {
 	if err := ds.SaveUpdateCheckState(datastore.UpdateCheckState{
 		LastCheckedAt:   checkedAt.Format(time.RFC3339),
 		LastSeenVersion: "v1.1.0",
+		LastReleaseURL:  "https://example.invalid/v1.1.0",
 	}); err != nil {
 		t.Fatalf("Failed to seed state: %v", err)
 	}
@@ -269,6 +273,11 @@ func TestNewChecker_SeedsFromPersistedState(t *testing.T) {
 	}
 	if result.LatestVersion != "v1.1.0" {
 		t.Errorf("Expected seeded LatestVersion v1.1.0, got %q", result.LatestVersion)
+	}
+	// Regression check: the announcement's link needs this populated
+	// immediately after a restart, not just after the next live check.
+	if result.ReleaseURL != "https://example.invalid/v1.1.0" {
+		t.Errorf("Expected seeded ReleaseURL to be set, got %q", result.ReleaseURL)
 	}
 	if !result.CheckedAt.Equal(checkedAt) {
 		t.Errorf("Expected seeded CheckedAt %v, got %v", checkedAt, result.CheckedAt)


### PR DESCRIPTION
## Summary

Follow-up to #591, prompted by the update-check notice rendering a raw `https://...` URL as plain text instead of a clickable link. Made it general rather than a one-off fix, since future announcements (e.g. linking to docs) may want the same thing.

- Added `Announcement.LinkText`/`LinkURL` (+ `LinkURLFunc`, the dynamic counterpart for the update-check entry's per-release URL) alongside the existing `Message`/`MessageFunc` pair.
- Both frontends now render it as a real `<a>` element:
  - Admin UI (`script.js`, `innerHTML`-based): escapes `Message`/`LinkText`/`LinkURL` via the existing `escapeHtml()` before composing the markup. Previously `Message` went into `innerHTML` unescaped — this incidentally hardens that, though the content was always developer-controlled, never user input.
  - Player (`Announcements.js`, Preact/htm): templates an actual `<a>` element rather than interpolating a string, since Preact escapes string children by default — a raw `<a href=...>` string would otherwise render as literal text, not a link.
- Rephrased the #419 admin-gate announcement to use the new field too (was a plain "See issue #419 for details." text mention).

**Bug found while wiring this up:** `UpdateCheckState` never persisted the release URL, only the version — so after a restart, the announcement would show a correct message but a broken/empty link until the next live check completed (which can be up to a full interval away, since a fresh check is skipped when the persisted last-check is still recent). Fixed by adding `UpdateCheckState.LastReleaseURL` and threading it through `Checker.persist`/`NewChecker`'s seeding path, with a test (`TestNewChecker_SeedsFromPersistedState`) that would have caught it.

Also fixed two `gocritic` `rangeValCopy` findings in `handlers_announcements.go` (switched to index-based iteration), surfaced by the `Announcement` struct growing with the new fields.

Refs #591

## Test plan

- [x] Unit tests: link fields present/absent in the DTO, dynamic `LinkURLFunc` resolution, the release-URL persistence roundtrip and restart-seeding regression test
- [x] `make lint` clean
- [x] Manually verified against a running instance: `/api/announcements?target=admin` returns `link_text`/`link_url` for the admin-gate notice