### PR TITLE
fix(player): snapshot last-seen timestamps

### DIFF
--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -104,11 +104,12 @@ func (app *WebApp) proxyServiceURL() string {
 	return app.ServiceURL
 }
 
-// DeviceEntry pairs a device id with its connection. Used by
-// DeviceSnapshot so callers can iterate without holding the lock.
+// DeviceEntry pairs a device id with its connection and the LastSeen value
+// captured by DeviceSnapshot under the registry lock.
 type DeviceEntry struct {
-	ID     string
-	Device *webtypes.DeviceConnection
+	ID       string
+	Device   *webtypes.DeviceConnection
+	LastSeen time.Time
 }
 
 // NewWebApp creates a new WebApp instance for SPA mode
@@ -137,17 +138,34 @@ func (app *WebApp) GetDevice(id string) (*webtypes.DeviceConnection, bool) {
 // holding any registry lock. Devices added or removed after the call
 // are not reflected. A pointer captured here stays valid even if the
 // device is later removed (RemoveDevice only detaches it from the map
-// and stops its goroutines), so iterating a stale snapshot is safe.
+// and stops its goroutines), so iterating a stale snapshot is safe. LastSeen
+// is copied by value because TouchDevice can update the connection after the
+// registry lock is released.
 func (app *WebApp) DeviceSnapshot() []DeviceEntry {
 	app.devicesMu.RLock()
 	defer app.devicesMu.RUnlock()
 
 	out := make([]DeviceEntry, 0, len(app.devices))
 	for id, device := range app.devices {
-		out = append(out, DeviceEntry{ID: id, Device: device})
+		out = append(out, DeviceEntry{ID: id, Device: device, LastSeen: device.LastSeen})
 	}
 
 	return out
+}
+
+func (app *WebApp) deviceListSnapshot() map[string]interface{} {
+	snapshot := app.DeviceSnapshot()
+	devices := make(map[string]interface{}, len(snapshot))
+
+	for _, entry := range snapshot {
+		devices[entry.ID] = map[string]interface{}{
+			"info":     entry.Device.DeviceInfo,
+			"status":   entry.Device.Status(),
+			"lastSeen": entry.LastSeen,
+		}
+	}
+
+	return devices
 }
 
 // DeviceCount returns the number of registered devices at call time.
@@ -218,21 +236,9 @@ func (app *WebApp) RemoveDevice(id string) bool {
 func (app *WebApp) HandleAPIDevices(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 
-	// Return all devices as JSON
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
 	response := webtypes.APIResponse{
 		Success: true,
-		Data:    devices,
+		Data:    app.deviceListSnapshot(),
 	}
 
 	if err := json.NewEncoder(w).Encode(response); err != nil {
@@ -702,20 +708,9 @@ func (app *WebApp) BroadcastDeviceList() {
 	app.WSMutex.RLock()
 	defer app.WSMutex.RUnlock()
 
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
 	message := webtypes.WebSocketMessage{
 		Type: "devices",
-		Data: devices,
+		Data: app.deviceListSnapshot(),
 	}
 
 	// Send to all connected clients

--- a/pkg/service/soundtouchweb/registry_test.go
+++ b/pkg/service/soundtouchweb/registry_test.go
@@ -4,9 +4,11 @@
 package soundtouchweb
 
 import (
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
@@ -115,6 +117,63 @@ func TestDeviceSnapshotAndCount(t *testing.T) {
 			t.Errorf("DeviceSnapshot missing %s", id)
 		}
 	}
+}
+
+func TestDeviceSnapshotCapturesLastSeen(t *testing.T) {
+	app := NewWebApp()
+	conn := newRegistryDevice("first")
+	fixed := time.Date(2026, time.August, 26, 12, 0, 0, 0, time.UTC)
+	conn.LastSeen = fixed
+	app.AddDevice("host-1", conn)
+
+	snapshot := app.DeviceSnapshot()
+	if len(snapshot) != 1 {
+		t.Fatalf("DeviceSnapshot len = %d; want 1", len(snapshot))
+	}
+
+	if !app.TouchDevice("host-1") {
+		t.Fatal("TouchDevice returned false for known id")
+	}
+
+	if !snapshot[0].LastSeen.Equal(fixed) {
+		t.Errorf("captured LastSeen = %v; want %v", snapshot[0].LastSeen, fixed)
+	}
+
+	current := app.DeviceSnapshot()
+	if !current[0].LastSeen.After(fixed) {
+		t.Errorf("current LastSeen = %v; want after %v", current[0].LastSeen, fixed)
+	}
+}
+
+func TestDeviceListSnapshotConcurrentLastSeen(t *testing.T) {
+	app := NewWebApp()
+	app.AddDevice("shared", newRegistryDevice("shared"))
+
+	const operations = 1000
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+
+		for range operations {
+			app.TouchDevice("shared")
+		}
+	}()
+
+	go func() {
+		defer wg.Done()
+
+		for range operations {
+			if _, err := json.Marshal(app.deviceListSnapshot()); err != nil {
+				t.Errorf("marshal device list snapshot: %v", err)
+				return
+			}
+		}
+	}()
+
+	wg.Wait()
 }
 
 func TestRemoveDevice(t *testing.T) {

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -45,21 +45,9 @@ func (app *WebApp) HandleWebSocket(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Send initial device list
-	snapshot := app.DeviceSnapshot()
-	devices := make(map[string]interface{}, len(snapshot))
-
-	for _, entry := range snapshot {
-		devices[entry.ID] = map[string]interface{}{
-			"info":     entry.Device.DeviceInfo,
-			"status":   entry.Device.Status(),
-			"lastSeen": entry.Device.LastSeen,
-		}
-	}
-
 	initialMessage := webtypes.WebSocketMessage{
 		Type: "devices",
-		Data: devices,
+		Data: app.deviceListSnapshot(),
 	}
 
 	if err := conn.WriteJSON(initialMessage); err != nil {


### PR DESCRIPTION
## Summary

- Copy each device's `LastSeen` timestamp into `DeviceSnapshot` while the registry read lock is held.
- Build the HTTP, initial WebSocket, and broadcast device-list payloads through one shared snapshot helper so they cannot race with discovery touching the same connection.
- Add regression coverage for snapshot isolation and concurrent device-list serialization.

The JSON schema and the meaning of `lastSeen` are unchanged. It still records the latest registry discovery or resynchronization, not the latest successful status poll.

## Linked issue

None. This is a small internal race fix found while reviewing a superseded local control-API experiment.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (the Docker-based HTTP integration suite was not run locally)
- [ ] Tested against a real SoundTouch device (no device behavior or wire protocol changes)
- `go test -race -count=20 ./pkg/service/soundtouchweb`
- `go test ./...`
- `go vet ./...`
- `golangci-lint` 2.13.1: zero issues
- `git diff --check origin/main...HEAD`

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed (not required; the existing JSON contract is preserved)
