### PR TITLE
docs(readme): remove obsolete Go Report Card badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 <p style="margin-top: -10px; font-style: italic; color: #666;">Bose SoundTouch Toolkit</p>
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/gesellix/bose-soundtouch.svg)](https://pkg.go.dev/github.com/gesellix/bose-soundtouch)
-[![Go Report Card](https://goreportcard.com/badge/github.com/gesellix/bose-soundtouch)](https://goreportcard.com/report/github.com/gesellix/bose-soundtouch)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 > Independent project. **Not affiliated with, endorsed by, sponsored


### PR DESCRIPTION
## Summary
- Removes the Go Report Card badge from README.md; the linked report (https://goreportcard.com/report/github.com/gesellix/bose-soundtouch) is obsolete for this project.

## Test plan
- [x] Confirmed no other references to goreportcard in the repo (docs/HTML/YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)