### PR TITLE
docs: fix two broken links to the model support matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ See the [API Reference](https://gesellix.github.io/Bose-SoundTouch/docs/referenc
 - **[SoundTouch Plus](https://github.com/thlucas1/homeassistantcomponent_soundtouchplus)** (Todd Lucas) — Home Assistant integration; extensive undocumented API documentation
 - **[ÜberBöse API](https://github.com/julius-d/ueberboese-api)** (Julius) — API research and advanced endpoint discovery
 - **[Bose SoundTouch Hook](https://github.com/CodeFinder2/bose-soundtouch-hook)** (Adrian Böckenkamp) — `LD_PRELOAD` hooking for reverse engineering device internals
-- **[STR, SoundTouch Reborn](https://github.com/JRpersonal/streborn)** ([st-reborn.de](https://st-reborn.de)) — on-device agent plus desktop app; its published `iptables` REDIRECT technique is what makes AfterTouch's on-device install reachable over the LAN on co-processor chassis (see [Model Support Matrix](https://gesellix.github.io/Bose-SoundTouch/docs/reference/model-support-matrix/))
+- **[STR, SoundTouch Reborn](https://github.com/JRpersonal/streborn)** ([st-reborn.de](https://st-reborn.de)) — on-device agent plus desktop app; its published `iptables` REDIRECT technique is what makes AfterTouch's on-device install reachable over the LAN on co-processor chassis (see [Model Support Matrix](https://gesellix.github.io/Bose-SoundTouch/docs/reference/MODEL-SUPPORT-MATRIX/))
 
 ---
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -160,7 +160,7 @@ browser.
 > so the Admin UI is reachable from the LAN without any tunnel. Check with
 > `/etc/init.d/aftertouch status` on the speaker, which reports the LAN port
 > when the redirect is active. Details and per-model status:
-> [Model Support Matrix](../../reference/MODEL-SUPPORT-MATRIX/).
+> [Model Support Matrix](../reference/MODEL-SUPPORT-MATRIX.md).
 >
 > Keep the tunnel in mind anyway for **linking music-service accounts**:
 > Spotify only accepts `https://` or *loopback* OAuth redirect URIs, so


### PR DESCRIPTION
## Summary

Two broken links to the new Model Support Matrix, both introduced in #619.

- **`README.md`** pointed at a lowercased URL. The site sets
  `disablePathToLower = true`, so published URLs keep the source filename's
  case; every other link in that README already does this
  (`API-ENDPOINTS/`, `CLI-REFERENCE/`). This is the 404 that was reported.
- **`ON-DEVICE-INSTALL-WALKTHROUGH.md`** was wrong in a different way:
  `../../reference/MODEL-SUPPORT-MATRIX/` instead of
  `../reference/MODEL-SUPPORT-MATRIX.md`, i.e. wrong depth *and* missing
  extension, versus the convention used by other cross-links from `guides/`.

The two remaining links to the same document (`TROUBLESHOOTING.md` and
`scripts/on-device-install/README.md`) were already correct.

## Test plan
- [x] Confirmed the working URL resolves:
      https://gesellix.github.io/Bose-SoundTouch/docs/reference/MODEL-SUPPORT-MATRIX/
- [x] Verified both relative links resolve to the real file on disk
- [x] Swept the repo for other published-site links with a lowercased final
      path segment; none found