### PR TITLE
fix(admin-ui): make Migration tab actions consistently reachable

### DIFF
--- a/pkg/service/handlers/web/css/style.css
+++ b/pkg/service/handlers/web/css/style.css
@@ -129,6 +129,20 @@ pre { background-color: #eee; padding: 10px; overflow-x: auto; font-size: 12px; 
     background-color: #d32f2f;
 }
 
+/* .btn-primary marks the one "do the thing" confirm action of a panel
+   (Save Settings, Apply Suggested/Custom Plan, Enable SSH, …). Everything
+   else stays the plain default button so color consistently signals the
+   same two meanings everywhere: primary = confirm, danger = destructive. */
+.btn-primary {
+    background-color: #2196f3;
+    color: white;
+    border: none;
+    padding: 5px 10px;
+}
+.btn-primary:hover {
+    background-color: #1769aa;
+}
+
 .badge {
     padding: 2px 6px;
     border-radius: 4px;

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -533,7 +533,7 @@
         </div>
 
         <div style="margin-bottom: 20px">
-            <button onclick="updateSettings()">Save Settings</button>
+            <button class="btn-primary" onclick="updateSettings()">Save Settings</button>
             <span
                 id="settings-status"
                 style="margin-left: 10px; font-size: 0.9em"
@@ -691,9 +691,27 @@
             class="summary-box"
             style="display: none"
         >
-            <h3>
-                Migration Summary for
-                <span id="summary-device-display"></span>
+            <h3 style="display: flex; align-items: baseline; justify-content: space-between">
+                <span>
+                    Migration Summary for
+                    <span id="summary-device-display"></span>
+                </span>
+                <span style="display: flex; gap: 6px">
+                    <button
+                        type="button"
+                        onclick="refreshSummary()"
+                        title="Reload summary for this device"
+                        aria-label="Reload summary"
+                        style="padding: 2px 8px; font-size: 0.85em; line-height: 1; cursor: pointer; font-weight: normal"
+                    >&#x21bb; Reload</button>
+                    <button
+                        type="button"
+                        onclick="document.getElementById('migration-summary').style.display = 'none'"
+                        title="Hide this summary — doesn't change anything on the speaker"
+                        aria-label="Hide summary"
+                        style="padding: 2px 8px; font-size: 0.85em; line-height: 1; cursor: pointer; font-weight: normal"
+                    >&#x2715; Hide</button>
+                </span>
             </h3>
             <input type="hidden" id="summary-device-id"/>
             <p>Migration Status: <span id="migration-status"></span></p>
@@ -739,7 +757,8 @@
                                         <button
                                             id="trust-ca-btn"
                                             type="button"
-                                            style="display: none; background-color: #607d8b; color: white; border: none; padding: 2px 8px; font-size: 0.85em"
+                                            class="btn-primary"
+                                            style="display: none; padding: 2px 8px; font-size: 0.85em"
                                         >Trust CA Now</button>
                                         <a
                                             href="/setup/ca.crt"
@@ -760,7 +779,24 @@
                         <tbody>
                             <tr style="border-top: 1px solid #eee">
                                 <td style="padding: 4px 8px; width: 170px; color: #555" title="The remote_services file controls whether SSH is available after reboot">SSH (remote_services)</td>
-                                <td id="state-remote-services-cell" style="padding: 4px 8px"></td>
+                                <td id="state-remote-services-cell" style="padding: 4px 8px">
+                                    <span id="state-remote-services-line"></span>
+                                    <span style="margin-left: 12px; white-space: nowrap">
+                                        <button
+                                            id="ensure-remote-btn"
+                                            type="button"
+                                            class="btn-primary"
+                                            style="padding: 2px 8px; font-size: 0.85em"
+                                        >Enable SSH (Persist remote_services)</button>
+                                        <button
+                                            id="remove-remote-btn"
+                                            type="button"
+                                            class="btn-danger"
+                                            title="Removes the remote_services file — SSH will be disabled after the next reboot"
+                                            style="margin-left: 6px; padding: 2px 8px; font-size: 0.85em"
+                                        >Disable SSH (Remove remote_services)</button>
+                                    </span>
+                                </td>
                             </tr>
                             <tr style="border-top: 1px solid #eee">
                                 <td style="padding: 4px 8px; color: #555">Account paired</td>
@@ -772,6 +808,30 @@
                             </tr>
                         </tbody>
                     </table>
+                </div>
+            </div>
+
+            <!-- Speaker controls: real device actions that don't depend on
+                 the Customize form below, kept always visible rather than
+                 behind its collapse (see #621 — Reboot was previously
+                 reachable only after expanding "Customize this migration"
+                 and scrolling past it). -->
+            <div style="margin: 0 0 16px 0">
+                <h4 style="margin: 0 0 6px 0; font-size: 0.95em">Speaker controls</h4>
+                <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap">
+                    <button
+                        id="revert-migrate-btn"
+                        class="btn-danger"
+                        style="padding: 10px 20px; display: none"
+                    >
+                        Revert to Defaults
+                    </button>
+                    <button
+                        id="reboot-speaker-btn"
+                        style="padding: 10px 20px"
+                    >
+                        Reboot Speaker
+                    </button>
                 </div>
             </div>
 
@@ -819,25 +879,13 @@
                 <div style="margin-top: 10px">
                     <button
                         id="test-connection-explicit-btn"
-                        style="
-                                    background-color: #607d8b;
-                                    color: white;
-                                    border: none;
-                                    padding: 5px 10px;
-                                    font-size: 0.9em;
-                                "
+                        style="font-size: 0.9em"
                     >
                         Test with Explicit CA.crt
                     </button>
                     <button
                         id="test-connection-trusted-btn"
-                        style="
-                                    background-color: #607d8b;
-                                    color: white;
-                                    border: none;
-                                    padding: 5px 10px;
-                                    font-size: 0.9em;
-                                "
+                        style="font-size: 0.9em"
                     >
                         Test with Shared Trust Store
                     </button>
@@ -879,13 +927,7 @@
                 <div style="margin-top: 10px">
                     <button
                         id="test-dns-btn"
-                        style="
-                                    background-color: #28a745;
-                                    color: white;
-                                    border: none;
-                                    padding: 5px 10px;
-                                    font-size: 0.9em;
-                                "
+                        style="font-size: 0.9em"
                     >
                         Test DNS Redirection
                     </button>
@@ -1067,6 +1109,7 @@
                         <button
                             type="button"
                             id="plan-apply-btn"
+                            class="btn-primary"
                             onclick="applySuggestedPlan()"
                             style="font-size: 0.95em"
                         >Apply Suggested Plan</button>
@@ -1150,8 +1193,9 @@
                     <button
                         type="button"
                         id="customize-apply-btn"
+                        class="btn-primary"
                         onclick="applyCustomPlan()"
-                        style="background-color: #4caf50; color: white; border: none; padding: 8px 14px; font-size: 0.95em"
+                        style="padding: 8px 14px; font-size: 0.95em"
                     >Apply Custom Plan</button>
                     <span id="customize-apply-status" style="margin-left: 10px; font-size: 0.9em"></span>
                 </div>
@@ -1235,64 +1279,6 @@
                         Root CA.
                     </div>
                 </div>
-            </div>
-            <div style="margin-top: 15px">
-                <button
-                    id="revert-migrate-btn"
-                    style="
-                                background-color: #ff9800;
-                                color: white;
-                                border: none;
-                                padding: 10px 20px;
-                                display: none;
-                            "
-                >
-                    Revert to Defaults
-                </button>
-                <button
-                    id="reboot-speaker-btn"
-                    style="
-                                background-color: #607d8b;
-                                color: white;
-                                border: none;
-                                padding: 10px 20px;
-                            "
-                >
-                    Reboot Speaker
-                </button>
-                <button
-                    id="ensure-remote-btn"
-                    style="
-                                background-color: #2196f3;
-                                color: white;
-                                border: none;
-                                padding: 10px 20px;
-                            "
-                >
-                    Enable SSH (Persist remote_services)
-                </button>
-                <button
-                    id="remove-remote-btn"
-                    title="Removes the remote_services file — SSH will be disabled after the next reboot"
-                    style="
-                                background-color: #f44336;
-                                color: white;
-                                border: none;
-                                padding: 10px 20px;
-                            "
-                >
-                    Disable SSH (Remove remote_services)
-                </button>
-                <button
-                    onclick="
-                                document.getElementById(
-                                    'migration-summary',
-                                ).style.display = 'none'
-                            "
-                    style="padding: 10px 20px"
-                >
-                    Cancel
-                </button>
             </div>
             </details>
         </div>

--- a/pkg/service/handlers/web/index.html
+++ b/pkg/service/handlers/web/index.html
@@ -868,7 +868,9 @@
                             background-color: #eefbff;
                         "
             >
-                <strong>HTTPS Connection Test:</strong><br/>
+                <strong>HTTPS Connection Test:</strong>
+                <span id="connection-test-relevance-note" style="font-size: 0.85em"></span>
+                <br/>
                 <span style="font-size: 0.85em; color: #555"
                 >Verify the device can reach the server over
                             HTTPS.</span

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -2096,7 +2096,7 @@ async function showSummary(deviceId) {
             if (accountIdEl && summary.account_id) accountIdEl.innerText = summary.account_id;
         }
 
-        renderMigrationState(summary);
+        renderMigrationState(summary, targetUrl);
         renderPlan(summary);
         renderPlanCurrentURLs(summary);
         renderPlanPairing(summary, deviceId);
@@ -2148,6 +2148,20 @@ async function showSummary(deviceId) {
         const connectionTestPane = document.getElementById("connection-test");
         if (connectionTestPane) {
             connectionTestPane.style.display = summary.ssh_success ? "block" : "none";
+        }
+
+        // Stays visible either way (the user may still want to check it),
+        // but the default Suggested Plan never needs HTTPS — only note it
+        // as required when the Target URL itself is https://.
+        const connectionTestNote = document.getElementById("connection-test-relevance-note");
+        if (connectionTestNote) {
+            if (isHttpsTarget(targetUrl)) {
+                connectionTestNote.innerText = "Required for your current plan (HTTPS)";
+                connectionTestNote.style.color = "#c62828";
+            } else {
+                connectionTestNote.innerText = "Optional for your current plan (HTTP)";
+                connectionTestNote.style.color = "#666";
+            }
         }
 
         const currentConfigElem = document.getElementById("current-config");
@@ -3826,7 +3840,11 @@ function looksTransient(msg) {
 // DNS interception, CA/TLS), and preconditions (remote_services,
 // pairing, backup). Reads only fields the backend already exposes —
 // is_migrated remains the OR of the per-axis booleans.
-function renderMigrationState(summary) {
+//
+// targetUrl is the current Target Domain value, used only to judge
+// whether CA/TLS is actually relevant to the current plan (see
+// isHttpsTarget) — the default Suggested Plan never needs it.
+function renderMigrationState(summary, targetUrl) {
     // --- Transports ---
     setStateChip("state-ssh", summary.ssh_success, "Reachable", "Unreachable");
     setStateChip("state-telnet", summary.telnet_reachable, "Reachable", "Unreachable");
@@ -3907,7 +3925,7 @@ function renderMigrationState(summary) {
     const caLine = document.getElementById("state-ca-line");
     if (caLine) {
         caLine.replaceChildren();
-        const v = caVerdict(summary);
+        const v = caVerdict(summary, isHttpsTarget(targetUrl));
         caLine.appendChild(stateLine(v.icon, v.text, v.note));
     }
 
@@ -4041,9 +4059,22 @@ function dnsInterceptionVerdict(summary) {
     return {icon: "⚠️", text: "/etc/hosts redirects", note: "(deprecated method)"};
 }
 
-function caVerdict(summary) {
+// isHttpsTarget reports whether a target/service URL uses the https
+// scheme. Used to distinguish "CA/TLS optional" (the default Suggested
+// Plan for both XML-over-SSH and Telnet migrates over plain HTTP, no CA
+// involved) from "CA/TLS required" (Target Domain is https://, or the
+// Customize form's DNS-interception method is chosen — that one always
+// targets https://*.bose.com).
+function isHttpsTarget(url) {
+    return /^https:/i.test((url || "").trim());
+}
+
+function caVerdict(summary, httpsRelevant) {
     if (summary.ca_cert_trusted) return {icon: "✅", text: "Local root CA installed", note: ""};
-    return {icon: "❌", text: "Not installed", note: "(HTTPS to local service will fail TLS validation until injected via SSH)"};
+    if (httpsRelevant) {
+        return {icon: "❌", text: "Not installed", note: "(required — your Target URL is HTTPS; install it before migrating, or click Trust CA Now)"};
+    }
+    return {icon: "⚪", text: "Not installed", note: "(not needed — your Target URL is HTTP; only required if you switch to HTTPS or use the DNS-interception method)"};
 }
 
 function remoteServicesVerdict(summary) {

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -2558,17 +2558,14 @@ async function migrate(deviceId, ip, method) {
                 }),
             );
 
-            // Make reboot button available and prominent
+            // Make reboot button available and prominent. It lives in the
+            // always-visible "Speaker controls" row (see #621 — it used to
+            // be reachable only after expanding "Customize this migration"),
+            // so no need to force any collapsed container open here.
             const rebootBtn = document.getElementById("reboot-speaker-btn");
             rebootBtn.style.display = "inline-block";
             rebootBtn.disabled = false;
             rebootBtn.style.border = "2px solid #000";
-
-            // The Reboot button now lives inside the "Customize this
-            // migration" <details>; expand it so the post-migration
-            // reboot affordance is reachable from the Plan flow too.
-            const customize = rebootBtn.closest("details");
-            if (customize) customize.open = true;
 
             // Re-show summary but with prominence on reboot
             summaryDiv.style.display = "block";
@@ -3915,11 +3912,14 @@ function renderMigrationState(summary) {
     }
 
     // --- Preconditions ---
-    const remoteCell = document.getElementById("state-remote-services-cell");
-    if (remoteCell) {
-        remoteCell.replaceChildren();
+    // Like CA/TLS above, the cell also hosts the Enable/Disable SSH
+    // buttons as siblings of this line — only rewrite the verdict span so
+    // they stay put across re-renders.
+    const remoteLine = document.getElementById("state-remote-services-line");
+    if (remoteLine) {
+        remoteLine.replaceChildren();
         const v = remoteServicesVerdict(summary);
-        remoteCell.appendChild(stateLine(v.icon, v.text, v.note));
+        remoteLine.appendChild(stateLine(v.icon, v.text, v.note));
     }
 
     const pairedCell = document.getElementById("state-paired");


### PR DESCRIPTION
## Summary
- Follow-up on #621: Reboot Speaker (plus Revert to Defaults, Enable SSH, Disable SSH) was reachable only after expanding the collapsed "Customize this migration" section and scrolling past three fieldsets and the XML/telnet diff panes, while every other real action elsewhere in the admin UI is visible by default.
- Moved Revert to Defaults and Reboot Speaker into an always-visible "Speaker controls" row directly under the Migration State card.
- Moved Enable/Disable SSH into the Preconditions table, inline with the SSH (remote_services) status row, sized like the existing "Trust CA Now" button next to the CA/TLS row.
- Added shared `.btn-primary`/`.btn-danger` CSS classes so button color consistently means the same thing everywhere (primary = confirm, danger = destructive) instead of ad-hoc inline colors.
- Replaced the "Cancel" button (which only hid the whole summary panel, not any of the actions it sat beside) with a "✕ Hide" control next to the "Migration Summary for `<device>`" heading, plus a "↻ Reload" shortcut.
- Removed the now-unneeded force-open-the-details hack in `migrate()` since Reboot no longer lives inside any collapsed container.
- Separately: the default Suggested Plan (XML-over-SSH or Telnet) migrates over plain HTTP and never touches CA/TLS, but the CA/TLS precondition and the HTTPS Connection Test panel always looked mandatory. Both now carry a note distinguishing "optional for your current plan (HTTP)" from "required (HTTPS target / DNS interception)".

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/service/handlers/...`
- [x] `make lint` — 0 issues
- [x] Verified against the actually-served `/admin` HTML/CSS/JS (built + curled), not just source files
- [x] Reviewed a screen recording of the live Admin UI in a browser confirming the relocated buttons/colors render correctly
- [ ] Reporter confirmation on real hardware (candidate fix)

Relates to #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)