### PR TITLE
Retry configured player devices during discovery

### DIFF
--- a/cmd/soundtouch-player/README.md
+++ b/cmd/soundtouch-player/README.md
@@ -88,7 +88,7 @@ go build -o soundtouch-player
 ./soundtouch-player -port 8888
 
 # Connect to specific device
-./soundtouch-player -host 192.0.2.100
+./soundtouch-player --devices 192.0.2.100
 ```
 
 ### Command Line Options
@@ -137,7 +137,7 @@ device datastore).
 The application automatically discovers SoundTouch devices using:
 - **mDNS discovery** for local network devices
 - **UPnP/SSDP discovery** as fallback
-- **Manual device addition** via IP address
+- **Configured devices** via `--devices`, retried whenever discovery runs
 
 ### Real-time Updates
 The interface maintains WebSocket connections to each device for instant updates of:

--- a/cmd/soundtouch-player/main.go
+++ b/cmd/soundtouch-player/main.go
@@ -170,6 +170,15 @@ func main() {
 
 				webApp.BroadcastDiscoveryStatus("starting", webApp.DeviceCount())
 
+				// Register configured devices immediately rather than waiting for
+				// the full mDNS/UPnP sweep below (bounded by cfg.DiscoveryTimeout,
+				// currently 10s) to complete. manualHosts are also folded into
+				// discoveryService's PreferredDevices so a host that's offline
+				// right now still gets retried on every subsequent discovery pass.
+				for _, host := range manualHosts {
+					webApp.AddDeviceByHost(host, 8090, "manual")
+				}
+
 				webApp.DiscoverDevices(ctx, discoveryService)
 
 				webApp.BroadcastDiscoveryStatus("completed", webApp.DeviceCount())

--- a/cmd/soundtouch-player/main.go
+++ b/cmd/soundtouch-player/main.go
@@ -161,7 +161,7 @@ func main() {
 				log.Printf("Trusting AfterTouch service CA from %s", sanitizeLog(caPath))
 			}
 
-			discoveryService := soundtouchweb.NewDiscoveryService(ifaceName)
+			discoveryService := soundtouchweb.NewDiscoveryService(ifaceName, manualHosts...)
 
 			// Discover devices on startup
 			go func() {
@@ -169,10 +169,6 @@ func main() {
 				defer cancel()
 
 				webApp.BroadcastDiscoveryStatus("starting", webApp.DeviceCount())
-
-				for _, host := range manualHosts {
-					webApp.AddDeviceByHost(host, 8090, "manual")
-				}
 
 				webApp.DiscoverDevices(ctx, discoveryService)
 

--- a/pkg/service/soundtouchweb/discovery.go
+++ b/pkg/service/soundtouchweb/discovery.go
@@ -10,12 +10,13 @@ import (
 	"github.com/gesellix/bose-soundtouch/pkg/config"
 	"github.com/gesellix/bose-soundtouch/pkg/discovery"
 	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
+	"github.com/gesellix/bose-soundtouch/pkg/speaker"
 )
 
 // NewDiscoveryService loads config and returns a unified discovery service
 // preconfigured for the web UI's use (10 s discovery timeout, cache on).
 // When discoveryInterface is non-empty, mDNS/UPnP are pinned to that NIC.
-func NewDiscoveryService(discoveryInterface string) *discovery.UnifiedDiscoveryService {
+func NewDiscoveryService(discoveryInterface string, configuredHosts ...string) *discovery.UnifiedDiscoveryService {
 	cfg, err := config.LoadFromEnv()
 	if err != nil {
 		log.Printf("Failed to load config: %v, using defaults", err)
@@ -28,6 +29,17 @@ func NewDiscoveryService(discoveryInterface string) *discovery.UnifiedDiscoveryS
 
 	if discoveryInterface != "" {
 		cfg.DiscoveryInterface = discoveryInterface
+	}
+
+	for _, host := range configuredHosts {
+		if host == "" {
+			continue
+		}
+
+		cfg.PreferredDevices = append(cfg.PreferredDevices, config.DeviceConfig{
+			Host: host,
+			Port: speaker.HTTPPort,
+		})
 	}
 
 	return discovery.NewUnifiedDiscoveryService(cfg)
@@ -164,6 +176,11 @@ func (app *WebApp) DiscoverDevices(ctx context.Context, discoveryService *discov
 	log.Printf("Found %d devices", len(devices))
 
 	for _, device := range devices {
-		app.AddDeviceByHost(device.Host, device.Port, "discovered")
+		source := "discovered"
+		if device.DiscoveryMethod == "Configuration" {
+			source = "manual"
+		}
+
+		app.AddDeviceByHost(device.Host, device.Port, source)
 	}
 }

--- a/pkg/service/soundtouchweb/discovery.go
+++ b/pkg/service/soundtouchweb/discovery.go
@@ -3,6 +3,7 @@ package soundtouchweb
 import (
 	"context"
 	"log"
+	"strings"
 	"sync"
 	"time"
 
@@ -16,6 +17,11 @@ import (
 // NewDiscoveryService loads config and returns a unified discovery service
 // preconfigured for the web UI's use (10 s discovery timeout, cache on).
 // When discoveryInterface is non-empty, mDNS/UPnP are pinned to that NIC.
+// configuredHosts (e.g. from --devices) are folded into cfg.PreferredDevices
+// alongside any already loaded from PREFERRED_DEVICES (deduplicated by
+// host), so they're retried on every subsequent DiscoverDevices pass, not
+// just once at startup -- a host that's offline now still gets picked up
+// once it comes online.
 func NewDiscoveryService(discoveryInterface string, configuredHosts ...string) *discovery.UnifiedDiscoveryService {
 	cfg, err := config.LoadFromEnv()
 	if err != nil {
@@ -31,8 +37,13 @@ func NewDiscoveryService(discoveryInterface string, configuredHosts ...string) *
 		cfg.DiscoveryInterface = discoveryInterface
 	}
 
+	existingHosts := make(map[string]bool, len(cfg.PreferredDevices))
+	for _, d := range cfg.PreferredDevices {
+		existingHosts[d.Host] = true
+	}
+
 	for _, host := range configuredHosts {
-		if host == "" {
+		if host == "" || existingHosts[host] {
 			continue
 		}
 
@@ -40,6 +51,7 @@ func NewDiscoveryService(discoveryInterface string, configuredHosts ...string) *
 			Host: host,
 			Port: speaker.HTTPPort,
 		})
+		existingHosts[host] = true
 	}
 
 	return discovery.NewUnifiedDiscoveryService(cfg)
@@ -176,11 +188,21 @@ func (app *WebApp) DiscoverDevices(ctx context.Context, discoveryService *discov
 	log.Printf("Found %d devices", len(devices))
 
 	for _, device := range devices {
-		source := "discovered"
-		if device.DiscoveryMethod == "Configuration" {
-			source = "manual"
-		}
-
-		app.AddDeviceByHost(device.Host, device.Port, source)
+		app.AddDeviceByHost(device.Host, device.Port, classifySource(device.DiscoveryMethod))
 	}
+}
+
+// classifySource labels a discovered device "manual" if it came from (at
+// least in part) a configured host, "discovered" otherwise. discoveryMethod
+// can be a "+"-joined composite (e.g. "Configuration+mDNS/Bonjour") when
+// mergeDeviceData combines a configured host with the same device found via
+// mDNS/UPnP in the same sweep -- match by substring, not exact equality, so
+// a manually configured host that's also independently discoverable still
+// gets labeled "manual".
+func classifySource(discoveryMethod string) string {
+	if strings.Contains(discoveryMethod, "Configuration") {
+		return "manual"
+	}
+
+	return "discovered"
 }

--- a/pkg/service/soundtouchweb/discovery_test.go
+++ b/pkg/service/soundtouchweb/discovery_test.go
@@ -1,0 +1,58 @@
+package soundtouchweb
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestDiscoverDevicesRetriesConfiguredHosts(t *testing.T) {
+	var available atomic.Bool
+	var infoRequests atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/info" {
+			http.NotFound(w, r)
+			return
+		}
+
+		infoRequests.Add(1)
+		if !available.Load() {
+			http.Error(w, "offline", http.StatusServiceUnavailable)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<info deviceID="TESTDEVICE"><name>Configured speaker</name><type>SoundTouch 10</type></info>`))
+	}))
+	defer server.Close()
+
+	t.Setenv("UPNP_ENABLED", "false")
+	t.Setenv("MDNS_ENABLED", "false")
+	t.Setenv("PREFERRED_DEVICES", "")
+
+	configuredHost := strings.TrimPrefix(server.URL, "http://")
+	discoveryService := NewDiscoveryService("", configuredHost)
+	app := NewWebApp()
+
+	app.DiscoverDevices(context.Background(), discoveryService)
+	if got := app.DeviceCount(); got != 0 {
+		t.Fatalf("device count after offline probe = %d, want 0", got)
+	}
+
+	available.Store(true)
+	app.DiscoverDevices(context.Background(), discoveryService)
+	if got := app.DeviceCount(); got != 1 {
+		t.Fatalf("device count after retry = %d, want 1", got)
+	}
+	if got := infoRequests.Load(); got != 2 {
+		t.Fatalf("/info request count = %d, want 2", got)
+	}
+
+	if !app.RemoveDevice(configuredHost) {
+		t.Fatal("configured device was not registered under its host")
+	}
+}

--- a/pkg/service/soundtouchweb/discovery_test.go
+++ b/pkg/service/soundtouchweb/discovery_test.go
@@ -14,7 +14,13 @@ func TestDiscoverDevicesRetriesConfiguredHosts(t *testing.T) {
 	var available atomic.Bool
 	var infoRequests atomic.Int32
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	// NewTestServer (Go 1.27) registers its own t.Cleanup(Close) instead of
+	// needing a manual defer, and fails the test on a handler panic. It
+	// defaults to an in-memory transport reachable only via Server.Client(),
+	// but our production client.NewClient dials a real address, so Start()
+	// (rather than Client()) is used here to get a real loopback listener,
+	// same as the old NewServer -- see https://pkg.go.dev/net/http/httptest#NewTestServer.
+	server := httptest.NewTestServer(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/info" {
 			http.NotFound(w, r)
 			return
@@ -29,7 +35,7 @@ func TestDiscoverDevicesRetriesConfiguredHosts(t *testing.T) {
 		w.Header().Set("Content-Type", "application/xml")
 		_, _ = w.Write([]byte(`<info deviceID="TESTDEVICE"><name>Configured speaker</name><type>SoundTouch 10</type></info>`))
 	}))
-	defer server.Close()
+	server.Start()
 
 	t.Setenv("UPNP_ENABLED", "false")
 	t.Setenv("MDNS_ENABLED", "false")

--- a/pkg/service/soundtouchweb/discovery_test.go
+++ b/pkg/service/soundtouchweb/discovery_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestDiscoverDevicesRetriesConfiguredHosts(t *testing.T) {
@@ -54,5 +55,39 @@ func TestDiscoverDevicesRetriesConfiguredHosts(t *testing.T) {
 
 	if !app.RemoveDevice(configuredHost) {
 		t.Fatal("configured device was not registered under its host")
+	}
+
+	// AddDeviceByHost spawns a one-shot status-update goroutine and a 30s-
+	// ticker poll loop on successful registration. RemoveDevice signals the
+	// ticker loop to exit via conn.Done() but doesn't wait for it to actually
+	// observe the close, and the one-shot goroutine has no cancellation at
+	// all. Give them a moment to finish before the deferred server.Close()
+	// runs, so a still-in-flight request against the closing httptest server
+	// doesn't produce log noise or -race flakiness.
+	time.Sleep(50 * time.Millisecond)
+}
+
+// TestClassifySource covers the case the test above can't reach without a
+// real mDNS/UPnP sweep: mergeDeviceData joins discovery methods with "+"
+// when a configured host is also found via mDNS/UPnP in the same pass (see
+// pkg/discovery/unified.go), so DiscoveryMethod is not always exactly
+// "Configuration" for a manually configured device.
+func TestClassifySource(t *testing.T) {
+	tests := []struct {
+		discoveryMethod string
+		want            string
+	}{
+		{"Configuration", "manual"},
+		{"Configuration+mDNS/Bonjour", "manual"},
+		{"mDNS/Bonjour+Configuration", "manual"},
+		{"mDNS/Bonjour", "discovered"},
+		{"SSDP/UPnP", "discovered"},
+		{"", "discovered"},
+	}
+
+	for _, tt := range tests {
+		if got := classifySource(tt.discoveryMethod); got != tt.want {
+			t.Errorf("classifySource(%q) = %q, want %q", tt.discoveryMethod, got, tt.want)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

- Route `soundtouch-player --devices` entries through unified discovery's configured-device path.
- Retry configured speakers whenever discovery runs instead of trying them only once during process startup.
- Preserve mDNS and UPnP discovery before probing configured hosts, so an unreachable configured speaker cannot consume the network discovery timeout.
- Correct the stale `-host` example in the player README to use `--devices`.

## Linked issue

No linked issue. This is a small, focused fix for a hardware-reproduced startup timing bug.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (the Docker-based HTTP-client integration suite was not available locally)
- [ ] Tested against a real SoundTouch device (the bug and restart workaround were reproduced on hardware; the patched binary has not been deployed there)
- [x] `go test -count=1 ./...`
- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `golangci-lint v2.13.1 run`
- [x] Regression test verifies that a configured speaker unavailable during the first discovery is added after it becomes reachable and discovery runs again.

## Reproduction

Start `soundtouch-player` with a speaker in `--devices` while that speaker is offline. Bring the speaker online and trigger Discover in the web UI. Before this change the speaker remains absent because the manual host is tried only by the startup goroutine; restarting the player makes it appear. With this change, each discovery run includes the configured host and retries its `/info` probe.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed

OpenAI Codex assisted with implementation, tests, and review. I reviewed the complete diff and ran the validation listed above.
