### PR TITLE
feat(on-device): LAN access without SSH tunnel, install/restart fixes, setup sync/revert

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -86,7 +86,7 @@ body:
     attributes:
       label: AfterTouch version
       description: Shown in the admin UI footer, or via the binary's `--version`.
-      placeholder: "v0.111.2"
+      placeholder: "v0.123.0"
     validations:
       required: false
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ See the [API Reference](https://gesellix.github.io/Bose-SoundTouch/docs/referenc
 - **[SoundTouch Plus](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus)** (Todd Lucas) — Home Assistant integration; extensive undocumented API documentation
 - **[ÜberBöse API](https://github.com/julius-d/ueberboese-api)** (Julius) — API research and advanced endpoint discovery
 - **[Bose SoundTouch Hook](https://github.com/CodeFinder2/bose-soundtouch-hook)** (Adrian Böckenkamp) — `LD_PRELOAD` hooking for reverse engineering device internals
+- **[STR, SoundTouch Reborn](https://github.com/JRpersonal/streborn)** ([st-reborn.de](https://st-reborn.de)) — on-device agent plus desktop app; its published `iptables` REDIRECT technique is what makes AfterTouch's on-device install reachable over the LAN on co-processor chassis (see [Model Support Matrix](https://gesellix.github.io/Bose-SoundTouch/docs/reference/model-support-matrix/))
 
 ---
 

--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -1135,6 +1135,10 @@ func setupMigrateCmd() *cli.Command {
 			&cli.StringFlag{Name: "method", Value: string(setup.MigrationMethodTelnet), Usage: "telnet | hosts | resolv | xml"},
 			&cli.StringFlag{Name: "proxy-url", Usage: "Optional upstream proxy URL (for --method=xml)"},
 			&cli.BoolFlag{Name: "skip-preflight", Usage: "Skip the AfterTouch settings preflight (use when AfterTouch's settings endpoint is unreachable)"},
+			&cli.StringFlag{Name: "marge-url", Usage: "Override margeServerUrl instead of deriving it from --service-url (e.g. to restore the original Bose cloud URL). Applies to --method=telnet and --method=xml"},
+			&cli.StringFlag{Name: "stats-url", Usage: "Override statsServerUrl (telnet/xml)"},
+			&cli.StringFlag{Name: "sw-update-url", Usage: "Override swUpdateUrl (telnet/xml)"},
+			&cli.StringFlag{Name: "bmx-url", Usage: "Override bmxRegistryUrl (telnet/xml)"},
 		},
 		Action: func(c *cli.Context) error {
 			cfg := GetClientConfig(c)
@@ -1144,6 +1148,13 @@ func setupMigrateCmd() *cli.Command {
 			if err := validateServiceURL(serviceURL); err != nil {
 				PrintError(err.Error())
 				return err
+			}
+
+			options := map[string]string{
+				"marge_url":     c.String("marge-url"),
+				"stats_url":     c.String("stats-url"),
+				"sw_update_url": c.String("sw-update-url"),
+				"bmx_url":       c.String("bmx-url"),
 			}
 
 			m := setup.NewManager(serviceURL, nil, nil)
@@ -1169,7 +1180,7 @@ func setupMigrateCmd() *cli.Command {
 
 			fmt.Printf("Migrating %s → %s using method=%s\n", cfg.Host, serviceURL, method)
 
-			logs, err := m.MigrateSpeaker(cfg.Host, serviceURL, c.String("proxy-url"), nil, method)
+			logs, err := m.MigrateSpeaker(cfg.Host, serviceURL, c.String("proxy-url"), options, method)
 			if logs != "" {
 				fmt.Print(logs)
 			}

--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -52,10 +52,12 @@ func setupCommand() *cli.Command {
 			setupRemoteServicesCmd(),
 			setupInstallCACmd(),
 			setupMigrateCmd(),
+			setupRevertCmd(),
 			setupRebootCmd(),
 			setupVerifyCmd(),
 			setupPlanCmd(),
 			setupPairCmd(),
+			setupSyncCmd(),
 		},
 	}
 }
@@ -1013,6 +1015,116 @@ func promptBasicAuth() (string, string, error) {
 	return user, string(pass), nil
 }
 
+// setupSyncCmd wraps POST /api/setup/sync/{deviceId} — the same operation
+// as the web UI's Devices → Sync Data button. It only reads from the
+// speaker (presets, recents, sources) into AfterTouch's datastore; it never
+// writes anything back to the speaker. Useful for scripting or reproducing
+// what Sync does in isolation (see issue #614: Sync's own code cannot wipe
+// the speaker's preset table, since it never sends anything back).
+func setupSyncCmd() *cli.Command {
+	return &cli.Command{
+		Name:   "sync",
+		Usage:  "Pull presets/recents/sources from the speaker into AfterTouch's datastore (same as the web UI's \"Sync Data\" button)",
+		Before: RequireHost,
+		Flags: []cli.Flag{
+			&cli.StringFlag{Name: "service-url", Required: true, Usage: "AfterTouch base URL"},
+			&cli.StringFlag{Name: "auth", Usage: "Basic-auth credentials for AfterTouch as user:pass (omit to be prompted on 401)"},
+		},
+		Action: func(c *cli.Context) error {
+			cfg := GetClientConfig(c)
+			serviceURL := strings.TrimRight(c.String("service-url"), "/")
+
+			if err := validateServiceURL(serviceURL); err != nil {
+				PrintError(err.Error())
+				return err
+			}
+
+			client, err := CreateSoundTouchClient(cfg)
+			if err != nil {
+				PrintError(fmt.Sprintf("Failed to create client: %v", err))
+				return err
+			}
+
+			deviceInfo, err := client.GetDeviceInfo()
+			if err != nil {
+				PrintError(fmt.Sprintf("Failed to get device info from speaker: %v", err))
+				return err
+			}
+
+			if deviceInfo.DeviceID == "" {
+				err := fmt.Errorf("speaker at %s did not report a DeviceID", cfg.Host)
+				PrintError(err.Error())
+
+				return err
+			}
+
+			PrintDeviceHeader(fmt.Sprintf("Syncing %s into AfterTouch", deviceInfo.DeviceID), cfg.Host, cfg.Port)
+
+			if err := postSetupSync(serviceURL, deviceInfo.DeviceID, c.String("auth")); err != nil {
+				PrintError(err.Error())
+				return err
+			}
+
+			PrintSuccess(fmt.Sprintf("Synced presets, recents, and sources for %s.", deviceInfo.DeviceID))
+
+			return nil
+		},
+	}
+}
+
+// postSetupSync POSTs to AfterTouch's /api/setup/sync/{deviceId}, prompting
+// for basic-auth credentials on 401 (matches fetchCACert's pattern).
+func postSetupSync(serviceURL, deviceID, authFlag string) error {
+	endpoint := fmt.Sprintf("%s/api/setup/sync/%s", serviceURL, deviceID)
+
+	doRequest := func(user, pass string) (*http.Response, error) {
+		req, err := http.NewRequest(http.MethodPost, endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		if user != "" {
+			req.SetBasicAuth(user, pass)
+		}
+
+		client := &http.Client{Timeout: 30 * time.Second}
+
+		return client.Do(req)
+	}
+
+	user, pass := splitAuth(authFlag)
+
+	resp, err := doRequest(user, pass)
+	if err != nil {
+		return fmt.Errorf("POST %s: %w", endpoint, err)
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		_ = resp.Body.Close()
+
+		fmt.Printf("%s requires basic auth.\n", endpoint)
+
+		user, pass, err = promptBasicAuth()
+		if err != nil {
+			return err
+		}
+
+		resp, err = doRequest(user, pass)
+		if err != nil {
+			return fmt.Errorf("POST %s (with auth): %w", endpoint, err)
+		}
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("POST %s returned %d: %s", endpoint, resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	return nil
+}
+
 func setupMigrateCmd() *cli.Command {
 	return &cli.Command{
 		Name:   "migrate",
@@ -1383,6 +1495,45 @@ func renderMigrationSummary(deviceIP, serviceURL string, s *setup.MigrationSumma
 		fmt.Printf("Resolve IP source : %s (%d ms)\n", s.ResolveIPSource, s.ResolveIPDurationMS)
 	} else if s.ResolveIPDurationMS > 0 {
 		fmt.Printf("Resolve IP        : %d ms\n", s.ResolveIPDurationMS)
+	}
+}
+
+// setupRevertCmd wraps setup.Manager.RevertMigration — the same operation
+// as the web UI's "Revert to Defaults" button (Migrate tab). Restores
+// SoundTouchSdkPrivateCfg.xml, /etc/hosts, and /etc/resolv.conf from their
+// .original backups, removes the AfterTouch DNS-hook artifacts, and strips
+// just the AfterTouch-labeled cert out of the trust bundle. No --service-url
+// needed: everything it touches already lives on the speaker.
+//
+// Deliberately out of scope (matches the web UI button): SSH/remote_services
+// persistence (use `setup remote-services --remove`) and account pairing
+// (use `account unpair`) — see #614 self-test notes for the full checklist.
+func setupRevertCmd() *cli.Command {
+	return &cli.Command{
+		Name:   "revert",
+		Usage:  "Undo a migration: restore SoundTouchSdkPrivateCfg.xml/hosts/resolv.conf from backups and remove the AfterTouch CA cert",
+		Before: RequireHost,
+		Action: func(c *cli.Context) error {
+			cfg := GetClientConfig(c)
+			m := setup.NewManager("", nil, nil)
+
+			fmt.Printf("Reverting migration on %s...\n", cfg.Host)
+
+			logs, err := m.RevertMigration(cfg.Host)
+			if logs != "" {
+				fmt.Print(logs)
+			}
+
+			if err != nil {
+				PrintError(err.Error())
+				return err
+			}
+
+			PrintSuccess("Migration reverted. SSH access and account pairing are untouched by this — " +
+				"see `setup remote-services --remove` and `account unpair` if you want those cleared too.")
+
+			return nil
+		},
 	}
 }
 

--- a/cmd/soundtouch-cli/cmd_setup_test.go
+++ b/cmd/soundtouch-cli/cmd_setup_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -41,6 +43,46 @@ func captureStdout(t *testing.T, fn func()) string {
 	<-done
 
 	return buf.String()
+}
+
+func TestPostSetupSync_PostsToDeviceScopedURL(t *testing.T) {
+	var gotMethod, gotPath string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	defer srv.Close()
+
+	if err := postSetupSync(srv.URL, "DEVICEID01", ""); err != nil {
+		t.Fatalf("postSetupSync: %v", err)
+	}
+
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+
+	if want := "/api/setup/sync/DEVICEID01"; gotPath != want {
+		t.Errorf("expected path %q, got %q", want, gotPath)
+	}
+}
+
+func TestPostSetupSync_PropagatesServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "device not found", http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	err := postSetupSync(srv.URL, "DEVICEID01", "")
+	if err == nil {
+		t.Fatal("expected an error for a 404 response")
+	}
+
+	if !strings.Contains(err.Error(), "device not found") {
+		t.Errorf("expected error to include server body, got %q", err.Error())
+	}
 }
 
 func TestRenderSourceTable_AlignsColumnsAndDedupsDisplayName(t *testing.T) {

--- a/docs/content/docs/guides/CLI-REFERENCE.md
+++ b/docs/content/docs/guides/CLI-REFERENCE.md
@@ -1338,6 +1338,23 @@ soundtouch-cli --host <device> setup migrate --service-url http://192.0.2.10:800
 `--skip-preflight` skips AfterTouch's settings preflight check (useful when
 that endpoint is unreachable).
 
+`--marge-url`/`--stats-url`/`--sw-update-url`/`--bmx-url` override the
+corresponding field instead of deriving it from `--service-url` (applies to
+both `--method=telnet` and `--method=xml`). Useful beyond soundcork-style
+setups: e.g. pointing a speaker back at the **original Bose cloud URLs**
+without a full `setup revert` — telnet writes both the runtime and
+persisted layers in a single connection, no SSH or `.original` backup
+needed:
+
+```bash
+soundtouch-cli --host <device> setup migrate --method telnet \
+  --service-url https://streaming.bose.com \
+  --marge-url https://streaming.bose.com \
+  --stats-url https://events.api.bosecm.com \
+  --sw-update-url https://worldwide.bose.com/updates/soundtouch \
+  --bmx-url https://content.api.bose.io/bmx/registry/v1/services
+```
+
 #### `setup revert`
 
 Undoes a migration — the CLI equivalent of the web UI's "Revert to

--- a/docs/content/docs/guides/CLI-REFERENCE.md
+++ b/docs/content/docs/guides/CLI-REFERENCE.md
@@ -592,6 +592,9 @@ soundtouch-cli --host <device> account remove-amazon --user <USER>
 soundtouch-cli --host <device> account remove-deezer --user <USER>
 soundtouch-cli --host <device> account remove-iheart --user <USER>
 soundtouch-cli --host <device> account remove-nas --user <GUID/0> [--name <NAME>]
+
+# Unpair the device from its Marge cloud account entirely
+soundtouch-cli --host <device> account unpair
 ```
 
 **Supported Services:**
@@ -648,6 +651,11 @@ soundtouch-cli --host 192.0.2.10 account remove \
 - Network music libraries (STORED_MUSIC) don't require passwords, only the UPnP server GUID
 - After adding an account, use `source list` to verify it appears as available
 - Some services may require additional authentication steps through their mobile apps
+- `account unpair` is different from the above: it sends `UnPairDeviceWithAccount`
+  over the speaker's own local WebSocket to remove its **Marge cloud account**
+  pairing entirely (`margeAccountUUID`), not a single streaming-service login.
+  See `setup revert` for the related "undo a migration" operation, which
+  deliberately does *not* call this — the two are separate steps.
 
 ### Bass Control
 
@@ -1182,6 +1190,238 @@ https://github.com/gesellix/Bose-SoundTouch/releases/tag/v1.3.0
 - `soundtouch-backup` has the same `update-check` command.
 - If the running binary isn't a released version (e.g. a dev build),
   the command reports that and skips the comparison.
+
+### Setup & Migration
+
+The `setup <subcommand>` group provisions a speaker end-to-end: enabling
+SSH, factory-reset + Wi-Fi re-provisioning, pointing it at AfterTouch, CA
+trust, account pairing, reverting, and one-shot data sync. Each subcommand
+wraps an existing `pkg/service/setup` helper directly — there's no separate
+business logic in the CLI layer. Manual provisioning-loop background:
+[docs/analysis/SETUP-WEBSOCKET-EXPERIMENT.md](../analysis/SETUP-WEBSOCKET-EXPERIMENT.md)
+and [Device Initial Setup](DEVICE-INITIAL-SETUP.md).
+
+#### `setup inspect`
+
+Non-destructive snapshot of the speaker: identity, pairing state, Wi-Fi,
+sources, presets, and (with `--telnet`) the runtime URL configuration via
+`getpdo`. Good first command to run against an unfamiliar speaker.
+
+```bash
+soundtouch-cli --host <device> setup inspect
+soundtouch-cli --host <device> setup inspect --telnet   # also reads runtime URLs (slower)
+```
+
+#### `setup ssh-check`
+
+Probes whether port 22 is reachable. On failure, prints the `enable-ssh`
+suggestion and the USB-stick fallback procedure.
+
+```bash
+soundtouch-cli --host <device> setup ssh-check [--timeout 3s]
+```
+
+#### `setup enable-ssh`
+
+Bootstraps SSH on a speaker with no prior access, via the port-17000
+`envswitch` trick (#471) — no USB stick needed. Auto-pairs an unpaired
+(factory-reset) device first by default (the injection needs something to
+poll), waits for `:22`, and persists the `remote_services` marker so SSH
+survives a reboot.
+
+```bash
+soundtouch-cli --host <device> setup enable-ssh
+soundtouch-cli --host <device> setup enable-ssh --service-url https://192.0.2.10:8443
+```
+
+Flags:
+- `--service-url` — optional; only the vehicle for the injection, no live
+  server required. Set the real URL later via `setup migrate`.
+- `--wait` (default `90s`) — how long to wait for `:22` after injection.
+- `--full-config` — for stubborn devices (ST Portable, CineMate 520) where
+  the default injection is accepted but `sshd` never starts: writes all
+  four config URLs (the #515 sequence) and reboots.
+- `--command-delay` — only affects `--full-config`; pause between its 6
+  steps.
+- `--no-auto-pair` / `--account` — skip or control the automatic pairing
+  check.
+- `--no-reset-urls` — skip restoring clean `boseurls` after SSH is up.
+- `--no-persist` — skip persisting `remote_services` (SSH won't survive a
+  reboot).
+- `--authorized-key` — opt-in hardening: install an SSH public key instead
+  of relying on the empty-password login.
+- `--close-17000` — opt-in hardening: firewall off port 17000 from the LAN
+  (loopback access kept).
+
+#### `setup remote-services`
+
+Enables (default) or removes the `remote_services` SSH-enablement marker.
+
+```bash
+soundtouch-cli --host <device> setup remote-services            # ensure it's present
+soundtouch-cli --host <device> setup remote-services --remove   # disable SSH after next reboot
+```
+
+#### `setup factory-reset`
+
+Issues `sys factorydefault` over telnet — wipes account, presets, and
+Wi-Fi, and reboots the speaker into its own setup-mode AP. Prints the next
+steps (`wait-ap`, then `wifi-push`).
+
+```bash
+soundtouch-cli --host <device> setup factory-reset
+```
+
+> **Heads-up:** just before resetting, the speaker sends
+> `DELETE /streaming/account/{id}/device/{id}` to whatever `margeURL` is
+> *currently* configured. If that still points at `streaming.bose.com`
+> (not AfterTouch), AfterTouch keeps a stale datastore entry — migrate
+> first if you want a clean record.
+
+#### `setup wait-ap`
+
+Polls the speaker's setup-mode AP (default `192.0.2.1`) until `/info`
+responds, after a factory reset.
+
+```bash
+soundtouch-cli setup wait-ap [--ap-host 192.0.2.1] [--interval 2s] [--timeout 5m]
+```
+
+#### `setup wifi-push`
+
+POSTs `AddWirelessProfile` to the speaker's setup-mode endpoint — pushes
+your home Wi-Fi credentials while connected to the speaker's AP.
+
+```bash
+soundtouch-cli setup wifi-push --ssid="YourHomeSSID" --pass='your-password'
+```
+
+Flags: `--security` (default `wpa_or_wpa2`), `--ap-host` (default
+`192.0.2.1`), `--request-timeout` (default `30s` — the speaker can be slow
+to ACK before tearing down AP mode; 10s often races).
+
+#### `setup wait-online`
+
+Polls mDNS until a speaker matching `--match` comes online on the home
+network — run this after switching back from the speaker's AP.
+
+```bash
+soundtouch-cli setup wait-online --match=<last-6-hex-of-deviceID>
+```
+
+`--match` is empty by default (first speaker seen); `--interval` (`3s`) and
+`--timeout` (`5m`) control the poll.
+
+#### `setup install-ca`
+
+Fetches AfterTouch's CA cert from `/api/setup/ca.crt` and injects it into
+the speaker's trust store via SSH.
+
+```bash
+soundtouch-cli --host <device> setup install-ca --service-url https://192.0.2.10:8443
+```
+
+`--auth` (`user:pass`) supplies basic-auth credentials up front; omit it to
+be prompted interactively if the endpoint returns 401.
+
+#### `setup migrate`
+
+Applies a migration method to point the speaker at AfterTouch — the CLI
+equivalent of the web UI's Migrate tab.
+
+```bash
+soundtouch-cli --host <device> setup migrate --service-url http://192.0.2.10:8000 --method telnet
+```
+
+`--method` is one of `telnet` (default) | `hosts` | `resolv` | `xml`.
+`--proxy-url` sets an optional upstream proxy (only used by `--method=xml`).
+`--skip-preflight` skips AfterTouch's settings preflight check (useful when
+that endpoint is unreachable).
+
+#### `setup revert`
+
+Undoes a migration — the CLI equivalent of the web UI's "Revert to
+Defaults" button. Restores `SoundTouchSdkPrivateCfg.xml`, `/etc/hosts`, and
+`/etc/resolv.conf` from their `.original` backups, removes the AfterTouch
+DNS-hook artifacts, and strips just the AfterTouch-labeled certificate out
+of the trust bundle. No `--service-url` needed — everything it touches
+already lives on the speaker.
+
+```bash
+soundtouch-cli --host <device> setup revert
+```
+
+**Out of scope for this command** (matches the web UI button): SSH /
+`remote_services` persistence (use `setup remote-services --remove`) and
+account pairing (use `account unpair`) are untouched — revert them
+separately if you want a fully clean speaker.
+
+#### `setup reboot`
+
+Reboots the speaker — useful to force the envswitch parallel-persistence
+layer to apply after a migration.
+
+```bash
+soundtouch-cli --host <device> setup reboot [--method telnet|ssh]
+```
+
+`--method` defaults to `telnet`, which works without SSH on modern
+firmware.
+
+#### `setup verify`
+
+Read-only status probe across every migration axis (transports, URL
+configuration, DNS interception, CA/TLS, pairing) — doubles as a preflight
+check before applying changes and a verification step afterward. Exits
+non-zero if nothing reports migrated, so it's usable as a CI gate.
+
+```bash
+soundtouch-cli --host <device> setup verify --service-url http://192.0.2.10:8000
+```
+
+#### `setup plan`
+
+Recommends the next setup/migration steps based on `inspect` + `verify`
+state — prints a ready-to-run command for each recommended step.
+
+```bash
+soundtouch-cli --host <device> setup plan --service-url http://192.0.2.10:8000
+soundtouch-cli --host <device> setup plan --service-url http://192.0.2.10:8000 --reset   # plan a full factory-reset → Wi-Fi → migrate → pair flow
+```
+
+`--wifi-ssid` overrides the SSID used for the `wifi-push` step in a reset
+plan (default: reuse the SSID `inspect` found). `--include-pair` (default
+`true`) can be disabled if you'll pair manually.
+
+#### `setup pair`
+
+Pairs the speaker with an account via the WebSocket `SETUP` state machine
+(`--mode=full`, matching the Bose app's own flow) or a minimal
+`setMargeAccount`-only call (`--mode=bare`, the same underlying call the
+Health tab's "empty margeAccountUUID" QuickFix uses).
+
+```bash
+soundtouch-cli --host <device> setup pair --mode=full --account=1111111 --service-url http://192.0.2.10:8000
+soundtouch-cli --host <device> setup pair --mode=bare --account=1111111 --service-url http://192.0.2.10:8000
+```
+
+`--account` empty generates a fresh 7-digit ID. `--name` sets the speaker
+name during pairing (empty keeps current). `--language` defaults to `2`
+(English). `--token` defaults to a built-in placeholder matching the Bose
+app's token shape.
+
+#### `setup sync`
+
+Pulls presets, recents, and sources from the speaker into AfterTouch's
+datastore — the CLI equivalent of the web UI's Devices → Sync Data button.
+Read-only towards the speaker: it never writes anything back.
+
+```bash
+soundtouch-cli --host <device> setup sync --service-url http://192.0.2.10:8000
+```
+
+`--auth` (`user:pass`) supplies basic-auth credentials up front; omit it to
+be prompted interactively if the endpoint returns 401.
 
 ## Common Usage Patterns
 

--- a/docs/content/docs/guides/DEVICE-INITIAL-SETUP.md
+++ b/docs/content/docs/guides/DEVICE-INITIAL-SETUP.md
@@ -99,16 +99,26 @@ After factory restore the speaker enters setup mode automatically; no power-cycl
 
 ## 6. AP Mode Wi-Fi Provisioning via Console
 
-When BLE is unavailable (e.g. when using an Android emulator), use AP mode to push Wi-Fi credentials from the Mac command line.
+When BLE is unavailable (e.g. when using an Android emulator), use AP mode to push Wi-Fi credentials from the command line. The HTTP steps below (6.2, 6.3) are OS-agnostic; only the Wi-Fi-network-switching commands (6.1, 6.4) are platform-specific — macOS is shown inline, with Linux and Windows equivalents alongside.
 
-### 6.1 Connect Mac to Speaker AP
+### 6.1 Connect your machine to the Speaker AP
 
-After factory reset the speaker broadcasts an SSID like `Bose SoundTouch XXXX`. Connect the Mac to it:
+After factory reset the speaker broadcasts an SSID like `Bose SoundTouch XXXX`. Connect to it:
 
 ```bash
-# List nearby SSIDs — use System Settings → Wi-Fi (the airport command was removed in macOS Sequoia+)
-# Connect (replace with actual SSID)
+# macOS — list nearby SSIDs via System Settings → Wi-Fi (the `airport`
+# command was removed in macOS Sequoia+); connect (replace with actual SSID):
 networksetup -setairportnetwork en0 "Bose SoundTouch XXXX"
+```
+
+```bash
+# Linux (NetworkManager) — one-shot connect, no password (open AP):
+nmcli device wifi connect "Bose SoundTouch XXXX"
+```
+
+```powershell
+# Windows — connect via the built-in Wi-Fi menu, or from PowerShell:
+netsh wlan connect name="Bose SoundTouch XXXX"
 ```
 
 The speaker's web UI gateway is at `192.0.2.1` (verified: ST10 assigns `192.0.2.2` to the client via DHCP).
@@ -143,19 +153,36 @@ Expected response: `<?xml version="1.0" encoding="UTF-8" ?><AddWirelessProfileRe
 
 The speaker will disconnect from AP mode and join the home network within ~15–30 s.
 
-### 6.4 Reconnect Mac to Home Network
+### 6.4 Reconnect to your Home Network
 
 ```bash
+# macOS
 networksetup -setairportnetwork en0 "MyHomeNetwork" "MyPassword"
+```
+
+```bash
+# Linux (NetworkManager) — assumes the connection profile already exists
+# (e.g. from a prior manual connect); use `nmcli device wifi connect
+# "MyHomeNetwork" password "MyPassword"` instead for a first-time connect.
+nmcli connection up "MyHomeNetwork"
+```
+
+```powershell
+# Windows
+netsh wlan connect name="MyHomeNetwork"
 ```
 
 Wait ~15 s for the speaker to join the home network, then verify:
 
 ```bash
-# Discover the speaker's new IP via mDNS
-dns-sd -B _soundtouch._tcp local &
-sleep 5 ; kill %1
+# macOS/Linux — discover the speaker's new IP via mDNS.
+# macOS: dns-sd ships with the OS. Linux: use avahi-browse (avahi-utils package).
+dns-sd -B _soundtouch._tcp local &      # macOS
+avahi-browse -r _soundtouch._tcp        # Linux — Ctrl-C to stop
+sleep 5 ; kill %1 2>/dev/null           # only needed for the dns-sd form
 ```
+
+Windows has no equivalent built-in mDNS browser; use `soundtouch-cli discover devices` (this repo's own mDNS/UPnP discovery, cross-platform) or check your router's DHCP client list instead.
 
 ---
 

--- a/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
+++ b/docs/content/docs/guides/EXTERNAL-HOST-WALKTHROUGH.md
@@ -40,7 +40,7 @@ systemd unit that starts on boot.
 To pin a specific version instead of the latest:
 
 ```bash
-sudo bash install.sh v0.111.3
+sudo bash install.sh v0.123.0
 ```
 
 Check that the service is running:
@@ -278,7 +278,7 @@ curl -s http://192.0.2.1:8090/presets
 
 ```bash
 sudo bash install.sh              # updates to latest release
-sudo bash install.sh v0.111.3     # updates to a specific version
+sudo bash install.sh v0.123.0     # updates to a specific version
 ```
 
 The installer stops the service, downloads the new binary, and restarts

--- a/docs/content/docs/guides/MIGRATION-GUIDE.md
+++ b/docs/content/docs/guides/MIGRATION-GUIDE.md
@@ -107,6 +107,8 @@ Open `http://<server>:8000` and go to the **Settings** tab.
 
 Set the **Target Domain** to the address your speakers can reach — for example `https://soundtouch.fritz.box` or `http://192.0.2.100:8000`. This must be the host's address on your local network, not `localhost`.
 
+> **On-device install:** this "not `localhost`" rule is for the local-network-host and cloud/VPS scenarios above, where the service runs on a *different* machine than the speaker. If you're running AfterTouch directly on the speaker itself (see the [On-Device Install Walkthrough](ON-DEVICE-INSTALL-WALKTHROUGH.md)), the speaker and the service are the same machine — `http://localhost:8000` is exactly right there, and is the recommended value: it needs no DNS/mDNS to resolve and survives DHCP address changes since it never depends on the LAN address at all.
+
 If you plan to use DNS/DHCP redirect, enable the **DNS Discovery Server** and set the **DNS Bind Address** to `:53`. The upstream DNS should be your router's IP, not the service's own address.
 
 > **Tip**: If you change settings and they don't seem to take effect, check `data/settings.json` — settings saved in the UI take precedence over environment variables.
@@ -126,6 +128,14 @@ The XML migration writes updated configuration to the speaker's filesystem, whic
 3. Insert the drive into the speaker's USB port while it is powered on.
 4. Power-cycle the speaker (unplug the power cable, wait 10 seconds, reconnect).
 5. After boot, root SSH is available with no password: `ssh -oHostKeyAlgorithms=+ssh-rsa root@<SPEAKER-IP>`
+
+**Or, without a USB stick:** `soundtouch-cli setup enable-ssh` (#471) bootstraps SSH purely over the network, using the speaker's telnet:17000 diagnostic shell (open by default on most firmware) to inject the SSH-enable command:
+
+```shell
+soundtouch-cli --host <SPEAKER-IP> setup enable-ssh
+```
+
+It waits for `:22` to come up and persists the change (survives a reboot) by default. Falls back to the USB-stick method above if telnet:17000 is closed or the injection doesn't take on your model.
 
 You only need to do this once per speaker. SSH can remain enabled for future maintenance or be disabled after migration — your choice.
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -104,8 +104,11 @@ By default this installs the **latest release** — the script resolves it from
 GitHub's `releases/latest` redirect. To target a specific version instead:
 
 ```bash
-# Via environment variable (works with pipe-to-sh)
-VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+# Via environment variable — note it goes on `sh`, not `curl`: shell
+# variable-assignment prefixes only apply to the one command they're
+# attached to, and in a pipe each command is a separate process.
+# `VERSION=0.123.0 curl ... | sh` silently does NOT set it for `sh`.
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | VERSION=0.123.0 sh
 
 # Via command-line flag (pass args after sh -s --)
 curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0
@@ -372,7 +375,7 @@ older artefacts to keep `/mnt/nv` free:
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # Update to a specific version — three equivalent forms
-VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | VERSION=0.123.0 sh
 
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -86,10 +86,10 @@ GitHub's `releases/latest` redirect. To target a specific version instead:
 
 ```bash
 # Via environment variable (works with pipe-to-sh)
-VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # Via command-line flag (pass args after sh -s --)
-curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
+curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0
 ```
 
 Verify the installed version:
@@ -98,7 +98,7 @@ Verify the installed version:
 wget -qO- http://localhost:8000/health
 ```
 
-The JSON response should include `"version":"v0.111.3"` (or whichever
+The JSON response should include `"version":"v0.123.0"` (or whichever
 version you installed).
 
 ---
@@ -186,13 +186,13 @@ next reboot — which is fine for a one-time setup run):
 cd /tmp
 
 curl -L --fail -o soundtouch-cli \
-  https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.111.3/soundtouch-cli-v0.111.3-linux-armv7
+  https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.123.0/soundtouch-cli-v0.123.0-linux-armv7
 chmod +x soundtouch-cli
 
 /tmp/soundtouch-cli --version
 ```
 
-Replace `v0.111.3` with the version you installed.
+Replace `v0.123.0` with the version you installed.
 
 ---
 
@@ -305,12 +305,12 @@ older artefacts to keep `/mnt/nv` free:
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # Update to a specific version — three equivalent forms
-VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
-rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0
 
 curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh
-sh install.sh --version 0.111.3
+sh install.sh --version 0.123.0
 ```
 
 **Rollback:** the installer keeps a `.backup` file alongside the binary:

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -153,9 +153,19 @@ ssh -oHostKeyAlgorithms=+ssh-rsa -L 8000:localhost:8000 root@192.0.2.1
 Keep this terminal open. Navigate to **http://localhost:8000** in your
 browser.
 
-> Skip this step if your speaker's firmware exposes port 8000 on the LAN
-> directly — you can reach `http://192.0.2.1:8000` without a tunnel in that
-> case.
+> **You may not need the tunnel at all.** Try `http://192.0.2.1:8000` first.
+> If that doesn't load, try **`http://192.0.2.1:17008`**: on speakers whose
+> Wi-Fi co-processor refuses to pass `:8000` through (the ST20 and likely
+> others), the installer automatically redirects port `17008` to AfterTouch,
+> so the Admin UI is reachable from the LAN without any tunnel. Check with
+> `/etc/init.d/aftertouch status` on the speaker, which reports the LAN port
+> when the redirect is active. Details and per-model status:
+> [Model Support Matrix](../../reference/MODEL-SUPPORT-MATRIX/).
+>
+> Keep the tunnel in mind anyway for **linking music-service accounts**:
+> Spotify only accepts `https://` or *loopback* OAuth redirect URIs, so
+> `http://localhost:8000` through a tunnel succeeds where a plain LAN
+> address is rejected.
 
 ---
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -14,7 +14,9 @@ documenting a successful fresh installation on a SoundTouch 20 Series I.
 
 ## Prerequisites
 
-- SSH enabled on the speaker (the usual "Stick with remote_services" procedure).
+- SSH enabled on the speaker — either the usual "USB stick with
+  `remote_services`" procedure, or `soundtouch-cli setup enable-ssh`
+  (no stick needed, see Step 1).
 - Your machine can reach the speaker on the LAN.
 - The speaker's LAN IP address — replace `192.0.2.1` throughout with the
   actual address shown in your router or `arp -a`.
@@ -28,6 +30,23 @@ documenting a successful fresh installation on a SoundTouch 20 Series I.
 ---
 
 ## Step 1 — Connect to the speaker via SSH
+
+If SSH isn't enabled yet, you don't need a USB stick: `soundtouch-cli` can
+bootstrap it purely over the network (#471), using the speaker's
+telnet:17000 diagnostic shell (open by default on most firmware) to inject
+the SSH-enable command:
+
+```bash
+soundtouch-cli --host 192.0.2.1 setup enable-ssh
+```
+
+This waits for `:22` to come up and persists it (survives a reboot) by
+default. The USB-stick method (format FAT32, create an empty
+`remote_services` file in its root, insert, power-cycle) still works as a
+fallback if telnet:17000 is closed or the injection doesn't take on your
+model.
+
+Either way, connect the same way:
 
 ```bash
 ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
@@ -137,7 +156,42 @@ browser.
 
 ---
 
-## Step 6 — Run the Health QuickFix for empty `margeAccountUUID`
+## Step 6 — Migrate (point the speaker at itself)
+
+The speaker isn't pointed at the AfterTouch instance you just installed yet
+— this step does that. On-device, the speaker and the AfterTouch instance
+are the same machine, so **loopback is the correct and recommended Target
+Domain value**: `http://localhost:8000`. This is the one case where the
+general migration guide's "must not be `localhost`" warning does not
+apply — that warning is about the external-host/cloud scenarios, where
+`localhost` would resolve on the wrong machine (the service host, not the
+speaker). Here there is no wrong machine to resolve on.
+
+**Via the Admin UI:**
+
+1. Go to **Settings**, set **Target Domain** to `http://localhost:8000`.
+2. Go to **Devices**, find your speaker (it self-discovers on its own LAN
+   IP), click **Migrate**.
+3. Accept the suggested plan and let it apply.
+4. Reboot to apply the change:
+   ```bash
+   sync
+   reboot
+   ```
+
+**Or via the CLI** (equivalent, no browser needed — grab `soundtouch-cli`
+from Step 9 below first if you want this path):
+
+```bash
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 setup migrate \
+  --service-url http://localhost:8000 --method telnet
+sync
+reboot
+```
+
+---
+
+## Step 7 — Run the Health QuickFix for empty `margeAccountUUID`
 
 In the AfterTouch UI:
 
@@ -148,6 +202,14 @@ In the AfterTouch UI:
 4. Click the **QuickFix** button (labelled "Fix", "Pair account", or
    "Apply QuickFix" depending on the version) and confirm.
 
+Or via the CLI (same underlying pairing call, `--mode=bare` matches what
+the QuickFix does — see Step 9 to grab `soundtouch-cli` first):
+
+```bash
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 setup pair \
+  --mode=bare --account=1111111 --service-url http://localhost:8000
+```
+
 Then reboot again to let the pairing take effect:
 
 ```bash
@@ -157,7 +219,7 @@ reboot
 
 ---
 
-## Step 7 — Verify pairing and sources
+## Step 8 — Verify pairing and sources
 
 After the reboot reconnect via SSH and check:
 
@@ -171,32 +233,37 @@ wget -qO- http://localhost:8090/info | grep margeAccountUUID
 wget -qO- http://localhost:8090/sources
 ```
 
-If `margeAccountUUID` is still empty, re-run the Health QuickFix (Step 6)
+If `margeAccountUUID` is still empty, re-run the Health QuickFix (Step 7)
 and reboot again.
 
 ---
 
-## Step 8 — Download soundtouch-cli (optional, for preset setup)
+## Step 9 — Download soundtouch-cli (optional, for preset setup)
 
 If you want to program preset buttons from the command line, download the
-CLI binary to the speaker's `/tmp` (tmpfs, so it survives only until the
-next reboot — which is fine for a one-time setup run):
+CLI binary to `/mnt/nv/aftertouch` (the same persistent partition
+AfterTouch itself lives on) rather than `/tmp`: `/tmp` is tmpfs and gets
+wiped on every reboot, and if you used the CLI alternatives in Steps 6/7
+above, it needs to survive those steps' reboots too, not just the final
+one:
 
 ```bash
-cd /tmp
+cd /mnt/nv/aftertouch
 
 curl -L --fail -o soundtouch-cli \
   https://github.com/gesellix/Bose-SoundTouch/releases/download/v0.123.0/soundtouch-cli-v0.123.0-linux-armv7
 chmod +x soundtouch-cli
 
-/tmp/soundtouch-cli --version
+/mnt/nv/aftertouch/soundtouch-cli --version
 ```
 
-Replace `v0.123.0` with the version you installed.
+Replace `v0.123.0` with the version you installed. If you want the CLI
+alternatives in Steps 6/7, download it here first, before doing those
+steps — it'll be in place and already persistent either way.
 
 ---
 
-## Step 9 — Store custom radio streams to preset buttons
+## Step 10 — Store custom radio streams to preset buttons
 
 Each station must be playing before it can be saved. The `sleep 5` gives
 the speaker time to buffer and confirm the stream before storing.
@@ -206,52 +273,52 @@ the speaker time to buffer and confirm the stream before storing.
 
 ```bash
 # Preset 1 — Hitradio OE3
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "http://orf-live.ors-shoutcast.at/oe3-q2a" \
   --name "Hitradio OE3" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 1
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 1
 
 # Preset 2 — Lounge FM
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "http://188.138.9.183/digital.mp3" \
   --name "Lounge FM" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 2
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 2
 
 # Preset 3 — Country Nonstop
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "https://stream.laut.fm/country-nonstop" \
   --name "Country Nonstop" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 3
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 3
 
 # Preset 4 — Radio Piterpan
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "https://klasse1.fluidstream.eu/piterpan.mp3?FLID=8" \
   --name "Radio Piterpan" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 4
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 4
 
 # Preset 5 — kronehit
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "https://secureonair.krone.at/kronehit-hp.mp3" \
   --name "kronehit" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 5
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 5
 
 # Preset 6 — Radio Niederösterreich
-/tmp/soundtouch-cli --host 127.0.0.1 source custom-radio \
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 source custom-radio \
   --url "http://orf-live.ors-shoutcast.at/noe-q2a" \
   --name "Radio Niederoesterreich" \
   --service-url "http://localhost:8000"
 sleep 5
-/tmp/soundtouch-cli --host 127.0.0.1 preset store-current --slot 6
+/mnt/nv/aftertouch/soundtouch-cli --host 127.0.0.1 preset store-current --slot 6
 ```
 
 These are the stations from weissigera's setup (Austrian public and
@@ -260,7 +327,7 @@ pattern is the same regardless of station.
 
 ---
 
-## Step 10 — Verify presets and final reboot
+## Step 11 — Verify presets and final reboot
 
 ```bash
 wget -qO- http://localhost:8090/presets
@@ -286,7 +353,7 @@ should start playing the corresponding stream.
 | SSH "no matching host key type"                      | Add `-oHostKeyAlgorithms=+ssh-rsa`                  |
 | Port 8000 not reachable from LAN                     | Use the SSH tunnel (Step 5)                         |
 | `margeAccountUUID` still empty after reboot          | Re-run Health QuickFix, reboot again                |
-| Radio source error 1005                              | `margeAccountUUID` is empty — complete Step 6 first |
+| Radio source error 1005                              | `margeAccountUUID` is empty — complete Step 7 first |
 | `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20`            |
 | No space left on device during install               | Run the cleanup in Step 2; check `df -h /mnt/nv`    |
 
@@ -321,6 +388,39 @@ cp /mnt/nv/aftertouch/aftertouch-service.<old-version>.backup \
    /mnt/nv/aftertouch/aftertouch-service
 /etc/init.d/aftertouch restart
 ```
+
+**Testing a pre-release build (from `main`, not yet tagged):** `install.sh`
+only ever downloads from GitHub Releases, so there's no one-line installer
+for an unreleased commit. Cross-compile and swap the binary manually
+instead — this is a direct extension of the rollback procedure above:
+
+```bash
+# On your own machine, from a checkout of the branch/commit you want:
+make build-linux-armv7   # builds build/soundtouch-service-linux-armv7,
+                          # build/soundtouch-cli-linux-armv7, and
+                          # build/soundtouch-backup-linux-armv7
+
+scp build/soundtouch-service-linux-armv7 root@192.0.2.1:/mnt/nv/aftertouch/aftertouch-service.new
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
+
+rw
+/etc/init.d/aftertouch stop
+cp /mnt/nv/aftertouch/aftertouch-service /mnt/nv/aftertouch/aftertouch-service.pre-test.backup
+mv /mnt/nv/aftertouch/aftertouch-service.new /mnt/nv/aftertouch/aftertouch-service
+chmod +x /mnt/nv/aftertouch/aftertouch-service
+/etc/init.d/aftertouch start
+```
+
+If you're testing an unreleased `soundtouch-cli` change (not just the
+service), swap that binary too — same idea, and it lands in the same
+`/mnt/nv/aftertouch` directory Step 9 above uses:
+
+```bash
+scp build/soundtouch-cli-linux-armv7 root@192.0.2.1:/mnt/nv/aftertouch/soundtouch-cli
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1 chmod +x /mnt/nv/aftertouch/soundtouch-cli
+```
+
+Roll back the same way as above, using the `.pre-test.backup` file.
 
 ---
 

--- a/docs/content/docs/guides/RASPBERRY-PI.md
+++ b/docs/content/docs/guides/RASPBERRY-PI.md
@@ -40,14 +40,14 @@ sudo bash install.sh
 Install a specific version:
 
 ```bash
-sudo bash install.sh v0.111.3
+sudo bash install.sh v0.123.0
 ```
 
 Override defaults at install time:
 
 ```bash
 sudo \
-  VERSION=v0.111.3 \
+  VERSION=v0.123.0 \
   HOSTNAME_FQDN=soundtouch.local \
   HTTP_PORT=80 \
   HTTPS_PORT=443 \
@@ -105,7 +105,7 @@ journalctl -u soundtouch-service -b               # this boot only
 
 ```bash
 sudo bash install.sh              # update to latest release
-sudo bash install.sh v0.111.3     # update to a specific version
+sudo bash install.sh v0.123.0     # update to a specific version
 ```
 
 The script stops the service, downloads the new binary (backs up the old one to
@@ -157,14 +157,14 @@ sudo bash install-player.sh
 Install a specific version:
 
 ```bash
-sudo bash install-player.sh v0.111.3
+sudo bash install-player.sh v0.123.0
 ```
 
 Override defaults at install time:
 
 ```bash
 sudo \
-  VERSION=v0.111.3 \
+  VERSION=v0.123.0 \
   HTTP_PORT=8081 \
   bash install-player.sh
 ```
@@ -252,7 +252,7 @@ journalctl -u soundtouch-player -f
 
 ```bash
 sudo bash install-player.sh              # update to latest release
-sudo bash install-player.sh v0.111.3     # update to a specific version
+sudo bash install-player.sh v0.123.0     # update to a specific version
 ```
 
 ### Removal

--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -648,6 +648,40 @@ Confirmed on hardware across five device variants (2026-08-09): different ports 
 
 **Fix:** After a power-cycle, wait at least 90 seconds before retrying any telnet-based command. If it still fails after that, wait a full 2 minutes before assuming the port is genuinely closed on that firmware rather than just slow to come up.
 
+### ❌ Speaker gets slower/less responsive over time after `setup enable-ssh` with no `--service-url`
+
+**Symptoms:**
+
+- You ran `soundtouch-cli setup enable-ssh` without `--service-url` (or via the Admin UI's equivalent) to bootstrap SSH, and never followed up with a real `setup migrate`.
+- Over time (hours to days), the speaker becomes progressively less responsive — slow to answer `:8090`, SSH connections time out, the Admin UI shows it as flaky or offline.
+
+**Cause:**
+
+`enable-ssh` without `--service-url` writes a deliberately-invalid placeholder (`https://aftertouch.invalid`) into `margeServerUrl`/`swUpdateUrl`/etc — by design, since the SSH-enable injection only needs *a* URL to round-trip through, not a working one. But unless you run `setup migrate` (or the Admin UI's Migrate step) afterward, that placeholder **stays persisted** — the command's own success message says so explicitly. The firmware then retries a failing DNS/curl lookup against it on a background loop (same class of failure as the `mojo`/`taigan` unresolvable-hostname case, #546) — an ongoing resource drain that isn't dramatic on its own, but confirmed on real hardware (2026-08-16) to compound badly if anything else (e.g. a burst of SSH connections — see the `setup revert` entry below) puts the speaker under load at the same time.
+
+**Fix:** Always follow `enable-ssh` (when run without `--service-url`) with a real `setup migrate` before walking away. If you're recovering a speaker that's already stuck like this: power-cycle it, confirm it's reachable (`ping`, `curl :8090/info`, a single plain `ssh ... echo ok`) before doing anything else, then run `setup migrate` with the real URLs. If you want to point it back at the **original Bose cloud** URLs instead of AfterTouch (e.g. to fully decommission it), use the per-field overrides on `--method=telnet` — see the `setup migrate` section of [CLI-REFERENCE.md](CLI-REFERENCE.md) — which writes over a single telnet connection, no SSH required:
+
+```bash
+soundtouch-cli --host <SPEAKER-IP> setup migrate --method telnet \
+  --service-url https://streaming.bose.com \
+  --marge-url https://streaming.bose.com \
+  --stats-url https://events.api.bosecm.com \
+  --sw-update-url https://worldwide.bose.com/updates/soundtouch \
+  --bmx-url https://content.api.bose.io/bmx/registry/v1/services
+```
+
+### ❌ `setup revert` (or the Admin UI's "Revert to Defaults") fails with "backup .original not found" even though the file exists
+
+**Symptoms:**
+
+- You confirm via a separate SSH session that `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml.original` genuinely exists.
+- `setup revert` (or clicking "Revert to Defaults") still reports `backup .../SoundTouchSdkPrivateCfg.xml.original not found, cannot revert`.
+- A follow-up plain SSH command to the same speaker fails with `Operation timed out` at the TCP level — not an auth or shell error.
+
+**Cause — confirmed on hardware, not yet fixed:** `RevertMigration`'s full call graph opens **17 separate SSH connections** in rapid succession (`pkg/ssh.Client.Run()` dials fresh every call, with no connection reuse across `revertXMLConfig`/`revertHosts`/`revertResolvConf`/`revertAftertouchHook`/`removeRcLocalHooks`/`revertCACert`). Hitting a resource-constrained embedded speaker with that many rapid reconnects can overwhelm it — confirmed on real hardware (2026-08-16), where the speaker became unreachable shortly after. On top of that, `revertXMLConfig`'s error handling collapses *any* non-nil error from its file-existence check into "not found," so a dial failure gets misreported as a missing backup — the message doesn't mean what it says.
+
+**Fix (workaround, until the underlying dial-reuse issue is fixed):** Don't retry `setup revert` back-to-back. If it fails, wait a minute, confirm the speaker is reachable again (`ping`, a single plain `ssh ... echo ok`) before retrying — hammering it again while it's already struggling makes this worse, not better. If all you actually need is to point the speaker's URLs somewhere else (back to AfterTouch, or back to the original Bose cloud), prefer the lighter-weight `setup migrate --method telnet` with explicit URL overrides (previous entry) over a full `setup revert` — it uses one telnet connection instead of 17 SSH connections.
+
 ## 🔊 **Volume & Audio Issues**
 
 ### ❌ "Volume control not working"

--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -672,15 +672,17 @@ soundtouch-cli --host <SPEAKER-IP> setup migrate --method telnet \
 
 ### ❌ `setup revert` (or the Admin UI's "Revert to Defaults") fails with "backup .original not found" even though the file exists
 
+**Status: fixed** (branch `docs-ondevice-install-gaps`, not yet in a numbered release as of this writing) — kept below for anyone hitting this on an older build, and because the underlying "don't hammer a struggling speaker" advice is still good practice generally.
+
 **Symptoms:**
 
 - You confirm via a separate SSH session that `/opt/Bose/etc/SoundTouchSdkPrivateCfg.xml.original` genuinely exists.
 - `setup revert` (or clicking "Revert to Defaults") still reports `backup .../SoundTouchSdkPrivateCfg.xml.original not found, cannot revert`.
 - A follow-up plain SSH command to the same speaker fails with `Operation timed out` at the TCP level — not an auth or shell error.
 
-**Cause — confirmed on hardware, not yet fixed:** `RevertMigration`'s full call graph opens **17 separate SSH connections** in rapid succession (`pkg/ssh.Client.Run()` dials fresh every call, with no connection reuse across `revertXMLConfig`/`revertHosts`/`revertResolvConf`/`revertAftertouchHook`/`removeRcLocalHooks`/`revertCACert`). Hitting a resource-constrained embedded speaker with that many rapid reconnects can overwhelm it — confirmed on real hardware (2026-08-16), where the speaker became unreachable shortly after. On top of that, `revertXMLConfig`'s error handling collapses *any* non-nil error from its file-existence check into "not found," so a dial failure gets misreported as a missing backup — the message doesn't mean what it says.
+**Cause:** `RevertMigration`'s full call graph opened **17 separate SSH connections** in rapid succession (`pkg/ssh.Client.Run()` dialed fresh every call, with no connection reuse across `revertXMLConfig`/`revertHosts`/`revertResolvConf`/`revertAftertouchHook`/`removeRcLocalHooks`/`revertCACert`). Hitting a resource-constrained embedded speaker with that many rapid reconnects could overwhelm it — confirmed on real hardware (2026-08-16), where the speaker became unreachable shortly after. On top of that, `revertXMLConfig`'s error handling collapses *any* non-nil error from its file-existence check into "not found," so a dial failure got misreported as a missing backup — the message didn't mean what it said.
 
-**Fix (workaround, until the underlying dial-reuse issue is fixed):** Don't retry `setup revert` back-to-back. If it fails, wait a minute, confirm the speaker is reachable again (`ping`, a single plain `ssh ... echo ok`) before retrying — hammering it again while it's already struggling makes this worse, not better. If all you actually need is to point the speaker's URLs somewhere else (back to AfterTouch, or back to the original Bose cloud), prefer the lighter-weight `setup migrate --method telnet` with explicit URL overrides (previous entry) over a full `setup revert` — it uses one telnet connection instead of 17 SSH connections.
+**Fix:** `pkg/ssh.Client` now supports an opt-in persistent connection (`Connect()`/`Close()`) that `RevertMigration` uses to collapse those 17 connections into 1 — confirmed on the same real hardware (2026-08-16): a subsequent `setup revert` completed quickly, and the restored config file diffed byte-identical against `.original`. If you're on a build that predates this fix, don't retry `setup revert` back-to-back — if it fails, wait a minute and confirm the speaker is reachable again (`ping`, a single plain `ssh ... echo ok`) before retrying. If all you actually need is to point the speaker's URLs somewhere else (back to AfterTouch, or back to the original Bose cloud), the lighter-weight `setup migrate --method telnet` with explicit URL overrides (previous entry) uses one telnet connection instead of SSH entirely.
 
 ## 🔊 **Volume & Audio Issues**
 

--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -684,6 +684,35 @@ soundtouch-cli --host <SPEAKER-IP> setup migrate --method telnet \
 
 **Fix:** `pkg/ssh.Client` now supports an opt-in persistent connection (`Connect()`/`Close()`) that `RevertMigration` uses to collapse those 17 connections into 1 — confirmed on the same real hardware (2026-08-16): a subsequent `setup revert` completed quickly, and the restored config file diffed byte-identical against `.original`. If you're on a build that predates this fix, don't retry `setup revert` back-to-back — if it fails, wait a minute and confirm the speaker is reachable again (`ping`, a single plain `ssh ... echo ok`) before retrying. If all you actually need is to point the speaker's URLs somewhere else (back to AfterTouch, or back to the original Bose cloud), the lighter-weight `setup migrate --method telnet` with explicit URL overrides (previous entry) uses one telnet connection instead of SSH entirely.
 
+### ❌ On-device install: AfterTouch answers on the speaker but not from other machines on the LAN
+
+**Symptoms:**
+
+- On the speaker itself, `curl http://localhost:8000/health` works and `/etc/init.d/aftertouch status` is green.
+- From any other machine, `http://<speaker-ip>:8000` fails immediately (connection refused/reset, not a timeout).
+- SSH to the same speaker works fine, so it is clearly reachable in general.
+
+**Cause:**
+
+Some SoundTouch chassis carry a BCO ("SMSC") Wi-Fi/Bluetooth co-processor, and inbound LAN traffic reaches the main Linux SoC only for a fixed set of Bose's *own* service ports, a list that appears to be compiled into the co-processor's firmware. AfterTouch's `:8000` was never part of that original design, so the connection never arrives at the SoC at all. Confirmed on an ST20 (`spotty`, FW 27.0.6) in 2026-08: `tcpdump -i eth0` on the speaker saw **zero packets** for `:8000` while Bose's `:8090`/`:8091`/`:17000` answered normally from the same client. This is not a firewall (the speaker's `iptables` is empty) and not a binding problem (the service does listen on `0.0.0.0:8000`).
+
+**Fix:**
+
+The on-device installer handles this automatically: on an affected speaker it redirects a relayed Bose port to AfterTouch, so use:
+
+```
+http://<speaker-ip>:17008
+```
+
+To check or change it, on the speaker:
+
+```bash
+/etc/init.d/aftertouch status              # reports the LAN port when active
+iptables -t nat -S PREROUTING              # shows the redirect rule
+```
+
+Set `AFTERTOUCH_LAN_PORT` in `/opt/aftertouch/aftertouch.conf` to a different port, or to `none` to disable the redirect and use an SSH tunnel instead; then `/etc/init.d/aftertouch restart`. Note that **linking music-service accounts still works best through the tunnel** (`http://localhost:8000`), because Spotify only accepts `https://` or loopback OAuth redirect URIs. If you also run the `streborn` project on the same speaker, note it defaults to the same port, so change one of them. Which models are affected is tracked in [MODEL-SUPPORT-MATRIX.md](../reference/MODEL-SUPPORT-MATRIX.md).
+
 ## 🔊 **Volume & Audio Issues**
 
 ### ❌ "Volume control not working"

--- a/docs/content/docs/reference/MODEL-SUPPORT-MATRIX.md
+++ b/docs/content/docs/reference/MODEL-SUPPORT-MATRIX.md
@@ -1,0 +1,119 @@
+---
+title: "Model Support Matrix"
+---
+A living record of how individual SoundTouch models behave with AfterTouch,
+built up from things actually observed on hardware.
+
+**This table only claims what someone has verified.** Anything not tested is
+marked `?` rather than inferred from a similar-looking model. Bose used
+several different chassis designs across the SoundTouch line, and at least
+one behaviour (LAN reachability, below) differs between them in a way that is
+invisible from the outside. If you have a model that isn't filled in yet,
+[the commands below](#how-to-fill-in-a-row) produce everything a row needs.
+
+## What the columns mean
+
+- **variant / moduleType**: the speaker's own identifiers, straight out of
+  `/info`. `variant` is Bose's internal codename for the product; `moduleType`
+  distinguishes chassis generations (`scm` and `sm2` are the two seen so far).
+- **BCO**: whether the board carries a BCO co-processor (Bose's internal name
+  for the SMSC Wi-Fi/Bluetooth combo chip that also handles AirPlay). Bose's
+  own `has-bco` helper on the device is simply
+  `[ "$(cat /proc/module_type)" = scm ]`.
+- **`:8000` from LAN**: whether AfterTouch's own port is reachable from
+  another machine on the network *without* any workaround.
+- **Entry port**: when `:8000` isn't reachable, the port AfterTouch redirects
+  to itself so the admin UI still works. See
+  [LAN access on co-processor chassis](#lan-access-on-co-processor-chassis).
+
+## Matrix
+
+| Model               | variant  | moduleType | BCO | On-device install | `:8000` from LAN | Entry port | Evidence                                                              |
+|---------------------|----------|------------|-----|-------------------|------------------|------------|-----------------------------------------------------------------------|
+| SoundTouch 20       | `spotty` | `scm`      | yes | works             | ✗ blocked       | `17008`    | verified on hardware 2026-08-16 (FW 27.0.6), redirect survives reboot |
+| SoundTouch 10       | ?        | ?          | ?   | reported working  | ?                | ?          | not tested for LAN reachability                                       |
+| SoundTouch 30       | ?        | ?          | ?   | reported working  | ?                | ?          | not tested for LAN reachability                                       |
+| SoundTouch Portable | ?        | ?          | ?   | ?                 | ?                | ?          | not tested                                                            |
+| Wave / SA-4         | ?        | ?          | ?   | ?                 | ?                | ?          | not tested                                                            |
+
+Not every SoundTouch shares one firmware image, so treat a `?` as genuinely
+unknown. In particular, do not assume a model is unaffected just because it is
+newer or older than a model that is.
+
+## LAN access on co-processor chassis
+
+On chassis with a BCO co-processor, inbound LAN traffic reaches the speaker's
+main Linux SoC only for a fixed set of Bose's *own* service ports. That list
+appears to be compiled into the co-processor's firmware, and AfterTouch's
+`:8000` is not on it, so a connection attempt never arrives at the SoC at
+all. On a verified ST20, `tcpdump -i eth0` on the speaker recorded **zero
+packets** for `:8000` while Bose's `:8090`, `:8091`, `:8200`, `:82`, `:8080`
+and `:17000` all answered normally from the same client.
+
+This is not a firewall, and not something AfterTouch can fix by binding
+differently: the service already listens on `0.0.0.0:8000`, and the speaker's
+`iptables` is empty (there is no `nft` or `ebtables` at all).
+
+The on-device installer works around it by redirecting one of the relayed
+ports to AfterTouch. **Credit for this technique goes to the
+[STR / SoundTouch Reborn](https://github.com/JRpersonal/streborn) project**,
+which documented and shipped it first (their agent uses the same entry port
+for the same reason); finding their prior art is what turned this from an
+apparent hardware dead end into a one-line fix:
+
+```
+iptables -t nat -I PREROUTING 1 ! -i lo -p tcp --dport 17008 -j REDIRECT --to-ports 8000
+```
+
+`17008` is Bose's `SoftwareUpdate` listener. Its cloud service no longer
+exists, so taking over its inbound traffic costs nothing in practice. Only
+external traffic is matched (`! -i lo`), so anything running on the speaker
+still reaches AfterTouch on `:8000` exactly as before.
+
+The rule is re-applied by the init script on every start, so it survives
+reboots (confirmed on the ST20) without any background watchdog. It is
+removed again on `stop` and on uninstall.
+
+The redirect is applied automatically on chassis that need it, and configured
+via `AFTERTOUCH_LAN_PORT` in `/opt/aftertouch/aftertouch.conf`:
+
+| Value      | Effect                                                          |
+|------------|-----------------------------------------------------------------|
+| `auto`     | *(default)* redirect only where the co-processor blocks `:8000` |
+| `none`     | never redirect; use an SSH tunnel instead                       |
+| *(a port)* | always redirect that inbound port to AfterTouch                 |
+
+Two caveats worth knowing:
+
+- **Account linking still prefers the SSH tunnel.** Spotify only accepts
+  `https://` or *loopback* OAuth redirect URIs, so `http://localhost:8000`
+  through a tunnel works for linking where a plain LAN address does not.
+- **The `streborn` project defaults to the same port** for the same reason. If
+  you run both on one speaker, change `AFTERTOUCH_LAN_PORT`.
+
+## How to fill in a row
+
+Run these from a machine on the same network (replace the address), then open
+an issue or PR with the output:
+
+```bash
+# variant, moduleType, and whether an SCM/SMSC component is listed
+curl -s http://<speaker-ip>:8090/info
+
+# is AfterTouch's own port reachable directly? (only meaningful once
+# AfterTouch is installed on the device)
+curl -v --max-time 5 http://<speaker-ip>:8000/health
+
+# which Bose ports the chassis relays at all
+for p in 82 8080 8090 8091 8200 17000 17008; do
+  printf '%s: ' "$p"
+  curl -s -o /dev/null -w '%{http_code}\n' --max-time 3 "http://<speaker-ip>:$p/" || echo unreachable
+done
+```
+
+And on the speaker itself, if you have SSH access:
+
+```bash
+has-bco; echo "has-bco exit status: $?"   # 0 = BCO co-processor present
+cat /proc/module_type /proc/variant
+```

--- a/pkg/service/handlers/handlers_setup_test.go
+++ b/pkg/service/handlers/handlers_setup_test.go
@@ -965,3 +965,9 @@ func (m *mockSSH) UploadContent(content []byte, remotePath string) error {
 
 	return nil
 }
+
+// Connect/Close are no-ops here — the mock has no real connection to
+// reuse, and every test call already goes through Run/UploadContent above
+// regardless of whether Connect was called first.
+func (m *mockSSH) Connect() error { return nil }
+func (m *mockSSH) Close() error   { return nil }

--- a/pkg/service/setup/setup.go
+++ b/pkg/service/setup/setup.go
@@ -124,9 +124,17 @@ type MigrationSummary struct {
 }
 
 // SSHClient defines the interface for SSH operations.
+//
+// Connect/Close are optional: Run/UploadContent both work standalone
+// (dialing their own one-off connection each time, as they always have).
+// Call Connect first when making several calls in a row — e.g.
+// RevertMigration's ~17 commands — so they reuse one connection instead of
+// dialing fresh every time; defer Close to release it afterward.
 type SSHClient interface {
 	Run(command string) (string, error)
 	UploadContent(content []byte, remotePath string) error
+	Connect() error
+	Close() error
 }
 
 // TelnetClient defines the interface for the device's port-17000 diagnostic
@@ -1869,6 +1877,18 @@ func (m *Manager) patchUdhcpcScript(client SSHClient, targetScript, hookMarker s
 // RevertMigration reverts the speaker to its original Bose cloud configuration.
 func (m *Manager) RevertMigration(deviceIP string) (string, error) {
 	client := m.NewSSH(deviceIP)
+
+	// This function alone makes ~17 client.Run/UploadContent calls across
+	// its sub-steps below. Dialing a fresh SSH connection per call (the
+	// default when Connect isn't used) was confirmed on real hardware to
+	// overwhelm a resource-constrained speaker; Connect+defer Close keeps
+	// it to one connection for the whole revert instead.
+	if err := client.Connect(); err != nil {
+		return "", fmt.Errorf("failed to connect for revert: %w", err)
+	}
+
+	defer func() { _ = client.Close() }()
+
 	rwCmd := "(rw || mount -o remount,rw /)"
 
 	var logs string

--- a/pkg/service/setup/setup_test.go
+++ b/pkg/service/setup/setup_test.go
@@ -132,6 +132,12 @@ func (m *mockSSH) UploadContent(content []byte, remotePath string) error {
 	return nil
 }
 
+// Connect/Close are no-ops here — the mock has no real connection to
+// reuse, and every test call already goes through Run/UploadContent above
+// regardless of whether Connect was called first.
+func (m *mockSSH) Connect() error { return nil }
+func (m *mockSSH) Close() error   { return nil }
+
 func TestMigrateViaHosts(t *testing.T) {
 	tempDir, err := os.MkdirTemp("", "setup-test")
 	if err != nil {

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -14,6 +14,15 @@ import (
 type Client struct {
 	Host string
 	User string
+
+	// conn is non-nil once Connect has been called, and is then reused by
+	// Run/UploadContent until Close. Left nil, each Run/UploadContent call
+	// dials its own one-off connection as before — Connect is opt-in for
+	// callers making several calls in a row (e.g. RevertMigration's ~17
+	// commands), where dialing fresh every time is both slow and, on a
+	// resource-constrained speaker, has been observed to overwhelm the
+	// device (#614 self-test, 2026-08-16).
+	conn *ssh.Client
 }
 
 // NewClient creates a new SSH client for the given host. The default user is "root".
@@ -66,21 +75,71 @@ func (c *Client) getConfig() *ssh.ClientConfig {
 	}
 }
 
+// Connect opens a persistent SSH connection reused by subsequent
+// Run/UploadContent calls, instead of each dialing its own. Call Close when
+// done with it. Idempotent — calling Connect again while already connected
+// is a no-op. Skip this for a single (or a rare few) command — dialing
+// once and reusing it is only worth the extra Close bookkeeping when
+// several calls follow in quick succession.
+func (c *Client) Connect() error {
+	if c.conn != nil {
+		return nil
+	}
+
+	conn, err := ssh.Dial("tcp", c.Host+":22", c.getConfig())
+	if err != nil {
+		return fmt.Errorf("failed to dial: %w", err)
+	}
+
+	c.conn = conn
+
+	return nil
+}
+
+// Close closes the persistent connection opened by Connect, if any. Safe
+// to call even when Connect was never called (e.g. every Run/UploadContent
+// call so far used its own one-off connection).
+func (c *Client) Close() error {
+	if c.conn == nil {
+		return nil
+	}
+
+	err := c.conn.Close()
+	c.conn = nil
+
+	return err
+}
+
+// dial returns the persistent connection from Connect if one is open,
+// otherwise dials a fresh one-off connection for the caller to close via
+// the returned closeFunc (a no-op when reusing the persistent connection —
+// that one is only closed by an explicit Close call).
+func (c *Client) dial() (conn *ssh.Client, closeFunc func(), err error) {
+	if c.conn != nil {
+		return c.conn, func() {}, nil
+	}
+
+	conn, err = ssh.Dial("tcp", c.Host+":22", c.getConfig())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to dial: %w", err)
+	}
+
+	return conn, func() { _ = conn.Close() }, nil
+}
+
 // Run executes a command on the remote host and returns the combined stdout and stderr.
 //
 // command MUST be a hardcoded shell literal or constructed entirely from
 // internal, service-controlled values — never from user-supplied HTTP input.
 func (c *Client) Run(command string) (string, error) {
-	config := c.getConfig()
-
-	client, err := ssh.Dial("tcp", c.Host+":22", config)
+	conn, closeConn, err := c.dial()
 	if err != nil {
-		return "", fmt.Errorf("failed to dial: %w", err)
+		return "", err
 	}
 
-	defer func() { _ = client.Close() }()
+	defer closeConn()
 
-	session, err := client.NewSession()
+	session, err := conn.NewSession()
 	if err != nil {
 		return "", fmt.Errorf("failed to create session: %w", err)
 	}
@@ -133,16 +192,14 @@ func (c *Client) ReadDir(remotePath string) (map[string][]byte, error) {
 
 // UploadContent uploads the given content to a file on the remote host using stdin piping.
 func (c *Client) UploadContent(content []byte, remotePath string) error {
-	config := c.getConfig()
-
-	client, err := ssh.Dial("tcp", c.Host+":22", config)
+	conn, closeConn, err := c.dial()
 	if err != nil {
-		return fmt.Errorf("failed to dial: %w", err)
+		return err
 	}
 
-	defer func() { _ = client.Close() }()
+	defer closeConn()
 
-	session, err := client.NewSession()
+	session, err := conn.NewSession()
 	if err != nil {
 		return fmt.Errorf("failed to create session: %w", err)
 	}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -44,3 +44,33 @@ func TestRun_DialFailure(t *testing.T) {
 		t.Errorf("Expected 'failed to dial' error, got: %v", err)
 	}
 }
+
+func TestClose_NoOpWithoutConnect(t *testing.T) {
+	client := NewClient("127.0.0.1")
+
+	if err := client.Close(); err != nil {
+		t.Errorf("Close on a never-connected client should be a no-op, got: %v", err)
+	}
+}
+
+func TestConnect_DialFailureLeavesConnNil(t *testing.T) {
+	client := NewClient("127.0.0.1:0")
+
+	err := client.Connect()
+	if err == nil {
+		t.Fatal("Expected dial failure, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to dial") {
+		t.Errorf("Expected 'failed to dial' error, got: %v", err)
+	}
+
+	if client.conn != nil {
+		t.Error("Connect should leave conn nil after a dial failure, so Run/UploadContent still fall back to their own one-off dial")
+	}
+
+	// Close after a failed Connect should still be a harmless no-op.
+	if err := client.Close(); err != nil {
+		t.Errorf("Close after a failed Connect should be a no-op, got: %v", err)
+	}
+}

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -94,8 +94,10 @@ Run the installer again with the version you want to install. The script backs u
 **Install (or upgrade to) a specific version** — three equivalent ways:
 
 ```bash
-# 1. Environment variable (works when piping into sh)
-VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+# 1. Environment variable — goes on `sh`, not `curl`: in a pipe, each
+#    command is a separate process, so `VERSION=X curl ... | sh` silently
+#    does NOT set it for `sh` (the one that actually reads $VERSION).
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | VERSION=0.123.0 sh
 
 # 2. Command-line flag (pass args after `sh -s --`)
 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -95,14 +95,14 @@ Run the installer again with the version you want to install. The script backs u
 
 ```bash
 # 1. Environment variable (works when piping into sh)
-VERSION=0.111.3 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
+VERSION=0.123.0 rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh
 
 # 2. Command-line flag (pass args after `sh -s --`)
-rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.111.3
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | sh -s -- --version 0.123.0
 
 # 3. Download first, then run with a flag
 curl -sSLo install.sh https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh
-sh install.sh --version 0.111.3
+sh install.sh --version 0.123.0
 ```
 
 Running **without** a version override installs the latest release: the script

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -56,7 +56,53 @@ After the installation check if you can access AfterTouch from your local device
 
 ### If `http://<IP_ADDRESS_OF_SPEAKER>:8000` fails: SSH port forwarding
 
-Some firmware images only bind the AfterTouch HTTP port to loopback (see issue #196). The workaround is an SSH tunnel — your machine talks to its own local `:8000`, the SSH connection forwards to the speaker's `:8000` on loopback.
+On some device models AfterTouch's port is reachable from other machines on
+your LAN out of the box. On others (see issue #196) it isn't, and (unlike
+the phrasing this README used to have) that's not AfterTouch or its
+firewall configuration choosing to bind loopback-only. AfterTouch itself
+binds `0.0.0.0` (all interfaces) correctly, confirmed by inspecting the
+running device directly, and there's no firewall rule (`iptables`,
+`nftables`, or otherwise) blocking it either.
+
+**Current knowledge (2026-08-16), confirmed on real hardware via a
+decrypted firmware backup plus simultaneous packet captures on both the
+speaker and a client machine:** some SoundTouch models built around a
+"combo" WiFi/Bluetooth co-processor (used for AirPlay) route LAN traffic
+through that co-processor before it reaches the main application
+processor where AfterTouch actually runs. That co-processor only relays a
+fixed set of the device's own original service ports (the same ones the
+stock SoundTouch app and companion services always used), a list that,
+as far as we can tell, is compiled into the co-processor's own firmware.
+AfterTouch's ports were never part of that original design, so they never
+got included. This isn't a bug in AfterTouch, a router/firewall setting,
+or WiFi client isolation; all three were separately ruled out.
+
+**The installer works around this automatically.** On an affected speaker
+it redirects one of the ports the co-processor *does* relay to AfterTouch,
+so the UI is reachable from the LAN without any tunnel:
+
+```
+http://<IP_ADDRESS_OF_SPEAKER>:17008
+```
+
+Port `17008` is Bose's software-update listener; that cloud service no
+longer exists, so taking over its inbound traffic costs nothing. Only
+traffic from other machines is affected; anything running on the speaker
+still reaches AfterTouch on `:8000` as before. Change or disable this with
+`AFTERTOUCH_LAN_PORT` (`auto` / `none` / a port number) in
+`/opt/aftertouch/aftertouch.conf`, or pass it at install time:
+
+```bash
+rw && curl -sSL https://raw.githubusercontent.com/gesellix/Bose-SoundTouch/main/scripts/on-device-install/install.sh | AFTERTOUCH_LAN_PORT=none sh
+```
+
+Which models need this, and how to report one that isn't listed yet, is
+tracked in
+[MODEL-SUPPORT-MATRIX.md](../../docs/content/docs/reference/MODEL-SUPPORT-MATRIX.md).
+The SSH tunnel below still works, and remains the better route for
+**linking music-service accounts**: Spotify only accepts `https://` or
+loopback OAuth redirect URIs, so `http://localhost:8000` through a tunnel
+succeeds where a plain LAN address is rejected.
 
 **Open a fresh terminal on your own machine** (Linux/macOS/Windows — NOT another shell inside the speaker's SSH session — see issue #250 for the trap that catches everyone here) and run:
 

--- a/scripts/on-device-install/aftertouch
+++ b/scripts/on-device-install/aftertouch
@@ -15,6 +15,7 @@ DESC="Bose AfterTouch service"
 DAEMON="/opt/aftertouch/aftertouch-service"
 PIDFILE="/var/run/$NAME.pid"
 DATADIR="/opt/aftertouch/data"
+CONFFILE="/opt/aftertouch/aftertouch.conf"
 SCRIPTNAME="/etc/init.d/$NAME"
 USER="root"
 LOG_TAG="aftertouch"
@@ -24,10 +25,120 @@ LOG_TAG="aftertouch"
 export PATH="/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin"
 
 
+# Optional settings written by install.sh (AFTERTOUCH_LAN_PORT, SERVICE_PORT).
+# Sourced before the defaults below so it can override either.
+# shellcheck source=/dev/null
+[ -r "$CONFFILE" ] && . "$CONFFILE"
+
+# Port the daemon binds locally. Kept in one variable because it appears in
+# the daemon arguments, the readiness poll and `status` -- three places that
+# used to hardcode 8000 independently, so changing one silently broke the
+# other two.
+SERVICE_PORT="${SERVICE_PORT:-8000}"
+
+# LAN entry port: a port number, "auto" (default), or "none".
+LAN_PORT_MODE="${AFTERTOUCH_LAN_PORT:-auto}"
+
+
 # Sanity check executable
 test -x "$DAEMON" || {
   echo "ERROR: Cannot execute $DAEMON (check path and permissions)." >&2
   exit 1
+}
+
+
+# ---------------------------------------------------------------------------
+# LAN entry-port redirect
+#
+# On chassis built around a BCO ("SMSC") Wi-Fi/Bluetooth co-processor,
+# inbound LAN traffic only reaches this Linux SoC for a fixed set of Bose's
+# own service ports, which appears to be compiled into the co-processor's
+# firmware. AfterTouch's :8000 is not on that list, so a LAN client's SYN
+# never arrives here at all -- confirmed on an ST20 (`spotty`), where
+# `tcpdump -i eth0` on the speaker saw zero packets for :8000 while Bose's
+# own :8090/:8091/:17000 answered normally from the same client. The usual
+# suspects were all ruled out: the service does bind 0.0.0.0 correctly, the
+# speaker's iptables is empty, and SSH over the same path works.
+#
+# Workaround: NAT one of the relayed Bose ports to ours. The default, 17008,
+# is Bose's SoftwareUpdate listener -- its cloud is gone, so taking over its
+# inbound traffic costs nothing real. Only external traffic is matched
+# (`! -i lo`), so anything running on the speaker still reaches both the real
+# service on loopback and AfterTouch on :8000 as before.
+#
+# Credit: the STR / SoundTouch Reborn project (github.com/JRpersonal/streborn)
+# documented and shipped this REDIRECT technique first, using the same entry
+# port for the same reason.
+#
+# Which models need this is tracked in
+# docs/content/docs/reference/MODEL-SUPPORT-MATRIX.md.
+# ---------------------------------------------------------------------------
+
+# Resolve LAN_PORT_MODE into $LAN_PORT. Returns non-zero when no redirect
+# should be installed.
+lan_redirect_port() {
+    case "$LAN_PORT_MODE" in
+        none|off|disabled|0)
+            return 1
+            ;;
+        auto|"")
+            # Only auto-enable where direct LAN access is known not to work.
+            # has-bco is Bose's own helper: [ "$(cat /proc/module_type)" = scm ]
+            has-bco >/dev/null 2>&1 || return 1
+            LAN_PORT=17008
+            ;;
+        *[!0-9]*)
+            echo "WARNING: ignoring AFTERTOUCH_LAN_PORT='$LAN_PORT_MODE'; expected a port number, 'auto' or 'none'." >&2
+            return 1
+            ;;
+        *)
+            LAN_PORT="$LAN_PORT_MODE"
+            ;;
+    esac
+    return 0
+}
+
+# Remove every PREROUTING rule pointing at our service port, whatever entry
+# port it used, so changing AFTERTOUCH_LAN_PORT cannot orphan the old rule.
+lan_redirect_purge() {
+    iptables -t nat -S PREROUTING 2>/dev/null \
+      | grep -- "--to-ports $SERVICE_PORT" \
+      | sed 's/^-A /-D /' \
+      | while read -r rule; do
+            # shellcheck disable=SC2086
+            iptables -t nat $rule 2>/dev/null || true
+        done
+}
+
+lan_redirect_apply() {
+    lan_redirect_port || return 0
+
+    if ! iptables -t nat -L PREROUTING -n >/dev/null 2>&1; then
+        echo "WARNING: this kernel has no iptables nat table; :$LAN_PORT was not" >&2
+        echo "         redirected. Reach AfterTouch over an SSH tunnel instead." >&2
+        return 0
+    fi
+
+    lan_redirect_purge
+
+    # Safety net for a kernel whose iptables lacks -S (purge would no-op):
+    # without this, every restart would stack another duplicate rule.
+    if iptables -t nat -C PREROUTING ! -i lo -p tcp --dport "$LAN_PORT" \
+         -j REDIRECT --to-ports "$SERVICE_PORT" 2>/dev/null; then
+        echo "LAN access already active on port $LAN_PORT."
+        return 0
+    fi
+
+    if iptables -t nat -I PREROUTING 1 ! -i lo -p tcp --dport "$LAN_PORT" \
+         -j REDIRECT --to-ports "$SERVICE_PORT" 2>/dev/null; then
+        echo "LAN access: port $LAN_PORT now reaches AfterTouch on :$SERVICE_PORT."
+    else
+        echo "WARNING: could not install the :$LAN_PORT -> :$SERVICE_PORT redirect." >&2
+    fi
+}
+
+lan_redirect_remove() {
+    lan_redirect_purge
 }
 
 
@@ -102,19 +213,22 @@ case "$1" in
         --background \
         --chuid "$USER" \
         --startas "/bin/sh" \
-        -- -c "logger -t $LOG_TAG <'$LOGFIFO' & \"$DAEMON\" --data-dir '$DATADIR' --record-interactions=false --discovery-interval=60m >'$LOGFIFO' 2>&1 & echo \$! >'$PIDFILE'; wait"
+        -- -c "logger -t $LOG_TAG <'$LOGFIFO' & \"$DAEMON\" --data-dir '$DATADIR' --port '$SERVICE_PORT' --record-interactions=false --discovery-interval=60m >'$LOGFIFO' 2>&1 & echo \$! >'$PIDFILE'; wait"
 
     tries=0
     max_tries=60
     while [ $tries -lt $max_tries ]; do
-        if curl -fsS http://localhost:8000 >/dev/null 2>&1; then
+        if curl -fsS "http://localhost:$SERVICE_PORT" >/dev/null 2>&1; then
+          # Only once the service actually answers is it worth pointing LAN
+          # traffic at it.
+          lan_redirect_apply
           exit 0
         fi
         sleep 2
         tries=$((tries + 1))
     done
 
-    echo "ERROR: daemon started but http://localhost:8000 never responded within $((max_tries * 2))s." >&2
+    echo "ERROR: daemon started but http://localhost:$SERVICE_PORT never responded within $((max_tries * 2))s." >&2
     echo "       Inspect the daemon's syslog output:" >&2
     echo "         logread | grep $LOG_TAG | tail -20" >&2
     exit 1
@@ -122,6 +236,9 @@ case "$1" in
 
   stop)
     echo "Stopping $DESC..."
+    # Drop the LAN redirect first: leaving it in place while nothing listens
+    # would silently blackhole the entry port.
+    lan_redirect_remove
     if [ -f "$PIDFILE" ]; then
       PID=$(cat "$PIDFILE")
       start-stop-daemon --stop \
@@ -162,11 +279,19 @@ case "$1" in
         # (Gustour's ST30: status said running, curl said
         # connection-refused). Distinguish the two states here so
         # status isn't a false-positive.
-        if curl -fsS --max-time 3 http://localhost:8000 >/dev/null 2>&1; then
-          echo "$NAME is running (PID $PID, http://localhost:8000 responding)."
+        if curl -fsS --max-time 3 "http://localhost:$SERVICE_PORT" >/dev/null 2>&1; then
+          echo "$NAME is running (PID $PID, http://localhost:$SERVICE_PORT responding)."
+          if lan_redirect_port; then
+            if iptables -t nat -C PREROUTING ! -i lo -p tcp --dport "$LAN_PORT" \
+                 -j REDIRECT --to-ports "$SERVICE_PORT" 2>/dev/null; then
+              echo "LAN access: reachable from other machines on port $LAN_PORT."
+            else
+              echo "LAN access: redirect for port $LAN_PORT is NOT installed." >&2
+            fi
+          fi
           exit 0
         else
-          echo "$NAME PID $PID is alive but http://localhost:8000 is not responding." >&2
+          echo "$NAME PID $PID is alive but http://localhost:$SERVICE_PORT is not responding." >&2
           echo "Recent log:" >&2
           logread 2>/dev/null | grep "$LOG_TAG" | tail -10 >&2
           exit 3

--- a/scripts/on-device-install/aftertouch
+++ b/scripts/on-device-install/aftertouch
@@ -42,25 +42,67 @@ case "$1" in
 
     mkdir -p "$DATADIR"
 
-    # Pipe stdout + stderr through `logger -t $LOG_TAG` so the
+    # Route stdout + stderr through `logger -t $LOG_TAG` so the
     # daemon's output lands in busybox syslog (bounded ring buffer,
     # never grows on disk). Users diagnose with:
     #
     #   logread        | grep aftertouch | tail -20
     #   logread -f     | grep aftertouch     # live tail
     #
-    # `exec` on the daemon replaces /bin/sh so --make-pidfile records
-    # the daemon's own PID (not the shell wrapper). The `logger`
-    # process sits on the read end of the pipe and exits cleanly
-    # when the daemon dies and closes its end.
+    # This used to be a `--startas "/bin/sh" -- -c "exec $DAEMON | logger"`
+    # pipeline, on the theory that `exec` replaces /bin/sh so --make-pidfile
+    # records the daemon's own PID. That's wrong for a *piped* command:
+    # POSIX requires each side of a pipe to run in its own forked process,
+    # so the top-level /bin/sh forks two children (one execs into the
+    # daemon, one becomes logger) and stays alive itself, blocked in
+    # wait() -- --make-pidfile recorded *that* wrapper's PID, not the
+    # daemon's. `stop` then killed the wrapper, which doesn't forward
+    # SIGTERM to its children, orphaning the real daemon (reparented to
+    # init) to keep running -- and keep holding :8000 -- forever, silently
+    # surviving every later stop/start/restart.
+    #
+    # A first fix attempt dropped the wrapper shell entirely in favor of
+    # `--exec "$DAEMON"` directly, with a plain shell-level `>FIFO`
+    # redirection on the start-stop-daemon invocation. That broke logging
+    # instead: this busybox's `--background` resets the backgrounded
+    # child's own stdio, ignoring the outer redirection, so the daemon's
+    # output never reached the FIFO -- confirmed on hardware (`logger`
+    # exited immediately with nothing to read, `logread` showed nothing
+    # new).
+    #
+    # This version keeps a wrapper shell -- its *own* FIFO redirection,
+    # set up by its own script logic rather than inherited from outside,
+    # isn't affected by whatever --background did to its stdio -- but has
+    # the wrapper record the daemon's real PID itself instead of trusting
+    # --make-pidfile. $! after a single, non-piped backgrounded command is
+    # portably that command's own PID; --make-pidfile can only ever see
+    # whatever process start-stop-daemon directly forked (the wrapper),
+    # never a PID from inside it.
+    LOGFIFO="/tmp/$NAME.fifo"
+    rm -f "$LOGFIFO"
+    mkfifo "$LOGFIFO"
+
+    # --pidfile (without --make-pidfile, since the wrapper writes it itself
+    # once it knows the daemon's real PID) makes start-stop-daemon's own
+    # "already running?" check keyed on *our* pidfile, not on "/bin/sh"
+    # identity. Without this, --startas "/bin/sh" is itself the match
+    # criterion -- and since the wrapper stays alive for the daemon's whole
+    # lifetime (blocked in its own `wait`), and `stop` only confirms the
+    # *daemon* PID died (not that the wrapper has finished tearing down),
+    # a `restart` firing `start` right after `stop` can catch the previous
+    # wrapper still mid-teardown. start-stop-daemon then silently refuses
+    # ("/bin/sh is already running", swallowed by --quiet) while the
+    # script burns its full 120s timeout waiting for a daemon that was
+    # never launched. Confirmed on hardware: a bare
+    # `start-stop-daemon --startas "/bin/sh" -- -c "echo hi"` was refused
+    # with exactly that message while a prior wrapper was still alive.
     start-stop-daemon --start \
         --quiet \
         --pidfile "$PIDFILE" \
         --background \
-        --make-pidfile \
         --chuid "$USER" \
         --startas "/bin/sh" \
-        -- -c "exec \"$DAEMON\" --data-dir '$DATADIR' --record-interactions=false --discovery-interval=60m 2>&1 | logger -t $LOG_TAG"
+        -- -c "logger -t $LOG_TAG <'$LOGFIFO' & \"$DAEMON\" --data-dir '$DATADIR' --record-interactions=false --discovery-interval=60m >'$LOGFIFO' 2>&1 & echo \$! >'$PIDFILE'; wait"
 
     tries=0
     max_tries=60

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -5,8 +5,10 @@ set -eo pipefail
 #   curl -sSL .../install.sh | sh
 # resolves and installs the latest release automatically (see below).
 #
-# Pin a specific version via environment variable or the --version/-v flag:
-#   VERSION=0.123.0 curl -sSL .../install.sh | sh
+# Pin a specific version via environment variable or the --version/-v flag.
+# The env var goes on `sh`, not `curl`: in a pipe, each command is its own
+# process, so `VERSION=X curl ... | sh` silently does NOT set it for `sh`.
+#   curl -sSL .../install.sh | VERSION=0.123.0 sh
 #   curl -sSL .../install.sh | sh -s -- --version 0.123.0
 VERSION=${VERSION:-}
 

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -138,8 +138,18 @@ mv "$UPDATE_TMP_DIR/init-script" /etc/init.d/aftertouch
 chmod +x /etc/init.d/aftertouch
 update-rc.d aftertouch defaults
 
-echo "Installation complete. Running initial startup..."
-/etc/init.d/aftertouch start
+echo "Installation complete. (Re)starting the service..."
+# Use `restart`, not `start`: if AfterTouch is already running (the normal
+# case for an in-place upgrade or downgrade), `start` calls start-stop-daemon
+# with a pidfile that still points at a live PID. start-stop-daemon then
+# refuses to launch a second instance and exits non-zero -- but this script
+# has no `set -e` here and never checked that exit status, so the old
+# process kept running untouched while the new binary sat unused on disk.
+# The post-install curl check below couldn't catch it either, since the old
+# process kept answering on :8000 throughout. `restart` stops the old
+# process first (a no-op if nothing was running yet, e.g. on a fresh
+# install), guaranteeing the newly-installed binary is the one that starts.
+/etc/init.d/aftertouch restart
 
 /etc/init.d/aftertouch status
 

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -127,6 +127,29 @@ if [ -n "$BACKUP_FILE" ]; then
   echo "Disk usage after GC:"; df -h "$INSTALL_DIR"
 fi
 
+# Settings file sourced by the init script. Written before the service is
+# (re)started so the very first start already sees it.
+#
+# An existing file is left alone on upgrade -- it may carry the operator's own
+# choices -- unless AFTERTOUCH_LAN_PORT was passed to this script explicitly.
+CONF_FILE="$INSTALL_DIR/aftertouch.conf"
+if [ -n "${AFTERTOUCH_LAN_PORT:-}" ] || [ ! -f "$CONF_FILE" ]; then
+  cat > "$CONF_FILE" <<CONFEOF
+# AfterTouch on-device settings. Sourced by /etc/init.d/aftertouch.
+#
+# AFTERTOUCH_LAN_PORT: how AfterTouch is reached from other machines.
+#   auto   (default) redirect a spare Bose port to AfterTouch, but only on
+#          speakers whose Wi-Fi co-processor refuses to pass :8000 through.
+#   none   never redirect; use an SSH tunnel instead.
+#   <port> always redirect this inbound port to AfterTouch.
+# See docs: reference/MODEL-SUPPORT-MATRIX.md
+AFTERTOUCH_LAN_PORT=${AFTERTOUCH_LAN_PORT:-auto}
+CONFEOF
+  echo "Wrote settings to $CONF_FILE (AFTERTOUCH_LAN_PORT=${AFTERTOUCH_LAN_PORT:-auto})"
+else
+  echo "Keeping existing settings in $CONF_FILE"
+fi
+
 echo "Creating init script..."
 curl \
   -sSL \
@@ -162,10 +185,35 @@ echo "Installation complete. (Re)starting the service..."
 # daemon's stdout/stderr through `logger -t aftertouch`, so panics
 # land in busybox syslog and `logread` reads them out.
 if curl -fsS --max-time 10 http://localhost:8000 >/dev/null 2>&1; then
+  # We are running ON the speaker, so print the address people actually need
+  # rather than a <your-device-ip> placeholder they have to resolve themselves.
+  LAN_IP=$(ip -4 addr show scope global 2>/dev/null \
+    | awk '/inet /{sub(/\/.*/,"",$2); print $2; exit}')
+  [ -n "$LAN_IP" ] || LAN_IP="<your-device-ip>"
+
+  # If the init script installed a LAN entry-port redirect, that port -- not
+  # 8000 -- is the one reachable from other machines.
+  LAN_PORT=$(iptables -t nat -S PREROUTING 2>/dev/null \
+    | grep -- '-j REDIRECT' \
+    | sed -n 's/.*--dport \([0-9][0-9]*\).*--to-ports 8000.*/\1/p' \
+    | head -1)
+
+  echo ""
   echo "Installation complete. AfterTouch $VERSION is now running on your device."
-  echo "Connect to http://<your-device-ip>:8000 from another machine on the LAN."
-  echo "If the device doesn't expose :8000 directly, port-forward via SSH:"
-  echo "  ssh -L 8000:localhost:8000 root@<IP_ADDRESS_OF_SPEAKER>"
+  echo ""
+  if [ -n "$LAN_PORT" ]; then
+    echo "  Open  http://$LAN_IP:$LAN_PORT  from any machine on your network."
+    echo ""
+    echo "  (This speaker's Wi-Fi co-processor does not pass port 8000 through to"
+    echo "   AfterTouch, so port $LAN_PORT is redirected to it instead. Set"
+    echo "   AFTERTOUCH_LAN_PORT in $CONF_FILE to change or disable this.)"
+  else
+    echo "  Open  http://$LAN_IP:8000  from any machine on your network."
+  fi
+  echo ""
+  echo "If that doesn't load, reach it through an SSH tunnel instead:"
+  echo "  ssh -oHostKeyAlgorithms=+ssh-rsa -L 8000:localhost:8000 root@$LAN_IP"
+  echo "then open http://localhost:8000"
 else
   echo "WARNING: the init script reports AfterTouch as running, but" >&2
   echo "  http://localhost:8000 isn't responding. The daemon may have" >&2

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -6,13 +6,13 @@ set -eo pipefail
 # resolves and installs the latest release automatically (see below).
 #
 # Pin a specific version via environment variable or the --version/-v flag:
-#   VERSION=0.111.3 curl -sSL .../install.sh | sh
-#   curl -sSL .../install.sh | sh -s -- --version 0.111.3
+#   VERSION=0.123.0 curl -sSL .../install.sh | sh
+#   curl -sSL .../install.sh | sh -s -- --version 0.123.0
 VERSION=${VERSION:-}
 
 # Parse optional command-line arguments so the script can be invoked as:
-#   install.sh --version 0.111.3
-#   install.sh -v 0.111.3
+#   install.sh --version 0.123.0
+#   install.sh -v 0.123.0
 while [ $# -gt 0 ]; do
   case "$1" in
     --version|-v)
@@ -29,7 +29,7 @@ GH_REPO=${GH_REPO:-gesellix/Bose-SoundTouch}
 
 # Used only when the latest-release lookup fails (offline / rate-limited /
 # a curl without -w support).
-FALLBACK_VERSION=${FALLBACK_VERSION:-0.111.3}
+FALLBACK_VERSION=${FALLBACK_VERSION:-0.123.0}
 
 # Resolve the latest release when no explicit version was provided, by
 # following the stable redirect https://github.com/<repo>/releases/latest

--- a/scripts/on-device-install/uninstall.sh
+++ b/scripts/on-device-install/uninstall.sh
@@ -5,6 +5,18 @@
 set -eu
 
 /etc/init.d/aftertouch stop || true
+
+# `stop` normally removes the LAN entry-port redirect. Repeat it directly in
+# case the init script was already gone or failed, so no rule is left behind
+# pointing at a service that no longer exists.
+iptables -t nat -S PREROUTING 2>/dev/null \
+  | grep -- '--to-ports 8000' \
+  | sed 's/^-A /-D /' \
+  | while read -r rule; do
+        # shellcheck disable=SC2086
+        iptables -t nat $rule 2>/dev/null || true
+    done
+
 rm -f /etc/init.d/aftertouch
 update-rc.d -f aftertouch remove
 

--- a/scripts/raspberry-pi/README.md
+++ b/scripts/raspberry-pi/README.md
@@ -31,8 +31,8 @@ Both install the **latest release** by default (resolved from GitHub's
 specific release:
 
 ```bash
-sudo bash install.sh v0.111.3
-sudo bash install-player.sh v0.111.3
+sudo bash install.sh v0.123.0
+sudo bash install-player.sh v0.123.0
 ```
 
 ## Removal

--- a/scripts/raspberry-pi/install-player.sh
+++ b/scripts/raspberry-pi/install-player.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Examples (override defaults via env vars):
 #
 #   sudo \
-#     VERSION=v0.111.3 \
+#     VERSION=v0.123.0 \
 #     HTTP_PORT=8081 \
 #     bash install-player.sh
 #
@@ -21,7 +21,7 @@ set -euo pipefail
 #     bash install-player.sh
 #
 # Or with a version argument to perform an update:
-#   sudo bash install-player.sh v0.111.3
+#   sudo bash install-player.sh v0.123.0
 #
 # Notes:
 # - This script downloads a release binary for your CPU (auto-detects armv7/arm64/amd64).
@@ -41,7 +41,7 @@ if [[ -n "$VERSION" && ! "$VERSION" =~ ^v ]]; then
 fi
 GH_REPO="${GH_REPO:-gesellix/Bose-SoundTouch}"
 # Used only when the latest-release lookup fails (offline / rate-limited).
-FALLBACK_VERSION="${FALLBACK_VERSION:-v0.111.3}"
+FALLBACK_VERSION="${FALLBACK_VERSION:-v0.123.0}"
 SERVICE_NAME="${SERVICE_NAME:-soundtouch-player}"
 BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-player}"
 

--- a/scripts/raspberry-pi/install.sh
+++ b/scripts/raspberry-pi/install.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Examples (override defaults via env vars):
 #
 #   sudo \
-#     VERSION=v0.111.3 \
+#     VERSION=v0.123.0 \
 #     HOSTNAME_FQDN=soundtouch.local \
 #     HTTP_PORT=80 \
 #     HTTPS_PORT=443 \
@@ -18,7 +18,7 @@ set -euo pipefail
 #     bash install.sh
 #
 # Or with a version argument to perform an update:
-#   sudo bash install.sh v0.111.3
+#   sudo bash install.sh v0.123.0
 #
 # Notes:
 # - This script downloads a release binary for your CPU (auto-detects armv7/arm64/amd64).
@@ -37,7 +37,7 @@ if [[ -n "$VERSION" && ! "$VERSION" =~ ^v ]]; then
 fi
 GH_REPO="${GH_REPO:-gesellix/Bose-SoundTouch}"
 # Used only when the latest-release lookup fails (offline / rate-limited).
-FALLBACK_VERSION="${FALLBACK_VERSION:-v0.111.3}"
+FALLBACK_VERSION="${FALLBACK_VERSION:-v0.123.0}"
 SERVICE_NAME="${SERVICE_NAME:-soundtouch-service}"
 BIN_PATH="${BIN_PATH:-/usr/local/bin/soundtouch-service}"
 
@@ -122,7 +122,7 @@ detect_arch_asset() {
 download_url_for() {
   local asset="$1"
   # Release asset pattern used by you earlier:
-  # soundtouch-service-v0.111.3-linux-armv7
+  # soundtouch-service-v0.123.0-linux-armv7
   echo "https://github.com/gesellix/Bose-SoundTouch/releases/download/${VERSION}/soundtouch-service-${VERSION}-${asset}"
 }
 


### PR DESCRIPTION
## Summary

Started as a #614 self-test guide and a hunt for on-device install doc gaps.
Running that guide against a real ST20 turned up a chain of genuine bugs,
and finally the root cause of a long-standing mystery (#196), so the branch
grew well past its original scope.

### Headline: on-device AfterTouch is reachable from the LAN, no SSH tunnel

`#196`/disc `#490` have been open since the on-device installer existed:
`:8000` works on the speaker but not from any other machine. The docs blamed
loopback-only binding. That was wrong.

Root cause, confirmed on hardware: some SoundTouch chassis carry a BCO
("SMSC") Wi-Fi/Bluetooth co-processor, and inbound LAN traffic reaches the
main Linux SoC **only for a fixed set of Bose's own original service ports**,
apparently compiled into the co-processor firmware. AfterTouch's `:8000` was
never part of that design, so connections never arrive at the SoC at all. A
port sweep from a LAN client showed Bose's `:82`/`:8080`/`:8090`/`:8091`/
`:8200`/`:17000` all answering while `:8000` failed, and `tcpdump -i eth0`
**on the speaker** recorded zero packets for it. Ruled out along the way:
iptables (empty), nft/ebtables (absent), the router, Wi-Fi client isolation,
and the binding itself (`0.0.0.0` is correct).

Fix: the init script installs a NAT redirect from a relayed Bose port, so
**`http://<speaker-ip>:17008`** just works. `17008` is Bose's software-update
listener, whose cloud no longer exists. Only external traffic is matched
(`! -i lo`), so anything on the speaker still reaches `:8000` as before.
Auto-enabled only where `has-bco` reports the co-processor; configurable via
`AFTERTOUCH_LAN_PORT` (`auto`/`none`/port) in `aftertouch.conf`. Applied on
`start`, removed on `stop`/uninstall, so no watchdog process is needed;
unlike prior art it is not pinned to the LAN IP, so it also survives DHCP
changes.

**Credit:** the REDIRECT technique comes from the
[STR / SoundTouch Reborn](https://github.com/JRpersonal/streborn) project,
which documented and shipped it first on the same entry port. Finding their
prior art is what turned this from an apparent hardware dead end into a
one-line fix. Credited in the root README, the new matrix doc, and the init
script.

### Two on-device install bugs found while testing

- **`VERSION=X curl ... | sh` silently ignored the pin.** Variable-assignment
  prefixes apply only to the command they're attached to; in a pipe each
  command is its own process, so `VERSION` reached `curl` (which ignores it),
  not `sh` (which reads it). Attempting to pin `v0.123.0` installed latest
  instead. Fixed everywhere it appeared.
- **Re-running the installer never replaced the running process.** The new
  binary landed on disk but the old one kept serving `:8000` indefinitely,
  including after a manual restart. Three stacked causes: `install.sh` called
  `start` rather than `restart` and never checked its exit status; the init
  script's `sh -c "exec ... | logger"` pipeline made `--make-pidfile` record
  the *wrapper's* PID, so `stop` killed the wrapper and orphaned the real
  daemon; and once that was fixed, `start-stop-daemon`'s "already running?"
  check matched on generic `/bin/sh` identity, letting a restart silently
  refuse to launch. Not downgrade-specific: this affected every in-place
  upgrade.

### New `soundtouch-cli` commands

- `setup sync` wraps `POST /api/setup/sync/{deviceId}` (the web UI's Sync
  Data button). Read-only towards the speaker.
- `setup revert` wraps `RevertMigration` (the "Revert to Defaults" button).
  Deliberately leaves SSH persistence and pairing alone, matching the button.
- `setup migrate` gained `--marge-url`/`--stats-url`/`--sw-update-url`/
  `--bmx-url`. The plumbing already existed but wasn't exposed. Used on real
  hardware to recover a speaker stuck on the `aftertouch.invalid` placeholder
  that `enable-ssh` leaves behind when run without `--service-url`.

### SSH connection reuse

`RevertMigration` opened **17 separate SSH connections** per call (every
`pkg/ssh.Client.Run` dialled fresh). On a resource-constrained speaker that
was enough to make it briefly unreachable, and a dial failure was reported as
the misleading "backup `.original` not found". Added an opt-in persistent
connection (`Connect`/`Close`) that collapses those 17 into 1; the ~21 other
call sites are untouched since they never call `Connect`.

### Documentation

- **New `reference/MODEL-SUPPORT-MATRIX.md`.** The repo had no per-model
  compatibility record, yet the LAN behaviour above is entirely
  chassis-dependent. Only the verified ST20 row is filled in; everything else
  is marked unknown rather than inferred, with self-serve commands so
  reporters can fill in their own model.
- `ON-DEVICE-INSTALL-WALKTHROUGH.md` never showed the Migrate step at all,
  jumping from install straight to the pairing QuickFix as if the speaker
  were already pointed at itself. Added it, plus a no-USB-stick `enable-ssh`
  alternative (#471) and a pre-release-build section.
- `MIGRATION-GUIDE.md`'s "never use `localhost`" warning had no on-device
  exception, though loopback is exactly right there.
- `DEVICE-INITIAL-SETUP.md`'s AP-mode commands were macOS-only; added
  `nmcli`/`netsh wlan`.
- `CLI-REFERENCE.md`'s entire `setup` group was undocumented (`--help` was
  the only reference); wrote up all 16 subcommands plus `account unpair`.
- `TROUBLESHOOTING.md`: the `aftertouch.invalid` gotcha, the SSH dial-storm,
  and the new `:8000`-vs-`:17008` entry.

A separate first commit bumps stale `0.111.x`-era example versions.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run ./...`
- [x] `go test ./cmd/soundtouch-cli/... ./pkg/service/setup/... ./pkg/ssh/...`
- [x] `sh -n` / `bash -n` on all on-device scripts
- [x] Real hardware (ST20 `spotty`, FW 27.0.6): `setup sync`/`setup revert`,
      SSH connection reuse (restored config byte-identical to `.original`),
      `setup migrate` URL overrides, the `VERSION=` fix, and the restart fix
- [x] LAN redirect on hardware: auto-detection, idempotency across repeated
      restarts (exactly one rule), `stop`/`start` teardown and restore,
      **persistence across a full power-cycle**, and `curl :17008/health`
      returning the service JSON
- [ ] Any chassis other than the ST20 (see the matrix; unknowns are marked)