### PR TITLE
fix(player): render literal x instead of HTML entity for dismiss button

### DIFF
--- a/pkg/service/soundtouchweb/static/js/components/Announcements.js
+++ b/pkg/service/soundtouchweb/static/js/components/Announcements.js
@@ -39,7 +39,7 @@ export function Announcements() {
                         ${a.message}
                         ${a.link_url ? html` <a href=${a.link_url} target="_blank" rel="noopener">${a.link_text || a.link_url}</a>` : null}
                     </span>
-                    <button class="announcement-dismiss" onClick=${() => dismiss(a.id)} title="Dismiss">&times;</button>
+                    <button class="announcement-dismiss" onClick=${() => dismiss(a.id)} title="Dismiss">×</button>
                 </div>
             `)}
         </div>


### PR DESCRIPTION
## Summary
- The player UI's announcement dismiss button showed the literal text `&times;` instead of `×`, as reported in https://github.com/gesellix/Bose-SoundTouch/issues/591#issuecomment-5239773351
- htm/Preact template literals insert text as a DOM text node rather than parsing it as HTML, so the entity was never decoded there
- The admin UI's equivalent button is unaffected because it's built as an HTML string inserted via `innerHTML`, where the browser does decode entities
- Fix: use the literal `×` character instead of the `&times;` entity in `Announcements.js`

## Test plan
- [ ] Load the player UI with an active announcement and confirm the dismiss button shows `×` instead of `&times;`

Relates to #591