### PR TITLE
chore: bump Go to 1.26.6, refresh example go.mod pins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM --platform=$BUILDPLATFORM golang:1.26.5-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
 
 # Declare automatic platform ARGs to make them available in build stage
 # See https://docs.docker.com/reference/dockerfile#automatic-platform-args-in-the-global-scope

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -35,7 +35,7 @@ services:
       start_period: 3s
 
   spotify-mock:
-    image: golang:1.26.5-alpine
+    image: golang:1.26.6-alpine
     container_name: spotify-mock
     working_dir: /app
     volumes:
@@ -53,7 +53,7 @@ services:
       start_period: 3s
 
   amazon-mock:
-    image: golang:1.26.5-alpine
+    image: golang:1.26.6-alpine
     container_name: amazon-mock
     working_dir: /app
     volumes:
@@ -71,7 +71,7 @@ services:
       start_period: 3s
 
   tunein-mock:
-    image: golang:1.26.5-alpine
+    image: golang:1.26.6-alpine
     container_name: tunein-mock
     working_dir: /app
     volumes:

--- a/examples/navigation-station-demo/go.mod
+++ b/examples/navigation-station-demo/go.mod
@@ -1,8 +1,8 @@
 module navigation-station-demo
 
-go 1.26.5
+go 1.26.6
 
-require github.com/gesellix/bose-soundtouch v0.118.0
+require github.com/gesellix/bose-soundtouch v0.123.0
 
 require github.com/gorilla/websocket v1.5.3 // indirect
 

--- a/examples/preset-management/go.mod
+++ b/examples/preset-management/go.mod
@@ -1,8 +1,8 @@
 module preset-management-example
 
-go 1.26.5
+go 1.26.6
 
-require github.com/gesellix/bose-soundtouch v0.118.0
+require github.com/gesellix/bose-soundtouch v0.123.0
 
 require github.com/gorilla/websocket v1.5.3 // indirect
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gesellix/bose-soundtouch
 
-go 1.26.5
+go 1.26.6
 
 require (
 	filippo.io/age v1.3.1


### PR DESCRIPTION
## Summary
- Bumps the `go` directive to 1.26.6 across the main module and both standalone example modules (`examples/preset-management`, `examples/navigation-station-demo`), plus the builder image in `Dockerfile` and the three mock-service images (`spotify-mock`, `amazon-mock`, `tunein-mock`) in `docker-compose.ci.yml`.
- Refreshes the examples' `require github.com/gesellix/bose-soundtouch` pin from the stale `v0.118.0` to the current `v0.123.0` release tag. The `replace` directive means they build against local source regardless, but the pin should still track reality.
- `go mod tidy` run in all three modules (root, `examples/preset-management`, `examples/navigation-station-demo`); no other dependency changes fell out of it.
- `docs/go.mod` (the separate Hugo/docs-theme module, pinned to Go 1.22.0) is intentionally untouched — different module, unrelated toolchain.

## Test plan
- [x] `go build ./...` (root + both example modules)
- [x] `go vet ./...` (root + both example modules)
- [x] `go test ./...` (root)
- [x] `golangci-lint run ./...`