### PR TITLE
fix(health): preset-count guidance + restore/nudge QuickFixes for #614

### DIFF
--- a/pkg/service/health/checks_presets_count.go
+++ b/pkg/service/health/checks_presets_count.go
@@ -50,6 +50,17 @@ func RegisterPresetsCountCheck(r *Registry, ds *datastore.DataStore) {
 	r.RegisterFix(CheckIDPresetsCount, FixIDRestorePresetsToSpeaker, func(target Target) (string, error) {
 		return restorePresetsToSpeaker(ds, target)
 	})
+
+	// Same underlying nudge as the refresh_sources check (FixIDPostSourcesUpdated,
+	// checks_refresh_sources.go): POSTs sourcesUpdated so the speaker re-fetches
+	// /full. Confirmed that /full carries presets alongside sources
+	// (marge.AccountFullToXML); NOT confirmed that firmware re-applies the
+	// presets section locally (see issue253_regression_test.go — that exact
+	// link is documented as untested). Offered as a cheap, non-destructive
+	// thing to try before the guaranteed-but-heavier restore-to-speaker push.
+	r.RegisterFix(CheckIDPresetsCount, FixIDPostSourcesUpdated, func(target Target) (string, error) {
+		return postSourcesUpdated(ds, target)
+	})
 }
 
 func runPresetsCountCheck(ds *datastore.DataStore) []Finding {
@@ -149,11 +160,18 @@ func comparePresetsForDeviceWithURL(ds *datastore.DataStore, account, deviceID, 
 		// (reboot and/or Sync leaving the speaker's own preset
 		// slots empty while the service's Presets.xml is untouched).
 		severity = SeverityWarning
-		quickFixes = []QuickFix{{
-			ID:      FixIDRestorePresetsToSpeaker,
-			Label:   "Restore presets to speaker",
-			Confirm: "This pushes AfterTouch's stored presets onto the speaker's own preset slots, one at a time. Doesn't require a reboot.",
-		}}
+		quickFixes = []QuickFix{
+			{
+				ID:      FixIDPostSourcesUpdated,
+				Label:   "Try a sourcesUpdated nudge first",
+				Confirm: "Asks the speaker to re-fetch /full (the same nudge used to refresh sources). /full does include presets, but whether the speaker applies them back to its own preset table isn't confirmed — this is free and non-destructive, worth trying before the push below.",
+			},
+			{
+				ID:      FixIDRestorePresetsToSpeaker,
+				Label:   "Restore presets to speaker",
+				Confirm: "This pushes AfterTouch's stored presets onto the speaker's own preset slots, one at a time. Doesn't require a reboot.",
+			},
+		}
 	}
 
 	return []Finding{{

--- a/pkg/service/health/checks_presets_count.go
+++ b/pkg/service/health/checks_presets_count.go
@@ -129,8 +129,9 @@ func comparePresetsForDeviceWithURL(ds *datastore.DataStore, account, deviceID, 
 	severity := SeverityInfo
 	if speakerCount == 0 && serviceCount > 0 {
 		// Speaker shows nothing while the service has presets —
-		// this is the post-reset preset-loss class from
-		// discussion #295 and #235.
+		// the post-reset preset-loss pattern confirmed in #614
+		// (reboot and/or Sync leaving the speaker's own preset
+		// slots empty while the service's Presets.xml is untouched).
 		severity = SeverityWarning
 	}
 
@@ -141,7 +142,7 @@ func comparePresetsForDeviceWithURL(ds *datastore.DataStore, account, deviceID, 
 			"Speaker shows %d preset slot(s); service Presets.xml has %d.",
 			speakerCount, serviceCount,
 		),
-		Details: "If the speaker shows fewer than the service, a power-cycle or a sourcesUpdated notification usually re-syncs. If it shows more, the service may have stale entries or the speaker is still holding pre-migration state.",
+		Details: "If the speaker shows fewer than the service, a sourcesUpdated notification sometimes re-syncs it. Don't power-cycle as a fix for this — it has itself been reported to wipe the speaker's presets (#614), so it may make things worse. If the speaker shows more than the service, the service may have stale entries or the speaker is still holding pre-migration state.",
 	}}
 }
 

--- a/pkg/service/health/checks_presets_count.go
+++ b/pkg/service/health/checks_presets_count.go
@@ -4,14 +4,23 @@ import (
 	"context"
 	"encoding/xml"
 	"fmt"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/gesellix/bose-soundtouch/pkg/client"
+	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
 )
 
 // CheckIDPresetsCount is the registry id of the speaker-vs-service
 // preset count check.
 const CheckIDPresetsCount = "speaker_presets_count"
+
+// FixIDRestorePresetsToSpeaker is the quick-fix that replays the
+// service's stored presets onto the speaker via its :8090/storePreset
+// endpoint, without requiring a reboot or re-entering them by hand.
+const FixIDRestorePresetsToSpeaker = "restore_presets_to_speaker"
 
 // speakerPresetsXML mirrors just enough of the speaker's :8090/presets
 // XML to count slots. The schema is the same as on the service side
@@ -36,6 +45,10 @@ func RegisterPresetsCountCheck(r *Registry, ds *datastore.DataStore) {
 		Run: func() []Finding {
 			return runPresetsCountCheck(ds)
 		},
+	})
+
+	r.RegisterFix(CheckIDPresetsCount, FixIDRestorePresetsToSpeaker, func(target Target) (string, error) {
+		return restorePresetsToSpeaker(ds, target)
 	})
 }
 
@@ -127,12 +140,20 @@ func comparePresetsForDeviceWithURL(ds *datastore.DataStore, account, deviceID, 
 	}
 
 	severity := SeverityInfo
+
+	var quickFixes []QuickFix
+
 	if speakerCount == 0 && serviceCount > 0 {
 		// Speaker shows nothing while the service has presets —
 		// the post-reset preset-loss pattern confirmed in #614
 		// (reboot and/or Sync leaving the speaker's own preset
 		// slots empty while the service's Presets.xml is untouched).
 		severity = SeverityWarning
+		quickFixes = []QuickFix{{
+			ID:      FixIDRestorePresetsToSpeaker,
+			Label:   "Restore presets to speaker",
+			Confirm: "This pushes AfterTouch's stored presets onto the speaker's own preset slots, one at a time. Doesn't require a reboot.",
+		}}
 	}
 
 	return []Finding{{
@@ -142,8 +163,84 @@ func comparePresetsForDeviceWithURL(ds *datastore.DataStore, account, deviceID, 
 			"Speaker shows %d preset slot(s); service Presets.xml has %d.",
 			speakerCount, serviceCount,
 		),
-		Details: "If the speaker shows fewer than the service, a sourcesUpdated notification sometimes re-syncs it. Don't power-cycle as a fix for this — it has itself been reported to wipe the speaker's presets (#614), so it may make things worse. If the speaker shows more than the service, the service may have stale entries or the speaker is still holding pre-migration state.",
+		Details:    "If the speaker shows fewer than the service, a sourcesUpdated notification sometimes re-syncs it. Don't power-cycle as a fix for this — it has itself been reported to wipe the speaker's presets (#614), so it may make things worse. If the speaker shows more than the service, the service may have stale entries or the speaker is still holding pre-migration state.",
+		QuickFixes: quickFixes,
 	}}
+}
+
+// restorePresetsToSpeaker replays every preset in the service's
+// Presets.xml onto the live speaker via :8090/storePreset, one slot
+// at a time. Unlike Sync (which only ever reads from the speaker),
+// this is the one direction that can put presets back after they've
+// been wiped, without needing to re-enter them by hand — see #614.
+func restorePresetsToSpeaker(ds *datastore.DataStore, target Target) (string, error) {
+	if target.Account == "" || target.Device == "" {
+		return "", fmt.Errorf("account and device are required")
+	}
+
+	dev, err := ds.GetDeviceInfo(target.Account, target.Device)
+	if err != nil || dev == nil {
+		return "", fmt.Errorf("device %s not found in datastore", target.Device)
+	}
+
+	if dev.IPAddress == "" {
+		return "", fmt.Errorf("device %s has no IP address recorded", target.Device)
+	}
+
+	presets, err := ds.GetPresets(target.Account, target.Device)
+	if err != nil {
+		return "", fmt.Errorf("read service Presets.xml: %w", err)
+	}
+
+	if len(presets) == 0 {
+		return "", fmt.Errorf("service has no presets recorded for %s", target.Device)
+	}
+
+	c := client.NewClientFromHost(dev.IPAddress)
+
+	restored := 0
+
+	var failures []string
+
+	for i := range presets {
+		p := &presets[i]
+
+		slot, atoiErr := strconv.Atoi(p.ID)
+		if atoiErr != nil || slot < 1 || slot > 6 {
+			failures = append(failures, fmt.Sprintf("slot %q: invalid preset id", p.ID))
+			continue
+		}
+
+		isPresetable, _ := strconv.ParseBool(p.IsPresetable)
+
+		ci := &models.ContentItem{
+			Source:        p.Source,
+			Type:          p.Type,
+			Location:      p.Location,
+			SourceAccount: p.SourceAccount,
+			IsPresetable:  isPresetable,
+			ItemName:      p.Name,
+			ContainerArt:  p.ContainerArt,
+		}
+
+		if storeErr := c.StorePreset(slot, ci); storeErr != nil {
+			failures = append(failures, fmt.Sprintf("slot %d: %v", slot, storeErr))
+			continue
+		}
+
+		restored++
+	}
+
+	if restored == 0 {
+		return "", fmt.Errorf("failed to restore any presets: %s", strings.Join(failures, "; "))
+	}
+
+	msg := fmt.Sprintf("Restored %d/%d preset(s) to %s.", restored, len(presets), displayName(dev.Name, target.Device))
+	if len(failures) > 0 {
+		msg += " Some slots failed: " + strings.Join(failures, "; ")
+	}
+
+	return msg, nil
 }
 
 // countNonEmpty returns the number of <preset> entries with a

--- a/pkg/service/health/checks_presets_count_test.go
+++ b/pkg/service/health/checks_presets_count_test.go
@@ -188,8 +188,17 @@ func TestPresetsCount_SpeakerEmptyOffersRestoreQuickFix(t *testing.T) {
 		t.Fatalf("expected one finding, got %+v", got)
 	}
 
-	if len(got[0].QuickFixes) != 1 || got[0].QuickFixes[0].ID != FixIDRestorePresetsToSpeaker {
-		t.Errorf("expected the restore-presets QuickFix, got %+v", got[0].QuickFixes)
+	// Offers both the cheap, unconfirmed pull-style nudge (sourcesUpdated,
+	// which makes the speaker re-fetch /full — /full does carry presets,
+	// but firmware re-applying them locally is unconfirmed) and the
+	// guaranteed push (restore_presets_to_speaker) — see #614 discussion.
+	fixIDs := map[string]bool{}
+	for _, qf := range got[0].QuickFixes {
+		fixIDs[qf.ID] = true
+	}
+
+	if len(got[0].QuickFixes) != 2 || !fixIDs[FixIDRestorePresetsToSpeaker] || !fixIDs[FixIDPostSourcesUpdated] {
+		t.Errorf("expected both the sourcesUpdated nudge and the restore-presets QuickFix, got %+v", got[0].QuickFixes)
 	}
 }
 

--- a/pkg/service/health/checks_presets_count_test.go
+++ b/pkg/service/health/checks_presets_count_test.go
@@ -1,6 +1,7 @@
 package health
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -171,6 +172,112 @@ func TestPresetsCount_UnreachableSpeaker(t *testing.T) {
 
 	if len(got[0].ManualCommands) != 1 {
 		t.Errorf("expected manual command on unreachable case, got %+v", got[0].ManualCommands)
+	}
+}
+
+func TestPresetsCount_SpeakerEmptyOffersRestoreQuickFix(t *testing.T) {
+	account, device := "1000001", "DEVICEID01"
+
+	ds := newPresetsCountDS(t, account, device)
+	writeServicePresets(t, ds, account, device, 3)
+
+	probeURL := stubSpeakerPresetsServer(t, 0)
+
+	got := comparePresetsForDeviceWithURL(ds, account, device, probeURL)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+
+	if len(got[0].QuickFixes) != 1 || got[0].QuickFixes[0].ID != FixIDRestorePresetsToSpeaker {
+		t.Errorf("expected the restore-presets QuickFix, got %+v", got[0].QuickFixes)
+	}
+}
+
+func TestPresetsCount_SpeakerHasMoreOffersNoQuickFix(t *testing.T) {
+	account, device := "1000001", "DEVICEID01"
+
+	ds := newPresetsCountDS(t, account, device)
+	writeServicePresets(t, ds, account, device, 1)
+
+	probeURL := stubSpeakerPresetsServer(t, 3)
+
+	got := comparePresetsForDeviceWithURL(ds, account, device, probeURL)
+	if len(got) != 1 {
+		t.Fatalf("expected one finding, got %+v", got)
+	}
+
+	if len(got[0].QuickFixes) != 0 {
+		t.Errorf("expected no QuickFix when speaker has more than the service, got %+v", got[0].QuickFixes)
+	}
+}
+
+func TestRestorePresetsToSpeaker_PushesEachSlot(t *testing.T) {
+	account, device := "1000001", "DEVICEID01"
+
+	ds := newPresetsCountDS(t, account, device)
+	writeServicePresets(t, ds, account, device, 3)
+
+	var storedSlots []string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/storePreset" {
+			http.NotFound(w, r)
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		storedSlots = append(storedSlots, string(body))
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, _ := url.Parse(srv.URL)
+	if err := ds.SaveDeviceInfo(account, device, &models.ServiceDeviceInfo{
+		DeviceID:  device,
+		AccountID: account,
+		IPAddress: u.Host,
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	msg, err := restorePresetsToSpeaker(ds, Target{Account: account, Device: device})
+	if err != nil {
+		t.Fatalf("restorePresetsToSpeaker: %v", err)
+	}
+
+	if !strings.Contains(msg, "3/3") {
+		t.Errorf("expected message to report 3/3 restored, got %q", msg)
+	}
+
+	if len(storedSlots) != 3 {
+		t.Fatalf("expected 3 /storePreset calls, got %d", len(storedSlots))
+	}
+
+	for i, body := range storedSlots {
+		if !strings.Contains(body, `id="`+itoa(i+1)+`"`) {
+			t.Errorf("call %d: expected preset id %d in body, got %q", i, i+1, body)
+		}
+
+		if !strings.Contains(body, `source="TUNEIN"`) {
+			t.Errorf("call %d: expected source TUNEIN in body, got %q", i, body)
+		}
+	}
+}
+
+func TestRestorePresetsToSpeaker_NoServicePresets(t *testing.T) {
+	account, device := "1000001", "DEVICEID01"
+	ds := newPresetsCountDS(t, account, device)
+
+	if err := ds.SaveDeviceInfo(account, device, &models.ServiceDeviceInfo{
+		DeviceID:  device,
+		AccountID: account,
+		IPAddress: "127.0.0.1:1",
+	}); err != nil {
+		t.Fatalf("SaveDeviceInfo: %v", err)
+	}
+
+	if _, err := restorePresetsToSpeaker(ds, Target{Account: account, Device: device}); err == nil {
+		t.Error("expected an error when the service has no presets to restore")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Corrects the `speaker_presets_count` health check's guidance text, which told users a power-cycle "usually re-syncs" missing presets — #614 shows a power-cycle is itself one of the reported triggers for the speaker wiping its own presets. Also fixes the check's comment, which cited discussion #295 and #235 as prior instances of this pattern; neither actually discusses preset loss (verified against both), so that citation was wrong from the original commit.
- Adds a **"Restore presets to speaker"** QuickFix on the same warning: replays the service's `Presets.xml` onto the live speaker via its local `:8090/storePreset` endpoint (`client.StorePreset`), one slot at a time. No reboot needed, and no manual re-entry required — this is the missing write direction, since Sync only ever reads from the speaker.
- Adds a second, cheaper **"Try a sourcesUpdated nudge first"** QuickFix on the same warning: reuses the existing `postSourcesUpdated` fix to ask the speaker to re-fetch `/full`. Confirmed that `/full` does carry presets alongside sources (`marge.AccountFullToXML`, plus a genuine captured Bose-cloud `/full` response with live presets); NOT confirmed whether firmware actually re-applies that preset section back onto its own local table (the existing `issue253_regression_test.go` already flags that exact link as untested). Offered as a free, non-destructive thing to try before the guaranteed-but-heavier push.

No frontend changes needed — the admin UI's QuickFix dispatch is fully generic on checkId/fixId.

Refs #614. Not claiming #614 resolved — root cause (why the speaker wipes its presets on reboot/Sync) is still unconfirmed; see the reply drafted at `_/i614/reply-draft.md` (not committed, local-only) for what's still being asked of the reporter.

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/service/health/...`
- [x] `golangci-lint run ./pkg/service/health/...`
- [x] `go vet ./...`
- [ ] Real-hardware confirmation from the #614 reporter once released