### PR TITLE
docs(cli): document the update-check command in CLI-REFERENCE.md

### DIFF
--- a/docs/content/docs/guides/CLI-REFERENCE.md
+++ b/docs/content/docs/guides/CLI-REFERENCE.md
@@ -1157,6 +1157,32 @@ soundtouch-cli --host 192.0.2.10 events subscribe --filter zone --no-reconnect
 - Events are displayed in real-time with emoji indicators
 - Verbose mode shows additional technical details
 
+### Update Check
+
+#### `update-check`
+
+Check GitHub Releases for a newer `soundtouch-cli` version. Unlike
+`soundtouch-service`'s periodic background check, this doesn't need a
+`--host` or any device on the network: it's a single, on-demand GitHub API
+request. Running the command is itself the opt-in, so there's no config
+flag or persisted state.
+
+**Usage:**
+```bash
+soundtouch-cli update-check
+```
+
+**Example output:**
+```
+A newer version is available: v1.3.0 (you're on v1.2.0)
+https://github.com/gesellix/Bose-SoundTouch/releases/tag/v1.3.0
+```
+
+**Notes:**
+- `soundtouch-backup` has the same `update-check` command.
+- If the running binary isn't a released version (e.g. a dev build),
+  the command reports that and skips the comparison.
+
 ## Common Usage Patterns
 
 ### Quick Device Setup


### PR DESCRIPTION
## Summary
- #591 added `soundtouch-cli update-check` / `soundtouch-backup update-check` (PR #611), but `docs/content/docs/guides/CLI-REFERENCE.md` (the CLI command reference) never got the matching entry.
- Adds an "Update Check" section documenting the command, usage, example output, and a note that `soundtouch-backup` has the same command.

## Test plan
- [x] Docs-only change, no code touched
- [x] Manually reviewed rendered markdown for formatting