### PR TITLE
fix(player): guard multiroom zone creation

### DIFF
--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -955,6 +955,7 @@ func (app *WebApp) HandleGetZone(w http.ResponseWriter, r *http.Request) {
 // becomes the master.
 func (app *WebApp) HandleZoneAdd(w http.ResponseWriter, r *http.Request) {
 	masterIP := chi.URLParam(r, "id")
+
 	slaveIP := chi.URLParam(r, "slaveId")
 	if masterIP == slaveIP {
 		app.sendError(w, "A device cannot be added to its own zone", http.StatusBadRequest)
@@ -977,6 +978,7 @@ func (app *WebApp) HandleZoneAdd(w http.ResponseWriter, r *http.Request) {
 		app.sendError(w, "Device not ready", http.StatusInternalServerError)
 		return
 	}
+
 	if masterConn.DeviceInfo.DeviceID == slaveConn.DeviceInfo.DeviceID {
 		app.sendError(w, "A device cannot be added to its own zone", http.StatusBadRequest)
 		return

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -956,6 +956,10 @@ func (app *WebApp) HandleGetZone(w http.ResponseWriter, r *http.Request) {
 func (app *WebApp) HandleZoneAdd(w http.ResponseWriter, r *http.Request) {
 	masterIP := chi.URLParam(r, "id")
 	slaveIP := chi.URLParam(r, "slaveId")
+	if masterIP == slaveIP {
+		app.sendError(w, "A device cannot be added to its own zone", http.StatusBadRequest)
+		return
+	}
 
 	masterConn, ok := app.GetDevice(masterIP)
 	if !ok {
@@ -971,6 +975,27 @@ func (app *WebApp) HandleZoneAdd(w http.ResponseWriter, r *http.Request) {
 
 	if masterConn.Client == nil || masterConn.DeviceInfo == nil || slaveConn.DeviceInfo == nil {
 		app.sendError(w, "Device not ready", http.StatusInternalServerError)
+		return
+	}
+	if masterConn.DeviceInfo.DeviceID == slaveConn.DeviceInfo.DeviceID {
+		app.sendError(w, "A device cannot be added to its own zone", http.StatusBadRequest)
+		return
+	}
+
+	nowPlaying, err := masterConn.Client.GetNowPlaying()
+	if err != nil {
+		app.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	sources, err := masterConn.Client.GetSources()
+	if err != nil {
+		app.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if !currentSourceAllowsMultiroom(nowPlaying, sources) {
+		app.sendError(w, "Start a multiroom-capable source before grouping speakers", http.StatusConflict)
 		return
 	}
 
@@ -994,6 +1019,27 @@ func (app *WebApp) HandleZoneAdd(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	app.sendControlResponse(w, masterConn.Client.SetZone(zoneReq), "Device added to zone")
+}
+
+func currentSourceAllowsMultiroom(nowPlaying *models.NowPlaying, sources *models.Sources) bool {
+	if nowPlaying == nil || sources == nil {
+		return false
+	}
+
+	source := strings.TrimSpace(nowPlaying.Source)
+	if source == "" || source == "STANDBY" || source == "INVALID_SOURCE" {
+		return false
+	}
+
+	for i := range sources.SourceItem {
+		item := &sources.SourceItem[i]
+		if item.Source == source && item.MultiroomAllowed &&
+			(nowPlaying.SourceAccount == "" || item.SourceAccount == nowPlaying.SourceAccount) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // HandleZoneRemove removes a slave from the zone.

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -767,6 +768,151 @@ func TestHandleSourceControl_ForwardsAccount(t *testing.T) {
 				t.Errorf("XML should contain %q, got: %s", want, capturedBody)
 			}
 		})
+	}
+}
+
+func TestHandleZoneAddRejectsSelf(t *testing.T) {
+	app := NewWebApp()
+	req := httptest.NewRequest("POST", "/api/control/devices/192.0.2.10/zone/add/192.0.2.10", nil)
+	req = withChiParams(req, map[string]string{"id": "192.0.2.10", "slaveId": "192.0.2.10"})
+	w := httptest.NewRecorder()
+
+	app.HandleZoneAdd(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "cannot be added to its own zone") {
+		t.Fatalf("unexpected response: %s", w.Body.String())
+	}
+}
+
+func TestHandleZoneAddRejectsSameHardwareUnderDifferentKeys(t *testing.T) {
+	app := NewWebApp()
+	app.AddDevice("speaker.local", webtypes.NewDeviceConnection(
+		client.NewClient(&client.Config{Host: "http://speaker.local"}),
+		&models.DeviceInfo{Name: "Speaker", DeviceID: "SAMEHW01"},
+	))
+	app.AddDevice("192.0.2.10", webtypes.NewDeviceConnection(nil,
+		&models.DeviceInfo{Name: "Speaker alias", DeviceID: "SAMEHW01"}))
+
+	req := httptest.NewRequest("POST", "/api/control/devices/speaker.local/zone/add/192.0.2.10", nil)
+	req = withChiParams(req, map[string]string{"id": "speaker.local", "slaveId": "192.0.2.10"})
+	w := httptest.NewRecorder()
+	app.HandleZoneAdd(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCurrentSourceAllowsMultiroom(t *testing.T) {
+	sources := &models.Sources{SourceItem: []models.SourceItem{
+		{Source: "SPOTIFY", SourceAccount: "first", MultiroomAllowed: true},
+		{Source: "BLUETOOTH", MultiroomAllowed: false},
+	}}
+
+	for _, test := range []struct {
+		name       string
+		nowPlaying *models.NowPlaying
+		allowed    bool
+	}{
+		{name: "matching account", nowPlaying: &models.NowPlaying{Source: "SPOTIFY", SourceAccount: "first"}, allowed: true},
+		{name: "different account", nowPlaying: &models.NowPlaying{Source: "SPOTIFY", SourceAccount: "second"}},
+		{name: "source disallows multiroom", nowPlaying: &models.NowPlaying{Source: "BLUETOOTH"}},
+		{name: "standby", nowPlaying: &models.NowPlaying{Source: "STANDBY"}},
+		{name: "missing state"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if got := currentSourceAllowsMultiroom(test.nowPlaying, sources); got != test.allowed {
+				t.Fatalf("currentSourceAllowsMultiroom() = %t, want %t", got, test.allowed)
+			}
+		})
+	}
+}
+
+func TestHandleZoneAddUsesSetZoneWithoutStartingPlayback(t *testing.T) {
+	var paths []string
+	var zoneBody string
+	masterSpeaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/now_playing":
+			_, _ = w.Write([]byte(`<nowPlaying deviceID="MASTERHW01" source="LOCAL_INTERNET_RADIO"><playStatus>PLAY_STATE</playStatus></nowPlaying>`))
+		case "/sources":
+			_, _ = w.Write([]byte(`<sources deviceID="MASTERHW01"><sourceItem source="LOCAL_INTERNET_RADIO" status="READY" isLocal="false" multiroomallowed="true" /></sources>`))
+		case "/getZone":
+			_, _ = w.Write([]byte(`<zone master="MASTERHW01"/>`))
+		case "/setZone":
+			body, _ := io.ReadAll(r.Body)
+			zoneBody = string(body)
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer masterSpeaker.Close()
+
+	app := NewWebApp()
+	master := webtypes.NewDeviceConnection(
+		client.NewClient(&client.Config{Host: masterSpeaker.URL}),
+		&models.DeviceInfo{Name: "Master", DeviceID: "MASTERHW01"},
+	)
+	master.SetStatus(&webtypes.DeviceStatus{IsConnected: true, LastActivity: time.Now()})
+	app.AddDevice("192.0.2.10", master)
+	app.AddDevice("192.0.2.20", webtypes.NewDeviceConnection(nil,
+		&models.DeviceInfo{Name: "Slave", DeviceID: "SLAVEHW02"}))
+
+	req := httptest.NewRequest("POST", "/api/control/devices/192.0.2.10/zone/add/192.0.2.20", nil)
+	req = withChiParams(req, map[string]string{"id": "192.0.2.10", "slaveId": "192.0.2.20"})
+	w := httptest.NewRecorder()
+	app.HandleZoneAdd(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	wantPaths := []string{"GET /now_playing", "GET /sources", "GET /getZone", "POST /setZone"}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Fatalf("requests = %v, want %v", paths, wantPaths)
+	}
+	if !strings.Contains(zoneBody, "SLAVEHW02") {
+		t.Fatalf("setZone body does not contain slave: %s", zoneBody)
+	}
+}
+
+func TestHandleZoneAddRejectsStandbyMaster(t *testing.T) {
+	var paths []string
+	masterSpeaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		switch r.URL.Path {
+		case "/now_playing":
+			_, _ = w.Write([]byte(`<nowPlaying deviceID="MASTERHW01" source="STANDBY"/>`))
+		case "/sources":
+			_, _ = w.Write([]byte(`<sources deviceID="MASTERHW01"><sourceItem source="LOCAL_INTERNET_RADIO" status="READY" multiroomallowed="true" /></sources>`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer masterSpeaker.Close()
+
+	app := NewWebApp()
+	app.AddDevice("192.0.2.10", webtypes.NewDeviceConnection(
+		client.NewClient(&client.Config{Host: masterSpeaker.URL}),
+		&models.DeviceInfo{Name: "Master", DeviceID: "MASTERHW01"},
+	))
+	app.AddDevice("192.0.2.20", webtypes.NewDeviceConnection(nil,
+		&models.DeviceInfo{Name: "Slave", DeviceID: "SLAVEHW02"}))
+
+	req := httptest.NewRequest("POST", "/api/control/devices/192.0.2.10/zone/add/192.0.2.20", nil)
+	req = withChiParams(req, map[string]string{"id": "192.0.2.10", "slaveId": "192.0.2.20"})
+	w := httptest.NewRecorder()
+	app.HandleZoneAdd(w, req)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+	if want := []string{"GET /now_playing", "GET /sources"}; !reflect.DeepEqual(paths, want) {
+		t.Fatalf("requests = %v, want %v", paths, want)
 	}
 }
 

--- a/pkg/service/soundtouchweb/static/js/components/Zone.js
+++ b/pkg/service/soundtouchweb/static/js/components/Zone.js
@@ -5,11 +5,22 @@ import { api } from '../api.js';
 
 const html = htm.bind(h);
 
+function currentSourceAllowsMultiroom(device) {
+    const nowPlaying = device?.status?.nowPlaying;
+    const source = nowPlaying?.Source;
+    if (!source || source === 'STANDBY' || source === 'INVALID_SOURCE') return false;
+
+    return (device?.status?.sources?.SourceItem || []).some(item =>
+        item.Source === source && item.MultiroomAllowed &&
+        (!nowPlaying.SourceAccount || item.SourceAccount === nowPlaying.SourceAccount));
+}
+
 export function Zone({ deviceId, devices }) {
     const [zone, setZone] = useState(null);
     const [candidates, setCandidates] = useState({});
     const [loading, setLoading] = useState(true);
     const [showPicker, setShowPicker] = useState(false);
+    const canGroup = currentSourceAllowsMultiroom(devices?.[deviceId]);
 
     function refresh() {
         Promise.all([api.zone(deviceId), api.zoneCandidates(deviceId)])
@@ -21,8 +32,12 @@ export function Zone({ deviceId, devices }) {
     }
 
     useEffect(() => { refresh(); }, [deviceId]);
+    useEffect(() => {
+        if (!canGroup) setShowPicker(false);
+    }, [canGroup]);
 
     async function addDevice(slaveId) {
+        if (!canGroup) return;
         setShowPicker(false);
         await api.zoneAdd(deviceId, slaveId);
         refresh();
@@ -70,9 +85,13 @@ export function Zone({ deviceId, devices }) {
                 <div class="zone-row">
                     <span class="zone-status-label">Standalone</span>
                     ${available.length > 0 && html`
-                        <button class="btn-secondary zone-btn" onClick=${() => setShowPicker(true)}>+ Group with…</button>
+                        <button class="btn-secondary zone-btn" onClick=${() => setShowPicker(true)}
+                            disabled=${!canGroup}>+ Group with…</button>
                     `}
                 </div>
+                ${available.length > 0 && !canGroup && html`
+                    <div class="zone-status-label">Start a multiroom-capable source before grouping speakers.</div>
+                `}
             `}
 
             ${zone.isMaster && html`
@@ -91,7 +110,8 @@ export function Zone({ deviceId, devices }) {
                     `)}
                     <div class="zone-actions">
                         ${available.length > 0 && html`
-                            <button class="btn-secondary zone-btn" onClick=${() => setShowPicker(true)}>+ Add speaker</button>
+                            <button class="btn-secondary zone-btn" onClick=${() => setShowPicker(true)}
+                                disabled=${!canGroup}>+ Add speaker</button>
                         `}
                         <button class="btn-secondary zone-btn" onClick=${dissolve}>Dissolve zone</button>
                     </div>
@@ -106,7 +126,7 @@ export function Zone({ deviceId, devices }) {
                 </div>
             `}
 
-            ${showPicker && html`
+            ${showPicker && canGroup && html`
                 <div class="overlay" onClick=${() => setShowPicker(false)}>
                     <div class="device-picker" onClick=${e => e.stopPropagation()}>
                         <div class="picker-title">Add to zone</div>


### PR DESCRIPTION
## Summary

- Exclude the selected logical or physical target, existing zone members, and disconnected devices from the player zone picker.
- Offer zone creation only while the selected speaker is playing a source that advertises multiroom support.
- Enforce the same self-target and source-capability invariants in the control handler so stale clients and direct API calls cannot bypass the UI guard.
- Keep successful grouping limited to the existing `/setZone` operation; the handler does not select a source, start playback, or change power state.

The original Stockholm client applies the same user-facing constraint: another speaker can be added only while the selected speaker is listening to a source that supports broadcasting. Without this guard, submitting `/setZone` for a standby master can cause the speakers to start playing as a firmware side effect.

## Linked issue

None. This is a focused player regression found while testing zone creation with a projected stereo-pair target.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (the Docker-based HTTP integration suite was not run locally)
- [ ] Tested against a real SoundTouch device (the failure was reproduced on hardware; this fix has not yet been deployed)
- `golangci-lint` 2.13.1: zero issues
- `go test ./...`
- `go test -race ./pkg/service/soundtouchweb`
- `go vet ./...`
- focused handler regressions verify standby rejection and the exact successful request sequence
- JavaScript syntax and diff checks
- independent architecture review

The successful handler regression permits only `GET /now_playing`, `GET /sources`, `GET /getZone`, and `POST /setZone`. The standby regression returns HTTP 409 before any zone mutation.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed (not required; the player explains the prerequisite inline)
