### PR TITLE
fix(player): project stereo pairs as logical devices

### DIFF
--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -46,6 +46,7 @@ GET      /api/control/devices/{id}/power-status                       soundtouch
 GET      /api/control/devices/{id}/recents                            soundtouchweb.(*WebApp).HandleDeviceRecents-fm
 GET      /api/control/devices/{id}/ws                                 soundtouchweb.(*WebApp).HandleDeviceWebSocket-fm
 GET      /api/control/devices/{id}/zone/                              soundtouchweb.(*WebApp).HandleGetZone-fm
+GET      /api/control/devices/{id}/zone/candidates                    soundtouchweb.(*WebApp).HandleGetZoneCandidates-fm
 GET      /api/control/providers/library/servers                       soundtouchweb.(*WebApp).HandleDiscoverLibraryServers-fm
 GET      /api/control/providers/radiobrowser/search                   soundtouchweb.(*WebApp).HandleRadioBrowserSearch-fm
 GET      /api/control/providers/tunein/navigate                       soundtouchweb.(*WebApp).HandleTuneInNavigate-fm

--- a/docs/content/docs/appendix/soundtouch-player-roadmap.md
+++ b/docs/content/docs/appendix/soundtouch-player-roadmap.md
@@ -101,13 +101,13 @@ rename and network/firmware info.
 
 ---
 
-## 4. Render stereo pairs as a single device
+## 4. Render stereo pairs as a single device (shipped)
 
-Today soundtouch-player shows the two halves of a stereo pair (formed via
-`/addGroup` — see issue #252) as independent entries in the device list. The
-Bose app collapsed a paired ST10 set into one "L+R" entry; restoring that
-presentation closes the perception gap BirdyBA flagged at
-<https://github.com/gesellix/Bose-SoundTouch/issues/252#issuecomment-4458140305>.
+soundtouch-player projects a valid two-speaker stereo pair (formed via
+`/addGroup` - see [issue #252](https://github.com/gesellix/Bose-SoundTouch/issues/252))
+as one logical control target. This restores the single-entry presentation
+expected by users while preserving both physical speakers in the service
+registry.
 
 **Device API:**
 - `GET /getGroup` on each speaker — returns the current `<group>` with
@@ -118,28 +118,30 @@ presentation closes the perception gap BirdyBA flagged at
   side is sufficient to detect the pair
 
 **Backend:**
-- During device-list assembly, call `GET /getGroup` for each discovered device
-  in parallel (matches the propagation pattern already used by
-  `soundtouch-cli group create` in `cmd/soundtouch-cli/cmd_group.go`)
-- Bucket devices by `<masterDeviceId>` — each bucket emits one entry in the
-  list response. Standalone devices stay as their own bucket-of-one
-- Expose pair metadata on the list entry so the UI can render role chips
-  (`L`/`R`) and resolve role → physical device for actions
+- Poll `GET /getGroup` together with the other device status and consume
+  `groupUpdated` events. A generation check prevents an older poll from
+  overwriting a newer event.
+- Collapse only an exact two-member `LEFT`/`RIGHT` group whose registered
+  members agree on the group claim. Malformed, conflicting, or ambiguous data
+  fails open and leaves the physical entries visible.
+- Use the master speaker's existing registry key for the logical target, so
+  controls continue to route through the master without changing the raw
+  physical-device registry.
+- Use the same projection for the REST device list and the global player
+  WebSocket snapshot.
 
 **Frontend:**
-- Device list collapses paired devices into one card titled with both names
-  (e.g. `"Wohnzimmer L+R"`) and role chips
-- Clicking the card opens a device-detail page that exposes both per-role
-  status and a "Dissolve pair" action (DELETE flow, already wired in
-  `soundtouch-cli group remove` and in fakespeaker's `/removeGroup` GET)
-- Standalone speakers continue to render as today
+- Render one card using the shared member name or the group's name.
+- Show pair availability as `Stereo pair n/2` and mark the card degraded when
+  a member is unavailable or the group reports a non-OK state.
+- Hide the single-device remove action on a projected pair. Standalone
+  speakers continue to render as before.
 
-**Note:** Pair lifecycle (create / rename / remove) already works
-end-to-end — `pkg/client` group endpoints + `cmd/soundtouch-cli/cmd_group.go`,
-covered by tests in `cmd/soundtouch-cli/cmd_group_test.go` and exercisable
-against the fake speaker's group routes
-(`pkg/service/testing/fakespeaker/fakespeaker.go`). This task is purely about
-presentation in soundtouch-player's device list — no protocol work required.
+**Note:** Pair lifecycle (create / rename / remove) remains available through
+the existing client and CLI group operations. The player intentionally does
+not expose a "Dissolve pair" action yet: its current remove operation deletes
+one physical registry record rather than performing an atomic pair lifecycle
+operation.
 
 ---
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1429,14 +1429,17 @@ func (c *Client) GetZoneMembers() ([]string, error) {
 // distinguish with (*Group).IsEmpty().
 //
 // ST-10 is the only product that supports stereo pairs. Verified against
-// real hardware: a SoundTouch 20 does not reply to /getGroup at all -- the
-// request hangs until the client's own timeout (30s by default, see
-// DefaultConfig) rather than returning an empty group quickly. Callers on
-// a poll cycle must gate this call behind a stereo-pair-capable model check
-// (see stereoPairCapable in pkg/service/soundtouchweb) instead of relying on
-// a fast, harmless response on unsupported models. The endpoint is named
-// /getGroup on the device (mirroring /getZone), even though some
-// third-party wikis document it as plain /group.
+// real hardware: a SoundTouch 20 does not reply to /getGroup promptly. The
+// device's own firmware ("AllegroWebserver") eventually answers with a
+// plain-text "AllegroWebserver timeout: /getGroup" error body after an
+// internal delay exceeding several seconds, but well within the client's
+// own timeout (30s by default, see DefaultConfig) the request just looks
+// like it never replied at all. Callers on a poll cycle must gate this call
+// behind a stereo-pair-capable model check (see stereoPairCapable in
+// pkg/service/soundtouchweb) instead of relying on a fast, harmless
+// response on unsupported models. The endpoint is named /getGroup on the
+// device (mirroring /getZone), even though some third-party wikis document
+// it as plain /group.
 func (c *Client) GetGroup() (*models.Group, error) {
 	var g models.Group
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1428,9 +1428,14 @@ func (c *Client) GetZoneMembers() ([]string, error) {
 // An empty <group/> response is reported as a zero-value Group; callers can
 // distinguish with (*Group).IsEmpty().
 //
-// ST-10 is the only product that supports stereo pairs; on other devices
-// the call is harmless but will always return an empty group. The endpoint
-// is named /getGroup on the device (mirroring /getZone), even though some
+// ST-10 is the only product that supports stereo pairs. Verified against
+// real hardware: a SoundTouch 20 does not reply to /getGroup at all -- the
+// request hangs until the client's own timeout (30s by default, see
+// DefaultConfig) rather than returning an empty group quickly. Callers on
+// a poll cycle must gate this call behind a stereo-pair-capable model check
+// (see stereoPairCapable in pkg/service/soundtouchweb) instead of relying on
+// a fast, harmless response on unsupported models. The endpoint is named
+// /getGroup on the device (mirroring /getZone), even though some
 // third-party wikis document it as plain /group.
 func (c *Client) GetGroup() (*models.Group, error) {
 	var g models.Group

--- a/pkg/models/group.go
+++ b/pkg/models/group.go
@@ -1,6 +1,9 @@
 package models
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"strings"
+)
 
 // Group represents a stereo pair of two ST10 SoundTouch speakers.
 type Group struct {
@@ -31,4 +34,41 @@ type GroupRole struct {
 	DeviceID  string `xml:"deviceId"`
 	Role      string `xml:"role"`
 	IPAddress string `xml:"ipAddress,omitempty"`
+}
+
+// SameGroup reports whether left and right describe the same stereo-pair
+// configuration, comparing role assignments by device ID rather than by
+// slice order. The device's own /getGroup response and its groupUpdated
+// WebSocket event both populate Roles.Roles directly from XML unmarshaling
+// in wire order, so a polled read and a pushed event for the identical pair
+// are not guaranteed to list roles in the same order -- comparing with
+// reflect.DeepEqual (order-sensitive) would then report a spurious change
+// even though nothing about the pair actually changed. Two nil Groups are
+// equal; exactly one nil is not.
+func SameGroup(left, right *Group) bool {
+	if left == nil && right == nil {
+		return true
+	}
+
+	if left == nil || right == nil {
+		return false
+	}
+
+	if left.ID != right.ID || left.MasterDeviceID != right.MasterDeviceID ||
+		len(left.Roles.Roles) != len(right.Roles.Roles) {
+		return false
+	}
+
+	rightRoles := make(map[string]string, len(right.Roles.Roles))
+	for _, role := range right.Roles.Roles {
+		rightRoles[strings.TrimSpace(role.DeviceID)] = strings.ToUpper(strings.TrimSpace(role.Role))
+	}
+
+	for _, role := range left.Roles.Roles {
+		if rightRoles[strings.TrimSpace(role.DeviceID)] != strings.ToUpper(strings.TrimSpace(role.Role)) {
+			return false
+		}
+	}
+
+	return true
 }

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -52,6 +52,14 @@ type stereoPairMemberView struct {
 	Available bool   `json:"available"`
 }
 
+// stereoPairCapable reports whether info's model supports stereo pairing
+// (ST-10 only). This must stay a model-name check rather than a runtime
+// capability probe: verified against real hardware, a SoundTouch 20 lists
+// /getGroup (and /addGroup, /removeGroup, /updateGroup) in its own
+// /supportedURLs response even though the device doesn't actually reply to
+// /getGroup -- see Client.GetGroup's doc comment. The device's supportedURLs
+// listing reflects firmware-level route registration, not per-model feature
+// support, so it cannot be used to detect stereo-pair capability either.
 func stereoPairCapable(info *models.DeviceInfo) bool {
 	if info == nil {
 		return false

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -83,7 +83,7 @@ func captureDeviceProjectionEntries(snapshot []DeviceEntry) []deviceProjectionEn
 			ID:       entry.ID,
 			Info:     entry.Device.DeviceInfo,
 			Status:   entry.Device.Status(),
-			LastSeen: entry.Device.LastSeen,
+			LastSeen: entry.LastSeen,
 		})
 	}
 

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -52,6 +52,16 @@ type stereoPairMemberView struct {
 	Available bool   `json:"available"`
 }
 
+func stereoPairCapable(info *models.DeviceInfo) bool {
+	if info == nil {
+		return false
+	}
+
+	typeName := strings.ToLower(strings.TrimSpace(info.Type))
+
+	return typeName == "st10" || typeName == "soundtouch 10"
+}
+
 // deviceViewSnapshot projects the physical registry into logical control
 // targets for the HTTP API and the global player WebSocket.
 func (app *WebApp) deviceViewSnapshot() map[string]deviceView {

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -18,6 +18,17 @@ type deviceView struct {
 	StereoPair *stereoPairView        `json:"stereoPair,omitempty"`
 }
 
+// deviceProjectionEntry captures one immutable status pointer per physical
+// device. Projection must not re-read live connection state midway through
+// building a response, otherwise group membership and the emitted status can
+// describe different moments.
+type deviceProjectionEntry struct {
+	ID       string
+	Info     *models.DeviceInfo
+	Status   *webtypes.DeviceStatus
+	LastSeen time.Time
+}
+
 // stereoPairView describes the physical members represented by a logical
 // player target. Controls are always sent to MasterDeviceID via the map key.
 type stereoPairView struct {
@@ -48,13 +59,35 @@ func (app *WebApp) deviceViewSnapshot() map[string]deviceView {
 }
 
 func projectDeviceEntries(snapshot []DeviceEntry) map[string]deviceView {
-	byDeviceID := make(map[string][]DeviceEntry, len(snapshot))
+	return projectCapturedDeviceEntries(captureDeviceProjectionEntries(snapshot))
+}
+
+func captureDeviceProjectionEntries(snapshot []DeviceEntry) []deviceProjectionEntry {
+	captured := make([]deviceProjectionEntry, 0, len(snapshot))
 	for _, entry := range snapshot {
-		if entry.Device == nil || entry.Device.DeviceInfo == nil {
+		if entry.Device == nil {
 			continue
 		}
 
-		deviceID := strings.TrimSpace(entry.Device.DeviceInfo.DeviceID)
+		captured = append(captured, deviceProjectionEntry{
+			ID:       entry.ID,
+			Info:     entry.Device.DeviceInfo,
+			Status:   entry.Device.Status(),
+			LastSeen: entry.Device.LastSeen,
+		})
+	}
+
+	return captured
+}
+
+func projectCapturedDeviceEntries(snapshot []deviceProjectionEntry) map[string]deviceView {
+	byDeviceID := make(map[string][]deviceProjectionEntry, len(snapshot))
+	for _, entry := range snapshot {
+		if entry.Info == nil {
+			continue
+		}
+
+		deviceID := strings.TrimSpace(entry.Info.DeviceID)
 		if deviceID != "" {
 			byDeviceID[deviceID] = append(byDeviceID[deviceID], entry)
 		}
@@ -64,24 +97,23 @@ func projectDeviceEntries(snapshot []DeviceEntry) map[string]deviceView {
 	hidden := make(map[string]bool)
 
 	for _, entry := range snapshot {
-		if entry.Device == nil || entry.Device.DeviceInfo == nil {
+		if entry.Info == nil {
 			continue
 		}
 
-		status := entry.Device.Status()
-		if status == nil || !validMasterGroup(entry.Device.DeviceInfo.DeviceID, status.Group) {
+		if entry.Status == nil || !validMasterGroup(entry.Info.DeviceID, entry.Status.Group) {
 			continue
 		}
 
-		master, unique := uniqueDeviceEntry(byDeviceID, status.Group.MasterDeviceID)
-		if !unique || master.ID != entry.ID || !registeredMembersAgree(status.Group, byDeviceID) {
+		master, unique := uniqueDeviceEntry(byDeviceID, entry.Status.Group.MasterDeviceID)
+		if !unique || master.ID != entry.ID || !registeredMembersAgree(entry.Status.Group, byDeviceID) {
 			continue
 		}
 
-		pair := newStereoPairView(status.Group, byDeviceID)
+		pair := newStereoPairView(entry.Status.Group, byDeviceID)
 		masters[entry.ID] = pair
 
-		for _, role := range status.Group.Roles.Roles {
+		for _, role := range entry.Status.Group.Roles.Roles {
 			member, ok := uniqueDeviceEntry(byDeviceID, role.DeviceID)
 			if ok && member.ID != entry.ID {
 				hidden[member.ID] = true
@@ -91,15 +123,15 @@ func projectDeviceEntries(snapshot []DeviceEntry) map[string]deviceView {
 
 	devices := make(map[string]deviceView, len(snapshot))
 	for _, entry := range snapshot {
-		if entry.Device == nil || hidden[entry.ID] {
+		if hidden[entry.ID] {
 			continue
 		}
 
 		pair := masters[entry.ID]
 		devices[entry.ID] = deviceView{
-			Info:       projectedDeviceInfo(entry.Device.DeviceInfo, pair),
-			Status:     entry.Device.Status(),
-			LastSeen:   entry.Device.LastSeen,
+			Info:       projectedDeviceInfo(entry.Info, pair),
+			Status:     entry.Status,
+			LastSeen:   entry.LastSeen,
 			StereoPair: pair,
 		}
 	}
@@ -120,6 +152,7 @@ func validMasterGroup(deviceID string, group *models.Group) bool {
 
 	for _, role := range group.Roles.Roles {
 		memberID := strings.TrimSpace(role.DeviceID)
+
 		memberRole := strings.ToUpper(strings.TrimSpace(role.Role))
 		if memberID == "" || seenDevices[memberID] || (memberRole != "LEFT" && memberRole != "RIGHT") || seenRoles[memberRole] {
 			return false
@@ -133,16 +166,16 @@ func validMasterGroup(deviceID string, group *models.Group) bool {
 	return masterPresent && seenRoles["LEFT"] && seenRoles["RIGHT"]
 }
 
-func uniqueDeviceEntry(byDeviceID map[string][]DeviceEntry, deviceID string) (DeviceEntry, bool) {
+func uniqueDeviceEntry(byDeviceID map[string][]deviceProjectionEntry, deviceID string) (deviceProjectionEntry, bool) {
 	entries := byDeviceID[strings.TrimSpace(deviceID)]
 	if len(entries) != 1 {
-		return DeviceEntry{}, false
+		return deviceProjectionEntry{}, false
 	}
 
 	return entries[0], true
 }
 
-func registeredMembersAgree(group *models.Group, byDeviceID map[string][]DeviceEntry) bool {
+func registeredMembersAgree(group *models.Group, byDeviceID map[string][]deviceProjectionEntry) bool {
 	for _, role := range group.Roles.Roles {
 		entries := byDeviceID[strings.TrimSpace(role.DeviceID)]
 		if len(entries) > 1 {
@@ -153,8 +186,7 @@ func registeredMembersAgree(group *models.Group, byDeviceID map[string][]DeviceE
 			continue
 		}
 
-		status := entries[0].Device.Status()
-		if status == nil || !sameGroupClaim(group, status.Group) {
+		if entries[0].Status == nil || !sameGroupClaim(group, entries[0].Status.Group) {
 			return false
 		}
 	}
@@ -182,7 +214,7 @@ func sameGroupClaim(left, right *models.Group) bool {
 	return true
 }
 
-func newStereoPairView(group *models.Group, byDeviceID map[string][]DeviceEntry) *stereoPairView {
+func newStereoPairView(group *models.Group, byDeviceID map[string][]deviceProjectionEntry) *stereoPairView {
 	members := make([]stereoPairMemberView, 0, len(group.Roles.Roles))
 	available := 0
 
@@ -193,16 +225,15 @@ func newStereoPairView(group *models.Group, byDeviceID map[string][]DeviceEntry)
 			IPAddress: role.IPAddress,
 		}
 
-		if entry, ok := uniqueDeviceEntry(byDeviceID, role.DeviceID); ok && entry.Device != nil {
-			if entry.Device.DeviceInfo != nil {
-				member.Name = entry.Device.DeviceInfo.Name
-				if entry.Device.DeviceInfo.IPAddress != "" {
-					member.IPAddress = entry.Device.DeviceInfo.IPAddress
+		if entry, ok := uniqueDeviceEntry(byDeviceID, role.DeviceID); ok {
+			if entry.Info != nil {
+				member.Name = entry.Info.Name
+				if entry.Info.IPAddress != "" {
+					member.IPAddress = entry.Info.IPAddress
 				}
 			}
 
-			status := entry.Device.Status()
-			member.Available = status != nil && status.IsConnected
+			member.Available = entry.Status != nil && entry.Status.IsConnected
 			if member.Available {
 				available++
 			}
@@ -236,6 +267,7 @@ func projectedDeviceInfo(info *models.DeviceInfo, pair *stereoPairView) *models.
 
 func logicalPairName(groupName string, members []stereoPairMemberView) string {
 	commonName := ""
+
 	for _, member := range members {
 		name := strings.TrimSpace(member.Name)
 		if name == "" {

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -204,27 +204,7 @@ func registeredMembersAgree(group *models.Group, byDeviceID map[string][]deviceP
 			continue
 		}
 
-		if entries[0].Status == nil || !sameGroupClaim(group, entries[0].Status.Group) {
-			return false
-		}
-	}
-
-	return true
-}
-
-func sameGroupClaim(left, right *models.Group) bool {
-	if left == nil || right == nil || left.ID != right.ID || left.MasterDeviceID != right.MasterDeviceID ||
-		len(left.Roles.Roles) != len(right.Roles.Roles) {
-		return false
-	}
-
-	rightRoles := make(map[string]string, len(right.Roles.Roles))
-	for _, role := range right.Roles.Roles {
-		rightRoles[strings.TrimSpace(role.DeviceID)] = strings.ToUpper(strings.TrimSpace(role.Role))
-	}
-
-	for _, role := range left.Roles.Roles {
-		if rightRoles[strings.TrimSpace(role.DeviceID)] != strings.ToUpper(strings.TrimSpace(role.Role)) {
+		if entries[0].Status == nil || !models.SameGroup(group, entries[0].Status.Group) {
 			return false
 		}
 	}

--- a/pkg/service/soundtouchweb/device_projection.go
+++ b/pkg/service/soundtouchweb/device_projection.go
@@ -1,0 +1,260 @@
+package soundtouchweb
+
+import (
+	"strings"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
+)
+
+// deviceView is the player-facing representation of one control target.
+// A stereo pair is projected as one target keyed by its master speaker's host;
+// the underlying registry continues to track both physical speakers.
+type deviceView struct {
+	Info       *models.DeviceInfo     `json:"info"`
+	Status     *webtypes.DeviceStatus `json:"status"`
+	LastSeen   time.Time              `json:"lastSeen"`
+	StereoPair *stereoPairView        `json:"stereoPair,omitempty"`
+}
+
+// stereoPairView describes the physical members represented by a logical
+// player target. Controls are always sent to MasterDeviceID via the map key.
+type stereoPairView struct {
+	ID                   string                 `json:"id"`
+	Name                 string                 `json:"name,omitempty"`
+	MasterDeviceID       string                 `json:"masterDeviceId"`
+	Status               string                 `json:"status,omitempty"`
+	MemberCount          int                    `json:"memberCount"`
+	AvailableMemberCount int                    `json:"availableMemberCount"`
+	Degraded             bool                   `json:"degraded"`
+	Members              []stereoPairMemberView `json:"members"`
+}
+
+// stereoPairMemberView is the player-facing role and availability of one
+// physical speaker in a stereo pair.
+type stereoPairMemberView struct {
+	DeviceID  string `json:"deviceId"`
+	Role      string `json:"role"`
+	IPAddress string `json:"ipAddress,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Available bool   `json:"available"`
+}
+
+// deviceViewSnapshot projects the physical registry into logical control
+// targets for the HTTP API and the global player WebSocket.
+func (app *WebApp) deviceViewSnapshot() map[string]deviceView {
+	return projectDeviceEntries(app.DeviceSnapshot())
+}
+
+func projectDeviceEntries(snapshot []DeviceEntry) map[string]deviceView {
+	byDeviceID := make(map[string][]DeviceEntry, len(snapshot))
+	for _, entry := range snapshot {
+		if entry.Device == nil || entry.Device.DeviceInfo == nil {
+			continue
+		}
+
+		deviceID := strings.TrimSpace(entry.Device.DeviceInfo.DeviceID)
+		if deviceID != "" {
+			byDeviceID[deviceID] = append(byDeviceID[deviceID], entry)
+		}
+	}
+
+	masters := make(map[string]*stereoPairView)
+	hidden := make(map[string]bool)
+
+	for _, entry := range snapshot {
+		if entry.Device == nil || entry.Device.DeviceInfo == nil {
+			continue
+		}
+
+		status := entry.Device.Status()
+		if status == nil || !validMasterGroup(entry.Device.DeviceInfo.DeviceID, status.Group) {
+			continue
+		}
+
+		master, unique := uniqueDeviceEntry(byDeviceID, status.Group.MasterDeviceID)
+		if !unique || master.ID != entry.ID || !registeredMembersAgree(status.Group, byDeviceID) {
+			continue
+		}
+
+		pair := newStereoPairView(status.Group, byDeviceID)
+		masters[entry.ID] = pair
+
+		for _, role := range status.Group.Roles.Roles {
+			member, ok := uniqueDeviceEntry(byDeviceID, role.DeviceID)
+			if ok && member.ID != entry.ID {
+				hidden[member.ID] = true
+			}
+		}
+	}
+
+	devices := make(map[string]deviceView, len(snapshot))
+	for _, entry := range snapshot {
+		if entry.Device == nil || hidden[entry.ID] {
+			continue
+		}
+
+		pair := masters[entry.ID]
+		devices[entry.ID] = deviceView{
+			Info:       projectedDeviceInfo(entry.Device.DeviceInfo, pair),
+			Status:     entry.Device.Status(),
+			LastSeen:   entry.Device.LastSeen,
+			StereoPair: pair,
+		}
+	}
+
+	return devices
+}
+
+func validMasterGroup(deviceID string, group *models.Group) bool {
+	if group == nil || group.IsEmpty() || strings.TrimSpace(group.ID) == "" ||
+		strings.TrimSpace(group.MasterDeviceID) == "" || len(group.Roles.Roles) != 2 ||
+		strings.TrimSpace(deviceID) != strings.TrimSpace(group.MasterDeviceID) {
+		return false
+	}
+
+	seenDevices := make(map[string]bool, len(group.Roles.Roles))
+	seenRoles := make(map[string]bool, len(group.Roles.Roles))
+	masterPresent := false
+
+	for _, role := range group.Roles.Roles {
+		memberID := strings.TrimSpace(role.DeviceID)
+		memberRole := strings.ToUpper(strings.TrimSpace(role.Role))
+		if memberID == "" || seenDevices[memberID] || (memberRole != "LEFT" && memberRole != "RIGHT") || seenRoles[memberRole] {
+			return false
+		}
+
+		seenDevices[memberID] = true
+		seenRoles[memberRole] = true
+		masterPresent = masterPresent || memberID == strings.TrimSpace(group.MasterDeviceID)
+	}
+
+	return masterPresent && seenRoles["LEFT"] && seenRoles["RIGHT"]
+}
+
+func uniqueDeviceEntry(byDeviceID map[string][]DeviceEntry, deviceID string) (DeviceEntry, bool) {
+	entries := byDeviceID[strings.TrimSpace(deviceID)]
+	if len(entries) != 1 {
+		return DeviceEntry{}, false
+	}
+
+	return entries[0], true
+}
+
+func registeredMembersAgree(group *models.Group, byDeviceID map[string][]DeviceEntry) bool {
+	for _, role := range group.Roles.Roles {
+		entries := byDeviceID[strings.TrimSpace(role.DeviceID)]
+		if len(entries) > 1 {
+			return false
+		}
+
+		if len(entries) == 0 {
+			continue
+		}
+
+		status := entries[0].Device.Status()
+		if status == nil || !sameGroupClaim(group, status.Group) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func sameGroupClaim(left, right *models.Group) bool {
+	if left == nil || right == nil || left.ID != right.ID || left.MasterDeviceID != right.MasterDeviceID ||
+		len(left.Roles.Roles) != len(right.Roles.Roles) {
+		return false
+	}
+
+	rightRoles := make(map[string]string, len(right.Roles.Roles))
+	for _, role := range right.Roles.Roles {
+		rightRoles[strings.TrimSpace(role.DeviceID)] = strings.ToUpper(strings.TrimSpace(role.Role))
+	}
+
+	for _, role := range left.Roles.Roles {
+		if rightRoles[strings.TrimSpace(role.DeviceID)] != strings.ToUpper(strings.TrimSpace(role.Role)) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func newStereoPairView(group *models.Group, byDeviceID map[string][]DeviceEntry) *stereoPairView {
+	members := make([]stereoPairMemberView, 0, len(group.Roles.Roles))
+	available := 0
+
+	for _, role := range group.Roles.Roles {
+		member := stereoPairMemberView{
+			DeviceID:  role.DeviceID,
+			Role:      role.Role,
+			IPAddress: role.IPAddress,
+		}
+
+		if entry, ok := uniqueDeviceEntry(byDeviceID, role.DeviceID); ok && entry.Device != nil {
+			if entry.Device.DeviceInfo != nil {
+				member.Name = entry.Device.DeviceInfo.Name
+				if entry.Device.DeviceInfo.IPAddress != "" {
+					member.IPAddress = entry.Device.DeviceInfo.IPAddress
+				}
+			}
+
+			status := entry.Device.Status()
+			member.Available = status != nil && status.IsConnected
+			if member.Available {
+				available++
+			}
+		}
+
+		members = append(members, member)
+	}
+
+	return &stereoPairView{
+		ID:                   group.ID,
+		Name:                 logicalPairName(group.Name, members),
+		MasterDeviceID:       group.MasterDeviceID,
+		Status:               group.Status,
+		MemberCount:          len(members),
+		AvailableMemberCount: available,
+		Degraded:             available != len(members) || (group.Status != "" && group.Status != "GROUP_OK"),
+		Members:              members,
+	}
+}
+
+func projectedDeviceInfo(info *models.DeviceInfo, pair *stereoPairView) *models.DeviceInfo {
+	if info == nil || pair == nil || pair.Name == "" || pair.Name == info.Name {
+		return info
+	}
+
+	projected := *info
+	projected.Name = pair.Name
+
+	return &projected
+}
+
+func logicalPairName(groupName string, members []stereoPairMemberView) string {
+	commonName := ""
+	for _, member := range members {
+		name := strings.TrimSpace(member.Name)
+		if name == "" {
+			return groupName
+		}
+
+		if commonName == "" {
+			commonName = name
+			continue
+		}
+
+		if !strings.EqualFold(commonName, name) {
+			return groupName
+		}
+	}
+
+	if commonName != "" {
+		return commonName
+	}
+
+	return groupName
+}

--- a/pkg/service/soundtouchweb/device_projection_test.go
+++ b/pkg/service/soundtouchweb/device_projection_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -19,7 +20,7 @@ func projectionDevice(host, deviceID, name string, connected bool, group *models
 	})
 	conn.SetStatus(&webtypes.DeviceStatus{IsConnected: connected, Group: group})
 
-	return DeviceEntry{ID: host, Device: conn}
+	return DeviceEntry{ID: host, Device: conn, LastSeen: conn.LastSeen}
 }
 
 func testStereoGroup() *models.Group {
@@ -171,6 +172,50 @@ func TestProjectCapturedDeviceEntriesUsesOneCoherentStatusPerDevice(t *testing.T
 	if fresh := projectDeviceEntries(entries); len(fresh) != 2 {
 		t.Fatalf("fresh projection did not observe the cleared group: %+v", fresh)
 	}
+}
+
+func TestDeviceViewSnapshotConcurrentTouchUsesCapturedLastSeen(t *testing.T) {
+	app := NewWebApp()
+	conn := newRegistryDevice("Living Room")
+	if !app.AddDevice("192.0.2.10", conn) {
+		t.Fatal("AddDevice returned false on first insert")
+	}
+
+	stale := app.DeviceSnapshot()
+	if len(stale) != 1 {
+		t.Fatalf("DeviceSnapshot len = %d, want 1", len(stale))
+	}
+
+	if !app.TouchDevice("192.0.2.10") {
+		t.Fatal("TouchDevice returned false for registered device")
+	}
+	if got := projectDeviceEntries(stale)["192.0.2.10"].LastSeen; got != stale[0].LastSeen {
+		t.Fatalf("projection LastSeen = %s, want captured value %s", got, stale[0].LastSeen)
+	}
+
+	const iterations = 1000
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			app.TouchDevice("192.0.2.10")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+		<-start
+		for i := 0; i < iterations; i++ {
+			_ = app.deviceViewSnapshot()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 func TestHandleAPIDevicesUsesLogicalStereoProjection(t *testing.T) {

--- a/pkg/service/soundtouchweb/device_projection_test.go
+++ b/pkg/service/soundtouchweb/device_projection_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
@@ -147,6 +148,28 @@ func TestProjectDeviceEntriesRejectsConflictingMemberClaim(t *testing.T) {
 
 	if len(got) != 2 {
 		t.Fatalf("conflicting pair claims must fail open: %+v", got)
+	}
+}
+
+func TestProjectCapturedDeviceEntriesUsesOneCoherentStatusPerDevice(t *testing.T) {
+	group := testStereoGroup()
+	entries := []DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	}
+	captured := captureDeviceProjectionEntries(entries)
+
+	entries[0].Device.ApplyGroupEvent(&models.Group{}, time.Now())
+	entries[1].Device.ApplyGroupEvent(&models.Group{}, time.Now())
+
+	got := projectCapturedDeviceEntries(captured)
+	master := got["192.0.2.10"]
+	if master.StereoPair == nil || master.Status == nil || master.Status.Group == nil || master.Status.Group.ID != "pair-1" {
+		t.Fatalf("captured projection mixed newer connection state into its response: %+v", got)
+	}
+
+	if fresh := projectDeviceEntries(entries); len(fresh) != 2 {
+		t.Fatalf("fresh projection did not observe the cleared group: %+v", fresh)
 	}
 }
 

--- a/pkg/service/soundtouchweb/device_projection_test.go
+++ b/pkg/service/soundtouchweb/device_projection_test.go
@@ -1,0 +1,181 @@
+package soundtouchweb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
+)
+
+func projectionDevice(host, deviceID, name string, connected bool, group *models.Group) DeviceEntry {
+	conn := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{
+		DeviceID:  deviceID,
+		Name:      name,
+		IPAddress: host,
+	})
+	conn.SetStatus(&webtypes.DeviceStatus{IsConnected: connected, Group: group})
+
+	return DeviceEntry{ID: host, Device: conn}
+}
+
+func testStereoGroup() *models.Group {
+	return &models.Group{
+		ID:             "pair-1",
+		Name:           "Living Room + Living Room",
+		MasterDeviceID: "left-id",
+		Status:         "GROUP_OK",
+		Roles: models.GroupRoles{Roles: []models.GroupRole{
+			{DeviceID: "left-id", Role: "LEFT", IPAddress: "192.0.2.10"},
+			{DeviceID: "right-id", Role: "RIGHT", IPAddress: "192.0.2.11"},
+		}},
+	}
+}
+
+func TestProjectDeviceEntriesCollapsesStereoPairUnderMaster(t *testing.T) {
+	group := testStereoGroup()
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("projected devices = %d, want one logical stereo target: %+v", len(got), got)
+	}
+
+	master, ok := got["192.0.2.10"]
+	if !ok {
+		t.Fatalf("master control target missing: %+v", got)
+	}
+
+	if master.StereoPair == nil {
+		t.Fatal("master is missing stereo-pair metadata")
+	}
+
+	if master.StereoPair.MemberCount != 2 || master.StereoPair.AvailableMemberCount != 2 || master.StereoPair.Degraded {
+		t.Errorf("unexpected pair availability: %+v", master.StereoPair)
+	}
+
+	if master.Info.Name != "Living Room" || master.StereoPair.Name != "Living Room" {
+		t.Errorf("logical pair name was not projected consistently: %+v", master)
+	}
+
+	if _, ok := got["192.0.2.11"]; ok {
+		t.Error("physical right member must not be a second control target")
+	}
+}
+
+func TestProjectDeviceEntriesShowsDegradedPairWhenMemberIsMissing(t *testing.T) {
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, testStereoGroup()),
+	})
+
+	pair := got["192.0.2.10"].StereoPair
+	if pair == nil {
+		t.Fatal("connected master should remain a logical pair when its member is unavailable")
+	}
+
+	if pair.AvailableMemberCount != 1 || !pair.Degraded {
+		t.Errorf("missing member not reflected as degraded: %+v", pair)
+	}
+}
+
+func TestProjectDeviceEntriesKeepsStablePairWhenMasterIsDisconnected(t *testing.T) {
+	group := testStereoGroup()
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", false, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("projected devices = %d, want a stable logical pair while its master is registered", len(got))
+	}
+
+	pair := got["192.0.2.10"].StereoPair
+	if pair == nil || !pair.Degraded || pair.AvailableMemberCount != 1 {
+		t.Errorf("disconnected master should produce a degraded logical pair: %+v", got)
+	}
+}
+
+func TestProjectDeviceEntriesLeavesMemberPhysicalWhenMasterIsAbsent(t *testing.T) {
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, testStereoGroup()),
+	})
+
+	if len(got) != 1 || got["192.0.2.11"].StereoPair != nil {
+		t.Fatalf("member without a registered master must remain a physical target: %+v", got)
+	}
+}
+
+func TestProjectDeviceEntriesRequiresMasterReportedGroup(t *testing.T) {
+	group := testStereoGroup()
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, nil),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("slave-only group data must not collapse the registry: %+v", got)
+	}
+}
+
+func TestProjectDeviceEntriesRejectsMalformedGroup(t *testing.T) {
+	group := testStereoGroup()
+	group.Roles.Roles[1].DeviceID = group.Roles.Roles[0].DeviceID
+
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("malformed pair must not hide a physical device: %+v", got)
+	}
+}
+
+func TestProjectDeviceEntriesRejectsConflictingMemberClaim(t *testing.T) {
+	masterGroup := testStereoGroup()
+	memberGroup := testStereoGroup()
+	memberGroup.ID = "different-pair"
+
+	got := projectDeviceEntries([]DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, masterGroup),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, memberGroup),
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("conflicting pair claims must fail open: %+v", got)
+	}
+}
+
+func TestHandleAPIDevicesUsesLogicalStereoProjection(t *testing.T) {
+	app := NewWebApp()
+	group := testStereoGroup()
+	for _, entry := range []DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+	} {
+		app.AddDevice(entry.ID, entry.Device)
+	}
+
+	response := httptest.NewRecorder()
+	app.HandleAPIDevices(response, httptest.NewRequest("GET", "/api/control/devices", nil))
+
+	var payload struct {
+		Success bool                  `json:"success"`
+		Data    map[string]deviceView `json:"data"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode devices response: %v", err)
+	}
+
+	if response.Code != http.StatusOK || !payload.Success || len(payload.Data) != 1 {
+		t.Fatalf("unexpected devices response: status=%d payload=%+v", response.Code, payload)
+	}
+
+	if pair := payload.Data["192.0.2.10"].StereoPair; pair == nil || pair.ID != "pair-1" || pair.MemberCount != 2 {
+		t.Fatalf("logical stereo metadata missing from devices API: %+v", payload.Data)
+	}
+}

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -1099,6 +1099,54 @@ func (app *WebApp) HandleZoneLeave(w http.ResponseWriter, r *http.Request) {
 		"Left zone")
 }
 
+// HandleGetZoneCandidates returns every registered physical device, for the
+// "add to zone" picker. Unlike HandleAPIDevices, this deliberately bypasses
+// the stereo-pair projection (deviceViewSnapshot): Zone and Group are
+// separate, unrelated groupings, and a device that's currently hidden as a
+// stereo-pair member (see device_projection.go) must still be an
+// independently addressable zone target, exactly as the backend
+// HandleZoneAdd/HandleZoneRemove already treat it (both look devices up via
+// the raw registry, unaffected by projection).
+//
+// Deliberately does not exclude the {id} device itself: which candidates to
+// exclude (the page's own device, current zone members, ...) is a caller
+// concern, not an inherent property of "what devices exist" -- excluding it
+// here would make this endpoint silently unusable for any future caller
+// that isn't Zone.js's current "add to my own zone" flow.
+func (app *WebApp) HandleGetZoneCandidates(w http.ResponseWriter, r *http.Request) {
+	deviceID := chi.URLParam(r, "id")
+
+	if _, exists := app.GetDevice(deviceID); !exists {
+		app.sendError(w, "Device not found", http.StatusNotFound)
+		return
+	}
+
+	type zoneCandidate struct {
+		Info *models.DeviceInfo `json:"info,omitempty"`
+	}
+
+	candidates := make(map[string]zoneCandidate)
+
+	for _, entry := range app.DeviceSnapshot() {
+		if entry.Device == nil || entry.Device.DeviceInfo == nil {
+			continue
+		}
+
+		candidates[entry.ID] = zoneCandidate{Info: entry.Device.DeviceInfo}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	response := webtypes.APIResponse{
+		Success: true,
+		Data:    candidates,
+	}
+
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
 // HandleDeviceRecents returns recently played items for a device.
 func (app *WebApp) HandleDeviceRecents(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "id")

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -114,11 +114,12 @@ func (app *WebApp) proxyServiceURL() string {
 	return app.ServiceURL
 }
 
-// DeviceEntry pairs a device id with its connection. Used by
-// DeviceSnapshot so callers can iterate without holding the lock.
+// DeviceEntry pairs a device id with its connection and the LastSeen value
+// captured by DeviceSnapshot under the registry lock.
 type DeviceEntry struct {
-	ID     string
-	Device *webtypes.DeviceConnection
+	ID       string
+	Device   *webtypes.DeviceConnection
+	LastSeen time.Time
 }
 
 // NewWebApp creates a new WebApp instance for SPA mode
@@ -142,9 +143,9 @@ func (app *WebApp) GetDevice(id string) (*webtypes.DeviceConnection, bool) {
 	return device, ok
 }
 
-// DeviceSnapshot returns a list of (id, *DeviceConnection) pairs taken
-// under a single read lock. Callers can iterate the result without
-// holding any registry lock. Devices added or removed after the call
+// DeviceSnapshot returns device entries taken under a single read lock.
+// Callers can iterate the result without holding any registry lock.
+// Devices added or removed after the call
 // are not reflected. A pointer captured here stays valid even if the
 // device is later removed (RemoveDevice only detaches it from the map
 // and stops its goroutines), so iterating a stale snapshot is safe.
@@ -154,7 +155,11 @@ func (app *WebApp) DeviceSnapshot() []DeviceEntry {
 
 	out := make([]DeviceEntry, 0, len(app.devices))
 	for id, device := range app.devices {
-		out = append(out, DeviceEntry{ID: id, Device: device})
+		out = append(out, DeviceEntry{
+			ID:       id,
+			Device:   device,
+			LastSeen: device.LastSeen,
+		})
 	}
 
 	return out

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -251,20 +251,9 @@ func (app *WebApp) HandleAPIDevices(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
 	// Return all devices as JSON
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
 	response := webtypes.APIResponse{
 		Success: true,
-		Data:    devices,
+		Data:    app.deviceViewSnapshot(),
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -734,20 +723,9 @@ func (app *WebApp) BroadcastDeviceList() {
 	app.WSMutex.RLock()
 	defer app.WSMutex.RUnlock()
 
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
 	message := webtypes.WebSocketMessage{
 		Type: "devices",
-		Data: devices,
+		Data: app.deviceViewSnapshot(),
 	}
 
 	// Send to all connected clients

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -893,3 +893,78 @@ func TestHandleZoneLeave_UsesRemoveZoneSlave(t *testing.T) {
 		t.Errorf("removeZoneSlave body should name the master, got: %s", masterBody)
 	}
 }
+
+// TestHandleGetZoneCandidates_IncludesHiddenPairMemberAndSelf guards two
+// things the stereo-pair projection (device_projection.go) must not affect:
+// Zone and Group are separate, unrelated groupings, so (a) a stereo pair's
+// hidden non-master member -- absent from the collapsed "devices" list --
+// must still be a valid zone-add candidate, matching how HandleZoneAdd
+// already treats it (raw registry lookup, unaffected by projection); and
+// (b) the endpoint itself does not exclude the requesting {id} device,
+// since deciding what to exclude (this page's own device, current zone
+// members, ...) is the caller's concern -- Zone.js already does this via
+// the existing zoneIps set, which includes the master's own IP even for a
+// standalone zone (see models.ZoneInfo.IsStandalone).
+func TestHandleGetZoneCandidates_IncludesHiddenPairMemberAndSelf(t *testing.T) {
+	app := NewWebApp()
+
+	group := testStereoGroup()
+	master := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{DeviceID: "left-id", Name: "Living Room", IPAddress: "192.0.2.10"})
+	master.SetStatus(&webtypes.DeviceStatus{IsConnected: true, Group: group})
+	app.AddDevice("192.0.2.10", master)
+
+	hiddenMember := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{DeviceID: "right-id", Name: "Living Room", IPAddress: "192.0.2.11"})
+	hiddenMember.SetStatus(&webtypes.DeviceStatus{IsConnected: true, Group: group})
+	app.AddDevice("192.0.2.11", hiddenMember)
+
+	standalone := webtypes.NewDeviceConnection(nil, &models.DeviceInfo{DeviceID: "kitchen-id", Name: "Kitchen", IPAddress: "192.0.2.12"})
+	standalone.SetStatus(&webtypes.DeviceStatus{IsConnected: true})
+	app.AddDevice("192.0.2.12", standalone)
+
+	// Sanity check: the hidden member really is absent from the projected
+	// device list this test is guarding against leaking into.
+	projected := app.deviceViewSnapshot()
+	if _, visible := projected["192.0.2.11"]; visible {
+		t.Fatal("test setup: expected 192.0.2.11 to be hidden by the stereo-pair projection")
+	}
+
+	req := httptest.NewRequest("GET", "/api/control/devices/192.0.2.10/zone/candidates", nil)
+	req = withChiParams(req, map[string]string{"id": "192.0.2.10"})
+	w := httptest.NewRecorder()
+
+	app.HandleGetZoneCandidates(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var response webtypes.APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	data, ok := response.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected data to be a map, got %T", response.Data)
+	}
+
+	for _, ip := range []string{"192.0.2.10", "192.0.2.11", "192.0.2.12"} {
+		if _, ok := data[ip]; !ok {
+			t.Errorf("expected %s in zone candidates, got: %+v", ip, data)
+		}
+	}
+}
+
+func TestHandleGetZoneCandidates_UnknownDeviceNotFound(t *testing.T) {
+	app := NewWebApp()
+
+	req := httptest.NewRequest("GET", "/api/control/devices/192.0.2.99/zone/candidates", nil)
+	req = withChiParams(req, map[string]string{"id": "192.0.2.99"})
+	w := httptest.NewRecorder()
+
+	app.HandleGetZoneCandidates(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for an unknown device, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -86,6 +86,7 @@ func (app *WebApp) MountWeb(r chi.Router, discoveryService *discovery.UnifiedDis
 
 				r.Route("/zone", func(r chi.Router) {
 					r.Get("/", app.HandleGetZone)
+					r.Get("/candidates", app.HandleGetZoneCandidates)
 					r.Post("/add/{slaveId}", app.HandleZoneAdd)
 					r.Post("/remove/{slaveId}", app.HandleZoneRemove)
 					r.Post("/dissolve", app.HandleZoneDissolve)

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -399,6 +399,8 @@ img { display: block; max-width: 100%; }
 }
 .device-type { font-size: .8rem; color: var(--text-dim); margin-bottom: .5rem; display: flex; gap: .4rem; flex-wrap: wrap; }
 .device-ip { color: var(--text); font-family: monospace; font-weight: 500; }
+.stereo-pair-state { color: var(--accent); font-weight: 600; }
+.stereo-pair-state.degraded { color: var(--offline); }
 
 .device-indicator {
     width: 8px; height: 8px; border-radius: 50%;

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -20,6 +20,7 @@ export const api = {
     power: (id) => req(`/api/control/devices/${id}/power`, { method: 'POST' }),
     recents: (id) => req(`/api/control/devices/${id}/recents`),
     zone: (id) => req(`/api/control/devices/${id}/zone`),
+    zoneCandidates: (id) => req(`/api/control/devices/${id}/zone/candidates`),
     zoneAdd: (masterId, slaveId) => req(`/api/control/devices/${masterId}/zone/add/${slaveId}`, { method: 'POST' }),
     zoneRemove: (masterId, slaveId) => req(`/api/control/devices/${masterId}/zone/remove/${slaveId}`, { method: 'POST' }),
     zoneDissolve: (id) => req(`/api/control/devices/${id}/zone/dissolve`, { method: 'POST' }),

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -135,6 +135,13 @@ function App() {
         };
     }, []);
 
+    useEffect(() => {
+        if (selectedId && !devices[selectedId]) {
+            setSelectedId(null);
+            if (page === 'device') setPage('devices');
+        }
+    }, [devices, selectedId, page]);
+
     function showToast(msg) {
         setToast(null);
         setTimeout(() => setToast(msg), 10);

--- a/pkg/service/soundtouchweb/static/js/components/DeviceList.js
+++ b/pkg/service/soundtouchweb/static/js/components/DeviceList.js
@@ -23,6 +23,7 @@ function sortEntries(entries, mode) {
 
 function DeviceCard({ id, device, onSelect, onRemove }) {
     const { info, status } = device;
+    const stereoPair = device.stereoPair;
     const np = status?.nowPlaying;
     const isPlaying = np?.PlayStatus === 'PLAY_STATE';
     const isStandby = !np || np.Source === 'STANDBY';
@@ -33,14 +34,19 @@ function DeviceCard({ id, device, onSelect, onRemove }) {
                 <span class="device-name">${info?.name || id}</span>
                 <span class="device-header-right">
                     <span class="device-indicator ${status?.isConnected ? 'online' : 'offline'}"></span>
-                    <button class="device-remove" title="Remove this device"
+                    ${!stereoPair ? html`<button class="device-remove" title="Remove this device"
                             aria-label="Remove this device"
-                            onClick=${(e) => { e.stopPropagation(); onRemove(id); }}>✕</button>
+                            onClick=${(e) => { e.stopPropagation(); onRemove(id); }}>✕</button>` : null}
                 </span>
             </div>
             <div class="device-type">
                 ${info?.type || ''}
                 ${info?.ip_address ? html`<span class="device-ip">(${info.ip_address})</span>` : null}
+                ${stereoPair ? html`
+                    <span class="stereo-pair-state ${stereoPair.degraded ? 'degraded' : ''}">
+                        Stereo pair ${stereoPair.availableMemberCount}/${stereoPair.memberCount}
+                    </span>
+                ` : null}
             </div>
             ${!isStandby ? html`
                 <div class="now-playing-mini">

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -23,11 +23,26 @@ export function Library({ devices }) {
     // invalidate the current selection.
     useEffect(() => {
         const entries = Object.entries(devices);
-        if ((!deviceId || !devices[deviceId]) && entries.length > 0) {
-            setDeviceId(entries[0][0]);
-        } else if (deviceId && entries.length === 0) {
-            setDeviceId(null);
+        if (deviceId && devices[deviceId]) return;
+
+        if (entries.length === 0) {
+            if (deviceId) setDeviceId(null);
+            return;
         }
+
+        if (deviceId) {
+            // The selected device vanished from the list -- if that's because
+            // it just became a hidden stereo-pair member (see
+            // device_projection.go), follow it to its pair's master instead
+            // of silently jumping to an unrelated device.
+            const master = entries.find(([, d]) => d.stereoPair?.members?.some(m => m.ipAddress === deviceId));
+            if (master) {
+                setDeviceId(master[0]);
+                return;
+            }
+        }
+
+        setDeviceId(entries[0][0]);
     }, [devices, deviceId]);
 
     // Reload registered servers whenever deviceId changes.

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -23,10 +23,12 @@ export function Library({ devices }) {
     // invalidate the current selection.
     useEffect(() => {
         const entries = Object.entries(devices);
-        if (!deviceId && entries.length > 0) {
+        if ((!deviceId || !devices[deviceId]) && entries.length > 0) {
             setDeviceId(entries[0][0]);
+        } else if (deviceId && entries.length === 0) {
+            setDeviceId(null);
         }
-    }, [devices]);
+    }, [devices, deviceId]);
 
     // Reload registered servers whenever deviceId changes.
     useEffect(() => {

--- a/pkg/service/soundtouchweb/static/js/components/Zone.js
+++ b/pkg/service/soundtouchweb/static/js/components/Zone.js
@@ -7,13 +7,17 @@ const html = htm.bind(h);
 
 export function Zone({ deviceId, devices }) {
     const [zone, setZone] = useState(null);
+    const [candidates, setCandidates] = useState({});
     const [loading, setLoading] = useState(true);
     const [showPicker, setShowPicker] = useState(false);
 
     function refresh() {
-        api.zone(deviceId).then(resp => {
-            if (resp.success) setZone(resp.data);
-        }).finally(() => setLoading(false));
+        Promise.all([api.zone(deviceId), api.zoneCandidates(deviceId)])
+            .then(([zoneResp, candidatesResp]) => {
+                if (zoneResp.success) setZone(zoneResp.data);
+                if (candidatesResp.success) setCandidates(candidatesResp.data || {});
+            })
+            .finally(() => setLoading(false));
     }
 
     useEffect(() => { refresh(); }, [deviceId]);
@@ -48,11 +52,15 @@ export function Zone({ deviceId, devices }) {
 
     if (!zone) return null;
 
-    // Devices not already in the zone are available to add
+    // Devices not already in the zone are available to add. Sourced from a
+    // dedicated candidates endpoint rather than the `devices` prop: Zone and
+    // Group are separate, unrelated groupings, so a stereo pair's hidden
+    // member -- absent from the collapsed device list -- is still a valid,
+    // independent zone-add target.
     const zoneIps = new Set([zone.masterIp, ...(zone.members || []).map(m => m.ip)].filter(Boolean));
-    const available = Object.entries(devices || {}).filter(([ip]) => !zoneIps.has(ip));
+    const available = Object.entries(candidates).filter(([ip]) => !zoneIps.has(ip));
 
-    const deviceName = (ip) => devices[ip]?.info?.name || ip;
+    const deviceName = (ip) => devices[ip]?.info?.name || candidates[ip]?.info?.name || ip;
 
     return html`
         <div class="zone-section">

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -303,7 +303,9 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 		return
 	}
 
-	// /getGroup is ST10-only; ST20/ST30 may accept the request but never reply.
+	// /getGroup must be gated to ST10 models -- see Client.GetGroup's doc
+	// comment (verified against real hardware: a ST20 never replies at all,
+	// hanging until the client's timeout instead of returning quickly).
 	stereoCapable := stereoPairCapable(conn.DeviceInfo)
 
 	var groupGeneration uint64

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -46,23 +46,10 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send initial device list
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
-	initialMessage := webtypes.WebSocketMessage{
+	if err := conn.WriteJSON(webtypes.WebSocketMessage{
 		Type: "devices",
-		Data: devices,
-	}
-
-	if err := conn.WriteJSON(initialMessage); err != nil {
+		Data: app.deviceViewSnapshot(),
+	}); err != nil {
 		log.Printf("Failed to send initial data: %v", err)
 		return
 	}
@@ -100,21 +87,14 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Send periodic status updates
-		for _, entry := range app.DeviceSnapshot() {
-			status := entry.Device.Status()
-			if status.IsConnected {
-				statusMessage := webtypes.WebSocketMessage{
-					Type:     "status_update",
-					DeviceID: entry.ID,
-					Data:     status,
-				}
-
-				if err := conn.WriteJSON(statusMessage); err != nil {
-					log.Printf("Failed to send status update: %v", err)
-					return
-				}
-			}
+		// A full projected list keeps pair topology and availability current
+		// without event handlers writing to this browser connection.
+		if err := conn.WriteJSON(webtypes.WebSocketMessage{
+			Type: "devices",
+			Data: app.deviceViewSnapshot(),
+		}); err != nil {
+			log.Printf("Failed to send device update: %v", err)
+			return
 		}
 	}
 }
@@ -218,6 +198,10 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 			})
 		})
 
+		wsClient.OnGroupUpdated(func(event *models.GroupUpdatedEvent) {
+			applyGroupUpdatedEvent(conn, event)
+		})
+
 		if err := wsClient.Connect(); err != nil {
 			log.Printf("Failed to connect WebSocket for device %s: %v (retrying in %s)", sanitizeLog(deviceID), err, backoff)
 
@@ -298,6 +282,8 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 		return
 	}
 
+	groupGeneration := conn.BeginGroupRefresh()
+
 	// Phase 1: slow network fetches. Local vars only, no shared state
 	// is touched yet. Errors are recorded so the merge below can tell
 	// "field N stayed unchanged" apart from "field N got refreshed".
@@ -306,6 +292,7 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 	presets, presetsErr := conn.Client.GetPresets()
 	sources, sourcesErr := conn.Client.GetSources()
 	bass, bassErr := conn.Client.GetBass()
+	group, groupErr := conn.Client.GetGroup()
 
 	// Phase 2: fast merge. Only fields we successfully fetched
 	// overwrite; everything else keeps the value other goroutines may
@@ -338,11 +325,21 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 			statusUpdated = true
 		}
 
+		statusUpdated = statusUpdated || groupErr == nil
+
 		// Mark as connected if we successfully got at least one
 		// status from this round. Mirrors prior behaviour.
 		s.IsConnected = statusUpdated
 		s.LastActivity = time.Now()
 	})
+
+	if groupErr == nil {
+		conn.ApplyPolledGroup(groupGeneration, group)
+	}
+}
+
+func applyGroupUpdatedEvent(conn *webtypes.DeviceConnection, event *models.GroupUpdatedEvent) {
+	conn.ApplyGroupEvent(&event.Group, time.Now())
 }
 
 // HandleDeviceWebSocket handles individual device WebSocket connections for real-time device-specific updates

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -87,16 +87,37 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// A full projected list keeps pair topology and availability current
-		// without event handlers writing to this browser connection.
-		if err := conn.WriteJSON(webtypes.WebSocketMessage{
-			Type: "devices",
-			Data: app.deviceViewSnapshot(),
-		}); err != nil {
-			log.Printf("Failed to send device update: %v", err)
-			return
+		for _, message := range app.periodicPlayerMessages() {
+			if err := conn.WriteJSON(message); err != nil {
+				log.Printf("Failed to send device update: %v", err)
+				return
+			}
 		}
 	}
+}
+
+// periodicPlayerMessages refreshes the projected inventory while retaining
+// the established per-device status_update stream for API clients.
+func (app *WebApp) periodicPlayerMessages() []webtypes.WebSocketMessage {
+	snapshot := captureDeviceProjectionEntries(app.DeviceSnapshot())
+	messages := []webtypes.WebSocketMessage{{
+		Type: "devices",
+		Data: projectCapturedDeviceEntries(snapshot),
+	}}
+
+	for _, entry := range snapshot {
+		if entry.Status == nil || !entry.Status.IsConnected {
+			continue
+		}
+
+		messages = append(messages, webtypes.WebSocketMessage{
+			Type:     "status_update",
+			DeviceID: entry.ID,
+			Data:     entry.Status,
+		})
+	}
+
+	return messages
 }
 
 // HandleAPIDiscover triggers device discovery

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -303,7 +303,13 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 		return
 	}
 
-	groupGeneration := conn.BeginGroupRefresh()
+	// /getGroup is ST10-only; ST20/ST30 may accept the request but never reply.
+	stereoCapable := stereoPairCapable(conn.DeviceInfo)
+
+	var groupGeneration uint64
+	if stereoCapable {
+		groupGeneration = conn.BeginGroupRefresh()
+	}
 
 	// Phase 1: slow network fetches. Local vars only, no shared state
 	// is touched yet. Errors are recorded so the merge below can tell
@@ -313,7 +319,15 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 	presets, presetsErr := conn.Client.GetPresets()
 	sources, sourcesErr := conn.Client.GetSources()
 	bass, bassErr := conn.Client.GetBass()
-	group, groupErr := conn.Client.GetGroup()
+
+	var (
+		group    *models.Group
+		groupErr error
+	)
+
+	if stereoCapable {
+		group, groupErr = conn.Client.GetGroup()
+	}
 
 	// Phase 2: fast merge. Only fields we successfully fetched
 	// overwrite; everything else keeps the value other goroutines may
@@ -346,7 +360,7 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 			statusUpdated = true
 		}
 
-		statusUpdated = statusUpdated || groupErr == nil
+		statusUpdated = statusUpdated || (stereoCapable && groupErr == nil)
 
 		// Mark as connected if we successfully got at least one
 		// status from this round. Mirrors prior behaviour.
@@ -354,7 +368,7 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 		s.LastActivity = time.Now()
 	})
 
-	if groupErr == nil {
+	if stereoCapable && groupErr == nil {
 		conn.ApplyPolledGroup(groupGeneration, group)
 	}
 }

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -362,10 +362,13 @@ func (app *WebApp) UpdateDeviceStatus(_ string, conn *webtypes.DeviceConnection)
 			statusUpdated = true
 		}
 
-		statusUpdated = statusUpdated || (stereoCapable && groupErr == nil)
-
-		// Mark as connected if we successfully got at least one
-		// status from this round. Mirrors prior behaviour.
+		// Mark as connected if we successfully got at least one status
+		// from this round. Mirrors prior behaviour: deliberately does NOT
+		// fold groupErr in here. GetGroup is gated to stereo-capable
+		// models and trivially succeeds even when a device is otherwise
+		// struggling (an empty <group/> is a near-guaranteed reply), so
+		// counting it would let a device report connected while every
+		// substantive status fetch above actually failed this round.
 		s.IsConnected = statusUpdated
 		s.LastActivity = time.Now()
 	})

--- a/pkg/service/soundtouchweb/websocket_test.go
+++ b/pkg/service/soundtouchweb/websocket_test.go
@@ -3,6 +3,7 @@ package soundtouchweb
 import (
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestUpdateDeviceStatusRefreshesGroup(t *testing.T) {
 	</group>`)
 	defer server.Close()
 
-	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), nil)
+	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), &models.DeviceInfo{Type: "SoundTouch 10"})
 	NewWebApp().UpdateDeviceStatus("device-1", conn)
 
 	status := conn.Status()
@@ -48,7 +49,7 @@ func TestUpdateDeviceStatusPreservesGroupOnError(t *testing.T) {
 	server := newStatusTestServer(t, http.StatusInternalServerError, "group unavailable")
 	defer server.Close()
 
-	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), nil)
+	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), &models.DeviceInfo{Type: "SoundTouch 10"})
 	existing := &models.Group{ID: "pair-old", Name: "Existing Pair"}
 	conn.SetStatus(&webtypes.DeviceStatus{Group: existing})
 
@@ -61,6 +62,51 @@ func TestUpdateDeviceStatusPreservesGroupOnError(t *testing.T) {
 
 	if !status.IsConnected {
 		t.Error("other successful status fetches should keep the device connected")
+	}
+}
+
+func TestUpdateDeviceStatusSkipsGroupForNonStereoModel(t *testing.T) {
+	var groupRequested atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/getGroup" {
+			groupRequested.Store(true)
+			http.Error(w, "unsupported endpoint", http.StatusInternalServerError)
+
+			return
+		}
+
+		responses := map[string]string{
+			"/now_playing": `<nowPlaying source="STANDBY"><playStatus>STOP_STATE</playStatus></nowPlaying>`,
+			"/volume":      `<volume><targetvolume>10</targetvolume><actualvolume>10</actualvolume><muteenabled>false</muteenabled></volume>`,
+			"/presets":     `<presets/>`,
+			"/sources":     `<sources/>`,
+			"/bass":        `<bass><targetbass>0</targetbass><actualbass>0</actualbass></bass>`,
+		}
+		body, ok := responses[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(body))
+	}))
+	defer server.Close()
+
+	for _, model := range []string{"SoundTouch 20", "SoundTouch 30"} {
+		t.Run(model, func(t *testing.T) {
+			conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), &models.DeviceInfo{Type: model})
+			NewWebApp().UpdateDeviceStatus("device-1", conn)
+
+			if !conn.Status().IsConnected {
+				t.Fatal("successful ordinary status requests should mark a non-stereo model connected")
+			}
+		})
+	}
+
+	if groupRequested.Load() {
+		t.Fatal("UpdateDeviceStatus requested /getGroup for a non-stereo model")
 	}
 }
 

--- a/pkg/service/soundtouchweb/websocket_test.go
+++ b/pkg/service/soundtouchweb/websocket_test.go
@@ -110,6 +110,33 @@ func TestUpdateDeviceStatusSkipsGroupForNonStereoModel(t *testing.T) {
 	}
 }
 
+// TestUpdateDeviceStatusNotConnectedWhenOnlyGroupSucceeds covers a stereo-
+// capable device where every substantive status fetch fails but /getGroup
+// alone succeeds (a near-guaranteed reply -- even an empty <group/> is a
+// success, see Client.GetGroup's doc comment). IsConnected must not be set
+// from GetGroup's success alone, or a device with genuinely stale
+// NowPlaying/Volume/Presets/Sources/Bass data would be reported connected.
+func TestUpdateDeviceStatusNotConnectedWhenOnlyGroupSucceeds(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/getGroup" {
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(`<group/>`))
+
+			return
+		}
+
+		http.Error(w, "device struggling", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), &models.DeviceInfo{Type: "SoundTouch 10"})
+	NewWebApp().UpdateDeviceStatus("device-1", conn)
+
+	if conn.Status().IsConnected {
+		t.Fatal("IsConnected must stay false when every substantive status fetch failed, even though GetGroup alone succeeded")
+	}
+}
+
 func TestApplyGroupUpdatedEventReplacesGroup(t *testing.T) {
 	conn := webtypes.NewDeviceConnection(nil, nil)
 	previousActivity := time.Unix(1, 0)

--- a/pkg/service/soundtouchweb/websocket_test.go
+++ b/pkg/service/soundtouchweb/websocket_test.go
@@ -100,6 +100,42 @@ func TestApplyGroupUpdatedEventReplacesGroup(t *testing.T) {
 	}
 }
 
+func TestPeriodicPlayerMessagesPreserveStatusUpdateStream(t *testing.T) {
+	app := NewWebApp()
+	group := testStereoGroup()
+	for _, entry := range []DeviceEntry{
+		projectionDevice("192.0.2.10", "left-id", "Living Room", true, group),
+		projectionDevice("192.0.2.11", "right-id", "Living Room", true, group),
+		projectionDevice("192.0.2.12", "standalone-id", "Kitchen", false, nil),
+	} {
+		app.AddDevice(entry.ID, entry.Device)
+	}
+
+	messages := app.periodicPlayerMessages()
+	if len(messages) != 3 {
+		t.Fatalf("periodic messages = %d, want one devices frame and two connected status updates: %+v", len(messages), messages)
+	}
+
+	if messages[0].Type != "devices" {
+		t.Fatalf("first periodic message type = %q, want devices", messages[0].Type)
+	}
+	devices, ok := messages[0].Data.(map[string]deviceView)
+	if !ok || len(devices) != 2 || devices["192.0.2.10"].StereoPair == nil {
+		t.Fatalf("periodic devices frame is not the logical projection: %#v", messages[0].Data)
+	}
+
+	statusUpdates := make(map[string]bool)
+	for _, message := range messages[1:] {
+		if message.Type != "status_update" {
+			t.Fatalf("periodic message type = %q, want status_update", message.Type)
+		}
+		statusUpdates[message.DeviceID] = true
+	}
+	if !statusUpdates["192.0.2.10"] || !statusUpdates["192.0.2.11"] || statusUpdates["192.0.2.12"] {
+		t.Fatalf("unexpected status_update device IDs: %+v", statusUpdates)
+	}
+}
+
 func newStatusTestServer(t *testing.T, groupStatus int, groupBody string) *httptest.Server {
 	t.Helper()
 

--- a/pkg/service/soundtouchweb/websocket_test.go
+++ b/pkg/service/soundtouchweb/websocket_test.go
@@ -1,0 +1,141 @@
+package soundtouchweb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/client"
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
+)
+
+func TestUpdateDeviceStatusRefreshesGroup(t *testing.T) {
+	server := newStatusTestServer(t, http.StatusOK, `<group id="pair-1">
+		<name>Living Room</name>
+		<masterDeviceId>master-1</masterDeviceId>
+		<roles>
+			<groupRole><deviceId>master-1</deviceId><role>LEFT</role></groupRole>
+			<groupRole><deviceId>member-1</deviceId><role>RIGHT</role></groupRole>
+		</roles>
+		<status>GROUP_OK</status>
+	</group>`)
+	defer server.Close()
+
+	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), nil)
+	NewWebApp().UpdateDeviceStatus("device-1", conn)
+
+	status := conn.Status()
+	if status.Group == nil {
+		t.Fatal("Group was not populated by UpdateDeviceStatus")
+	}
+
+	if status.Group.ID != "pair-1" || status.Group.MasterDeviceID != "master-1" {
+		t.Errorf("Group = %+v, want refreshed stereo pair", status.Group)
+	}
+
+	if len(status.Group.Roles.Roles) != 2 {
+		t.Errorf("group roles = %d, want 2", len(status.Group.Roles.Roles))
+	}
+
+	if !status.IsConnected {
+		t.Error("successful status refresh should mark the device connected")
+	}
+}
+
+func TestUpdateDeviceStatusPreservesGroupOnError(t *testing.T) {
+	server := newStatusTestServer(t, http.StatusInternalServerError, "group unavailable")
+	defer server.Close()
+
+	conn := webtypes.NewDeviceConnection(client.NewClientFromHost(server.URL), nil)
+	existing := &models.Group{ID: "pair-old", Name: "Existing Pair"}
+	conn.SetStatus(&webtypes.DeviceStatus{Group: existing})
+
+	NewWebApp().UpdateDeviceStatus("device-1", conn)
+
+	status := conn.Status()
+	if status.Group != existing {
+		t.Errorf("Group = %+v, want previous group preserved on refresh error", status.Group)
+	}
+
+	if !status.IsConnected {
+		t.Error("other successful status fetches should keep the device connected")
+	}
+}
+
+func TestApplyGroupUpdatedEventReplacesGroup(t *testing.T) {
+	conn := webtypes.NewDeviceConnection(nil, nil)
+	previousActivity := time.Unix(1, 0)
+	conn.SetStatus(&webtypes.DeviceStatus{
+		Group:        &models.Group{ID: "pair-old"},
+		Volume:       &models.Volume{ActualVolume: 25},
+		IsConnected:  true,
+		LastActivity: previousActivity,
+	})
+
+	event := &models.GroupUpdatedEvent{
+		Group: models.Group{ID: "pair-new", Name: "Renamed Pair"},
+	}
+	applyGroupUpdatedEvent(conn, event)
+
+	status := conn.Status()
+	if status.Group != &event.Group || status.Group.ID != "pair-new" {
+		t.Errorf("Group = %+v, want event group", status.Group)
+	}
+
+	if status.Volume == nil || status.Volume.ActualVolume != 25 || !status.IsConnected {
+		t.Errorf("unrelated status fields were not preserved: %+v", status)
+	}
+
+	if !status.LastActivity.After(previousActivity) {
+		t.Errorf("LastActivity = %s, want after %s", status.LastActivity, previousActivity)
+	}
+
+	teardown := &models.GroupUpdatedEvent{Group: models.Group{}}
+	applyGroupUpdatedEvent(conn, teardown)
+
+	if conn.Status().Group != nil {
+		t.Errorf("teardown event did not clear the group: %+v", conn.Status().Group)
+	}
+}
+
+func newStatusTestServer(t *testing.T, groupStatus int, groupBody string) *httptest.Server {
+	t.Helper()
+
+	responses := map[string]string{
+		"/now_playing": `<nowPlaying source="STANDBY"><playStatus>STOP_STATE</playStatus></nowPlaying>`,
+		"/volume":      `<volume><targetvolume>10</targetvolume><actualvolume>10</actualvolume><muteenabled>false</muteenabled></volume>`,
+		"/presets":     `<presets/>`,
+		"/sources":     `<sources/>`,
+		"/bass":        `<bass><targetbass>0</targetbass><actualbass>0</actualbass></bass>`,
+	}
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method for %s = %s, want GET", r.URL.Path, r.Method)
+			w.WriteHeader(http.StatusMethodNotAllowed)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/xml")
+
+		if r.URL.Path == "/getGroup" {
+			w.WriteHeader(groupStatus)
+			_, _ = w.Write([]byte(groupBody))
+
+			return
+		}
+
+		body, ok := responses[r.URL.Path]
+		if !ok {
+			t.Errorf("unexpected status endpoint %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+
+			return
+		}
+
+		_, _ = w.Write([]byte(body))
+	}))
+}

--- a/pkg/service/soundtouchweb/webtypes/status_test.go
+++ b/pkg/service/soundtouchweb/webtypes/status_test.go
@@ -176,6 +176,39 @@ func TestEmptyGroupClearsCurrentClaim(t *testing.T) {
 	}
 }
 
+// TestApplyGroupEventIgnoresRoleOrder guards replaceGroup's change-detection
+// against a spurious "changed" report when the same pair's roles simply
+// arrive in a different order -- a polled /getGroup response and a pushed
+// groupUpdated event both populate Roles.Roles straight from XML unmarshal
+// in wire order, so nothing guarantees they list LEFT/RIGHT the same way
+// every time for the identical pair.
+func TestApplyGroupEventIgnoresRoleOrder(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+
+	leftFirst := &models.Group{
+		ID:             "pair-1",
+		MasterDeviceID: "master",
+		Roles: models.GroupRoles{Roles: []models.GroupRole{
+			{DeviceID: "master", Role: "LEFT"},
+			{DeviceID: "member", Role: "RIGHT"},
+		}},
+	}
+	conn.SetStatus(&DeviceStatus{Group: leftFirst})
+
+	rightFirst := &models.Group{
+		ID:             "pair-1",
+		MasterDeviceID: "master",
+		Roles: models.GroupRoles{Roles: []models.GroupRole{
+			{DeviceID: "member", Role: "RIGHT"},
+			{DeviceID: "master", Role: "LEFT"},
+		}},
+	}
+
+	if conn.ApplyGroupEvent(rightFirst, time.Now()) {
+		t.Fatal("reordered roles for the same pair must not report a change")
+	}
+}
+
 func TestStatusSnapshotIsolation(t *testing.T) {
 	// A snapshot returned by Status() must NOT change when a later
 	// UpdateStatus replaces a pointer field. This proves the atomic

--- a/pkg/service/soundtouchweb/webtypes/status_test.go
+++ b/pkg/service/soundtouchweb/webtypes/status_test.go
@@ -3,9 +3,11 @@
 package webtypes
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gesellix/bose-soundtouch/pkg/models"
 )
@@ -75,6 +77,7 @@ func TestUpdateStatus_PreservesUnchangedFields(t *testing.T) {
 	conn.SetStatus(&DeviceStatus{
 		Volume:      &models.Volume{ActualVolume: 10},
 		Bass:        &models.Bass{ActualBass: 3},
+		Group:       &models.Group{ID: "pair-1", Name: "Living Room"},
 		IsConnected: true,
 	})
 
@@ -92,8 +95,84 @@ func TestUpdateStatus_PreservesUnchangedFields(t *testing.T) {
 		t.Errorf("Bass not preserved: %+v", got.Bass)
 	}
 
+	if got.Group == nil || got.Group.ID != "pair-1" {
+		t.Errorf("Group not preserved: %+v", got.Group)
+	}
+
 	if !got.IsConnected {
 		t.Error("IsConnected not preserved")
+	}
+}
+
+func TestDeviceStatusGroupJSON(t *testing.T) {
+	status := DeviceStatus{
+		Group: &models.Group{
+			ID:             "pair-1",
+			Name:           "Living Room",
+			MasterDeviceID: "master-1",
+		},
+	}
+
+	payload, err := json.Marshal(status)
+	if err != nil {
+		t.Fatalf("Marshal DeviceStatus: %v", err)
+	}
+
+	var decoded struct {
+		Group *models.Group `json:"group"`
+	}
+
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		t.Fatalf("Unmarshal DeviceStatus: %v", err)
+	}
+
+	if decoded.Group == nil || decoded.Group.ID != "pair-1" || decoded.Group.MasterDeviceID != "master-1" {
+		t.Fatalf("group did not round-trip in status JSON: %+v", decoded.Group)
+	}
+
+	emptyPayload, err := json.Marshal(DeviceStatus{})
+	if err != nil {
+		t.Fatalf("Marshal empty DeviceStatus: %v", err)
+	}
+
+	var emptyDecoded map[string]json.RawMessage
+	if err := json.Unmarshal(emptyPayload, &emptyDecoded); err != nil {
+		t.Fatalf("Unmarshal empty DeviceStatus: %v", err)
+	}
+
+	if _, ok := emptyDecoded["group"]; ok {
+		t.Errorf("nil group should be omitted, JSON = %s", emptyPayload)
+	}
+}
+
+func TestGroupEventSupersedesInFlightPoll(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+	generation := conn.BeginGroupRefresh()
+
+	eventGroup := &models.Group{ID: "new-pair", MasterDeviceID: "master"}
+	if !conn.ApplyGroupEvent(eventGroup, time.Now()) {
+		t.Fatal("new group event should change group state")
+	}
+
+	if conn.ApplyPolledGroup(generation, &models.Group{ID: "stale-pair"}) {
+		t.Fatal("stale poll must not replace a newer group event")
+	}
+
+	if got := conn.Status().Group; got == nil || got.ID != "new-pair" {
+		t.Fatalf("Group = %+v, want newer event state", got)
+	}
+}
+
+func TestEmptyGroupClearsCurrentClaim(t *testing.T) {
+	conn := NewDeviceConnection(nil, &models.DeviceInfo{Name: "test"})
+	conn.SetStatus(&DeviceStatus{Group: &models.Group{ID: "pair-1"}})
+
+	if !conn.ApplyGroupEvent(&models.Group{}, time.Now()) {
+		t.Fatal("empty teardown event should change group state")
+	}
+
+	if got := conn.Status().Group; got != nil {
+		t.Fatalf("Group = %+v, want nil after teardown", got)
 	}
 }
 

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -2,7 +2,6 @@
 package webtypes
 
 import (
-	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -190,7 +189,7 @@ func (c *DeviceConnection) ApplyGroupEvent(group *models.Group, activity time.Ti
 }
 
 func (c *DeviceConnection) replaceGroup(group *models.Group, activity time.Time) bool {
-	changed := !reflect.DeepEqual(c.Status().Group, group)
+	changed := !models.SameGroup(c.Status().Group, group)
 	c.UpdateStatus(func(s *DeviceStatus) {
 		s.Group = group
 		if !activity.IsZero() {

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -29,7 +29,6 @@ type SoundTouchClient interface {
 	GetPresets() (*models.Presets, error)
 	GetSources() (*models.Sources, error)
 	GetBass() (*models.Bass, error)
-	GetGroup() (*models.Group, error)
 	NewWebSocketClient(config interface{}) *client.WebSocketClient
 }
 

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -2,6 +2,7 @@
 package webtypes
 
 import (
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,6 +29,7 @@ type SoundTouchClient interface {
 	GetPresets() (*models.Presets, error)
 	GetSources() (*models.Sources, error)
 	GetBass() (*models.Bass, error)
+	GetGroup() (*models.Group, error)
 	NewWebSocketClient(config interface{}) *client.WebSocketClient
 }
 
@@ -47,6 +49,12 @@ type DeviceConnection struct {
 
 	status atomic.Pointer[DeviceStatus]
 
+	// groupMu orders polled /getGroup responses against real-time
+	// groupUpdated events. Starting a newer refresh or receiving an event
+	// invalidates any older in-flight poll.
+	groupMu         sync.Mutex
+	groupGeneration uint64
+
 	// done is closed by Close when the device is removed from the
 	// registry, signalling its background goroutines (the status poller
 	// and the WebSocket reconnect loop) to exit. closeOnce keeps Close
@@ -62,6 +70,7 @@ type DeviceStatus struct {
 	Presets      *models.Presets    `json:"presets,omitempty"`
 	Sources      *models.Sources    `json:"sources,omitempty"`
 	Bass         *models.Bass       `json:"bass,omitempty"`
+	Group        *models.Group      `json:"group,omitempty"`
 	IsConnected  bool               `json:"isConnected"`
 	LastActivity time.Time          `json:"lastActivity"`
 }
@@ -85,10 +94,9 @@ func NewDeviceConnection(c *client.Client, info *models.DeviceInfo) *DeviceConne
 }
 
 // Status returns a snapshot of the current device status. The returned
-// pointer is read-only from the caller's perspective; mutating the
-// pointed-to struct has no effect on the stored status. Use
-// UpdateStatus or SetStatus to apply changes. Never returns nil for
-// connections built via NewDeviceConnection.
+// pointer is read-only from the caller's perspective and must not be
+// mutated. Use UpdateStatus or SetStatus to apply changes. Never returns
+// nil for connections built via NewDeviceConnection.
 func (c *DeviceConnection) Status() *DeviceStatus {
 	return c.status.Load()
 }
@@ -128,7 +136,7 @@ func (c *DeviceConnection) SetStatus(s *DeviceStatus) {
 // writers cannot silently lose each other's changes.
 //
 // The copy mut receives is a shallow value copy of the previous status.
-// Nested pointer fields (NowPlaying, Volume, Presets, Sources, Bass)
+// Nested pointer fields (NowPlaying, Volume, Presets, Sources, Bass, Group)
 // share their backing struct with the previous version: callers MUST
 // REPLACE these pointers (s.Volume = &models.Volume{...}) rather than
 // mutate through them (s.Volume.ActualVolume++ would race with any
@@ -145,6 +153,61 @@ func (c *DeviceConnection) UpdateStatus(mut func(*DeviceStatus)) {
 			return
 		}
 	}
+}
+
+// BeginGroupRefresh starts a new generation for an asynchronous /getGroup
+// request. Only the latest started request may later update Group.
+func (c *DeviceConnection) BeginGroupRefresh() uint64 {
+	c.groupMu.Lock()
+	defer c.groupMu.Unlock()
+
+	c.groupGeneration++
+
+	return c.groupGeneration
+}
+
+// ApplyPolledGroup stores a /getGroup result only when no newer poll or
+// groupUpdated event superseded it. Empty groups clear the current claim.
+func (c *DeviceConnection) ApplyPolledGroup(generation uint64, group *models.Group) bool {
+	c.groupMu.Lock()
+	defer c.groupMu.Unlock()
+
+	if generation != c.groupGeneration {
+		return false
+	}
+
+	return c.replaceGroup(normalizeGroup(group), time.Time{})
+}
+
+// ApplyGroupEvent stores the newest groupUpdated event and invalidates all
+// in-flight /getGroup requests. Empty teardown events clear the current claim.
+func (c *DeviceConnection) ApplyGroupEvent(group *models.Group, activity time.Time) bool {
+	c.groupMu.Lock()
+	defer c.groupMu.Unlock()
+
+	c.groupGeneration++
+
+	return c.replaceGroup(normalizeGroup(group), activity)
+}
+
+func (c *DeviceConnection) replaceGroup(group *models.Group, activity time.Time) bool {
+	changed := !reflect.DeepEqual(c.Status().Group, group)
+	c.UpdateStatus(func(s *DeviceStatus) {
+		s.Group = group
+		if !activity.IsZero() {
+			s.LastActivity = activity
+		}
+	})
+
+	return changed
+}
+
+func normalizeGroup(group *models.Group) *models.Group {
+	if group == nil || group.IsEmpty() {
+		return nil
+	}
+
+	return group
 }
 
 // APIResponse is a standard JSON response wrapper


### PR DESCRIPTION
## Summary

soundtouch-player currently lists both physical members of a stereo pair as independent control targets. This change projects a validated two-speaker `LEFT`/`RIGHT` group as one logical target keyed by its master speaker.

The implementation:

- tracks `/getGroup` state alongside the existing device status and applies `groupUpdated` events without allowing an older poll to overwrite a newer event;
- polls the SoundTouch 10-only `/getGroup` endpoint only for models that support stereo pairing, so ordinary refresh remains responsive on SoundTouch 20 and SoundTouch 30 speakers;
- collapses only exact two-member groups whose registered members agree on the group claim, while malformed or conflicting data fails open to the physical entries;
- uses the same logical-device projection for the REST list and global player WebSocket while retaining the established per-device `status_update` frames;
- captures each device's discovery timestamp under the registry lock before projecting it, avoiding a race with concurrent discovery refreshes;
- reports member availability and a degraded state to the player; and
- leaves the raw physical-device registry and pair lifecycle unchanged.

The player intentionally does not offer its existing single-device remove action for a projected pair. Pair creation, rename, and dissolve remain available through the existing client and CLI group operations.

This is the projection prerequisite for #665, #666, and #655. Until it merges, GitHub comparisons for those stacked PRs also include these five commits.

## Linked issue

Refs #252

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (fmt, vet, lint, tests)
- [x] Tested against a real SoundTouch device (details below)

The original four patches were rebased onto current `main` without semantic changes (`git range-diff` reports all four as identical), followed by the timestamp-snapshot race fix. At the rebased head `332a72f2a743c4d13b7f8bd18df2ff0294fc5e23` and in the integrated stack:

- focused `soundtouchweb` and `webtypes` tests passed;
- the same packages passed under the race detector;
- `go vet ./...` passed;
- `golangci-lint` 2.13.2 passed in exact-head GitHub CI;
- both native and forced-shim browser tests passed three consecutive runs; and
- `git diff --check` passed.

The integrated full `go test ./...` run passed every package except the existing environment-sensitive `TestUnifiedDiscoveryCache`, which received changing real-LAN SSDP/mDNS results between its two 100 ms discovery windows (five devices, then none); the isolated rerun passed.

The original patch-equivalent candidate also had all upstream checks green. Host-gated integration tests self-skipped because `SOUNDTOUCH_TEST_HOST` was unset.

A static Linux ARM64 build of the patch-equivalent candidate was deployed as a canary on a UniFi gateway with a real stereo pair made from two SoundTouch 10 speakers. The player exposed one logical target under the master, reported `Stereo pair 2/2`, retained both projected `devices` and legacy `status_update` WebSocket frames, and rendered correctly in desktop, tablet, and iPhone checks. Both physical speakers remained independently readable and their persisted group data stayed byte-identical.

The model guard was exercised on real SoundTouch 20 and SoundTouch 30 speakers. Four complete refresh rounds over 96 seconds kept `/info`, `/getZone`, `/recents`, and `/now_playing` responsive. A simultaneous 40-second gateway capture contained the normal player refresh requests and no `/getGroup` request, while `/getGroup` remained available for the SoundTouch 10 pair.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed

This PR does not add pair creation, rename, dissolve, or multiroom-zone behavior. It also does not change the raw device registry or address the separately tracked global WebSocket writer lifecycle.
