### PR TITLE
fix(datastore): log previously-silent empty-preset/recent reads (#614)

### DIFF
--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -956,6 +956,8 @@ func (ds *DataStore) readPresetsLocked(account, device string) ([]models.Service
 	data, err := ds.rootReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.Printf("[Datastore] readPresetsLocked: no Presets.xml at %s — reporting no presets", sanitizeLog(path))
+
 			return []models.ServicePreset{}, false, nil
 		}
 
@@ -1299,6 +1301,8 @@ func (ds *DataStore) GetRecents(account, device string) ([]models.ServiceRecent,
 	data, err := ds.rootReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
+			log.Printf("[Datastore] GetRecents: no Recents.xml at %s — reporting no recents", sanitizeLog(path))
+
 			return []models.ServiceRecent{}, nil
 		}
 

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -752,6 +752,13 @@ func CreateAccountDevice(ds *datastore.DataStore, account, deviceID string) (mod
 	device.Presets = mapPresetsToFullResponse(presets, sources)
 	device.Recents = mapRecentsToFullResponse(recents, sources)
 
+	if len(device.Presets) != len(presets) {
+		log.Printf("[Marge] /full: device %s — read %d preset(s) from disk, embedding %d after source mapping",
+			sanitizeLog(deviceID), len(presets), len(device.Presets))
+	} else {
+		log.Printf("[Marge] /full: device %s — embedding %d preset(s)", sanitizeLog(deviceID), len(device.Presets))
+	}
+
 	return device, nil
 }
 


### PR DESCRIPTION
## Summary
- `readPresetsLocked`'s `os.IsNotExist` branch and `GetRecents`' equivalent branch silently returned an empty result with no log line at all — unlike their sibling 0-byte/malformed-XML branches, which already log. When a reporter's speaker got served an empty preset list at reboot despite an intact on-disk `Presets.xml`, there was no durable record of it anywhere except a live capture taken at the exact moment.
- `CreateAccountDevice` now logs, per device per `/full` request, the raw disk-read preset count vs. what actually gets embedded after source-mapping — distinguishes "disk read came back empty" from "source-mapping silently dropped something afterward."

This is diagnostic-only, no behavior change. It doesn't fix #614 — the actual trigger for the empty response is still open. The goal is to make the next live reproduction traceable via `logread`, since a snapshot taken after the fact doesn't show anything wrong (confirmed: replaying the reporter's real `Presets.xml`/`Sources.xml` through the current code, and the reporter's own diagnostic's live `/full` capture taken a couple minutes post-reboot, both already show the correct presets).

## Test plan
- [x] `go build ./...`
- [x] `go test ./pkg/service/datastore/... ./pkg/service/marge/...`
- [x] `make check` (fmt, vet, lint, unit tests, docker-based integration suite)
- [x] Manually verified the new log lines fire correctly against a local scratch instance replaying real diagnostic data