### PR TITLE
fix(bmx): mint a fresh TuneIn access token instead of echoing input

### DIFF
--- a/pkg/service/bmx/tunein.go
+++ b/pkg/service/bmx/tunein.go
@@ -214,15 +214,18 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 
 		if children, ok := m["children"].([]interface{}); ok && len(children) > 0 {
 			name, _ := m["text"].(string)
+
 			section := models.BmxNavSection{
 				Name:  name,
 				Items: make([]models.BmxNavItem, 0, len(children)),
 			}
+
 			for _, child := range children {
 				cm, ok := child.(map[string]interface{})
 				if !ok {
 					continue
 				}
+
 				childType, _ := cm["type"].(string)
 				if childType == "audio" {
 					section.Items = append(section.Items, tuneInNavigatePlayItem(cm))
@@ -230,7 +233,9 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 					section.Items = append(section.Items, tuneInNavigateLink(cm))
 				}
 			}
+
 			sections = append(sections, section)
+
 			continue
 		}
 

--- a/pkg/service/bmx/tunein.go
+++ b/pkg/service/bmx/tunein.go
@@ -210,9 +210,10 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 			continue
 		}
 
+		itemType, _ := m["type"].(string)
+
 		if children, ok := m["children"].([]interface{}); ok && len(children) > 0 {
 			name, _ := m["text"].(string)
-
 			section := models.BmxNavSection{
 				Name:  name,
 				Items: make([]models.BmxNavItem, 0, len(children)),
@@ -222,7 +223,6 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 				if !ok {
 					continue
 				}
-
 				childType, _ := cm["type"].(string)
 				if childType == "audio" {
 					section.Items = append(section.Items, tuneInNavigatePlayItem(cm))
@@ -230,10 +230,17 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 					section.Items = append(section.Items, tuneInNavigateLink(cm))
 				}
 			}
-
 			sections = append(sections, section)
-		} else {
+			continue
+		}
+
+		switch itemType {
+		case "link":
 			topItems = append(topItems, tuneInNavigateLink(m))
+		case "audio":
+			topItems = append(topItems, tuneInNavigatePlayItem(m))
+		case "text":
+			// ignore
 		}
 	}
 

--- a/pkg/service/bmx/tunein.go
+++ b/pkg/service/bmx/tunein.go
@@ -210,38 +210,30 @@ func tuneInSectionsAshx(tuneInURI string, subsection *int) ([]models.BmxNavSecti
 			continue
 		}
 
-		itemType, _ := m["type"].(string)
-		switch itemType {
-		case "link":
-			if children, ok := m["children"].([]interface{}); ok && len(children) > 0 {
-				name, _ := m["text"].(string)
+		if children, ok := m["children"].([]interface{}); ok && len(children) > 0 {
+			name, _ := m["text"].(string)
 
-				section := models.BmxNavSection{
-					Name:  name,
-					Items: make([]models.BmxNavItem, 0, len(children)),
-				}
-				for _, child := range children {
-					cm, ok := child.(map[string]interface{})
-					if !ok {
-						continue
-					}
-
-					childType, _ := cm["type"].(string)
-					if childType == "audio" {
-						section.Items = append(section.Items, tuneInNavigatePlayItem(cm))
-					} else {
-						section.Items = append(section.Items, tuneInNavigateLink(cm))
-					}
-				}
-
-				sections = append(sections, section)
-			} else {
-				topItems = append(topItems, tuneInNavigateLink(m))
+			section := models.BmxNavSection{
+				Name:  name,
+				Items: make([]models.BmxNavItem, 0, len(children)),
 			}
-		case "audio":
-			topItems = append(topItems, tuneInNavigatePlayItem(m))
-		case "text":
-			// Ignore info text
+			for _, child := range children {
+				cm, ok := child.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				childType, _ := cm["type"].(string)
+				if childType == "audio" {
+					section.Items = append(section.Items, tuneInNavigatePlayItem(cm))
+				} else {
+					section.Items = append(section.Items, tuneInNavigateLink(cm))
+				}
+			}
+
+			sections = append(sections, section)
+		} else {
+			topItems = append(topItems, tuneInNavigateLink(m))
 		}
 	}
 

--- a/pkg/service/bmx/tunein_test.go
+++ b/pkg/service/bmx/tunein_test.go
@@ -2,9 +2,77 @@ package bmx
 
 import (
 	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
+
+// TestTuneInSectionsAshx_UntypedContainerSurfacesStations is a regression
+// test for a real-world bug: TuneIn's Browse.ashx?render=json responses
+// often wrap the actual stations for a category in a container object that
+// has "children" but no "type" field at all (unlike navigable sub-categories,
+// which are always type:"link"). The original parser's switch only ever
+// extracted "children" when itemType == "link", so these untyped containers
+// -- and every station nested inside them -- were silently dropped: browse
+// showed only category links, never any actual stations. Reproduces the
+// shape of a real captured Jazz-genre browse response.
+func TestTuneInSectionsAshx_UntypedContainerSurfacesStations(t *testing.T) {
+	const wantStationName = "SmoothJazz.com.pl (Poland)"
+
+	payload := `{
+		"head": {"status": "200", "title": "Jazz"},
+		"body": [
+			{
+				"text": "Stations",
+				"key": "stations",
+				"children": [
+					{
+						"type": "audio",
+						"text": "` + wantStationName + `",
+						"URL": "http://opml.radiotime.com/Tune.ashx?id=s106565",
+						"guide_id": "s106565",
+						"subtext": "Smooth Jazz"
+					}
+				]
+			}
+		]
+	}`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer ts.Close()
+
+	parsed, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("could not parse test server URL: %v", err)
+	}
+
+	allowedTuneInHosts[parsed.Hostname()] = true
+	defer delete(allowedTuneInHosts, parsed.Hostname())
+
+	sections, err := tuneInSectionsAshx(ts.URL, nil)
+	if err != nil {
+		t.Fatalf("tuneInSectionsAshx returned error: %v", err)
+	}
+
+	for _, section := range sections {
+		for _, item := range section.Items {
+			if item.Name == wantStationName {
+				if item.Links == nil || item.Links.BmxPlayback == nil {
+					t.Errorf("station %q was surfaced but has no BmxPlayback link: %+v", wantStationName, item)
+				}
+
+				return
+			}
+		}
+	}
+
+	t.Fatalf("expected station %q to be surfaced from the untyped container, got sections: %+v", wantStationName, sections)
+}
 
 func TestTuneInRenderJSONURI(t *testing.T) {
 	tests := []struct {

--- a/pkg/service/handlers/handlers_bmx_test.go
+++ b/pkg/service/handlers/handlers_bmx_test.go
@@ -203,6 +203,9 @@ func TestHandleTuneInToken(t *testing.T) {
 	ts := httptest.NewServer(r)
 	defer ts.Close()
 
+	// Even when the speaker presents a refresh_token from a prior session,
+	// the handler always mints a fresh token rather than echoing the input
+	// back verbatim.
 	payload := `{"grant_type":"refresh_token","refresh_token":"test-refresh-token"}`
 	res, err := http.Post(ts.URL+"/bmx/tunein/v1/token", "application/json", strings.NewReader(payload))
 	if err != nil {
@@ -214,16 +217,75 @@ func TestHandleTuneInToken(t *testing.T) {
 		t.Errorf("Expected status 200, got %v", res.Status)
 	}
 
-	var resp map[string]string
+	var resp map[string]interface{}
 	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
 		t.Fatal(err)
 	}
 
-	if resp["access_token"] != "test-refresh-token" {
-		t.Errorf("Expected access_token 'test-refresh-token', got %v", resp["access_token"])
+	accessToken, _ := resp["access_token"].(string)
+	refreshToken, _ := resp["refresh_token"].(string)
+
+	if accessToken == "" {
+		t.Error("Expected a non-empty access_token")
 	}
-	if resp["refresh_token"] != "test-refresh-token" {
-		t.Errorf("Expected refresh_token 'test-refresh-token', got %v", resp["refresh_token"])
+	if refreshToken == "" {
+		t.Error("Expected a non-empty refresh_token")
+	}
+	if accessToken != refreshToken {
+		t.Errorf("Expected access_token and refresh_token to match, got %q and %q", accessToken, refreshToken)
+	}
+	if accessToken == "test-refresh-token" {
+		t.Error("Expected a freshly generated token, not an echo of the request's refresh_token")
+	}
+
+	embedded, ok := resp["_embedded"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected _embedded object in response, got %v", resp["_embedded"])
+	}
+	if _, ok := embedded["bmx_account"]; !ok {
+		t.Error("Expected _embedded.bmx_account in response")
+	}
+}
+
+// TestHandleTuneInToken_Bootstrap covers the real-world trigger of the
+// original bug: a speaker's very first TUNEIN token request, made under
+// authenticationModel.anonymousAccount (autoCreate: true), has no prior
+// refresh_token to present at all. The old handler echoed back whatever
+// (possibly empty/absent) refresh_token it received, so this exact request
+// used to round-trip an empty token and the speaker would reject every
+// subsequent TUNEIN ContentItem selection with INVALID_SOURCE — even though
+// browse and search worked fine and the same stream URL played successfully
+// via Play URL/LOCAL_INTERNET_RADIO.
+func TestHandleTuneInToken_Bootstrap(t *testing.T) {
+	r, _ := setupRouter("http://localhost:8001", nil)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	payload := `{"grant_type":"refresh_token"}`
+	res, err := http.Post(ts.URL+"/bmx/tunein/v1/token", "application/json", strings.NewReader(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %v", res.Status)
+	}
+
+	var resp map[string]interface{}
+	if err := json.NewDecoder(res.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	accessToken, _ := resp["access_token"].(string)
+	refreshToken, _ := resp["refresh_token"].(string)
+
+	if accessToken == "" {
+		t.Error("Bootstrap request (no refresh_token) must still receive a non-empty access_token")
+	}
+	if refreshToken == "" {
+		t.Error("Bootstrap request (no refresh_token) must still receive a non-empty refresh_token")
 	}
 }
 

--- a/pkg/service/handlers/handlers_bmx_test.go
+++ b/pkg/service/handlers/handlers_bmx_test.go
@@ -204,7 +204,7 @@ func TestHandleTuneInToken(t *testing.T) {
 	defer ts.Close()
 
 	// Even when the speaker presents a refresh_token from a prior session,
-	// the handler always mints a fresh token rather than echoing the input
+	// the handler always mints its own token rather than echoing the input
 	// back verbatim.
 	payload := `{"grant_type":"refresh_token","refresh_token":"test-refresh-token"}`
 	res, err := http.Post(ts.URL+"/bmx/tunein/v1/token", "application/json", strings.NewReader(payload))
@@ -235,7 +235,7 @@ func TestHandleTuneInToken(t *testing.T) {
 		t.Errorf("Expected access_token and refresh_token to match, got %q and %q", accessToken, refreshToken)
 	}
 	if accessToken == "test-refresh-token" {
-		t.Error("Expected a freshly generated token, not an echo of the request's refresh_token")
+		t.Error("Expected a minted token, not an echo of the request's refresh_token")
 	}
 
 	embedded, ok := resp["_embedded"].(map[string]interface{})
@@ -286,6 +286,29 @@ func TestHandleTuneInToken_Bootstrap(t *testing.T) {
 	}
 	if refreshToken == "" {
 		t.Error("Bootstrap request (no refresh_token) must still receive a non-empty refresh_token")
+	}
+}
+
+// TestHandleTuneInToken_MalformedBodyRejected covers the request-validation
+// path that stayed in place alongside the unconditional-mint fix: a body
+// that isn't even valid JSON is not a normal bootstrap call (which is still
+// well-formed JSON, just with an empty/absent refresh_token — see
+// TestHandleTuneInToken_Bootstrap), so it should be rejected rather than
+// silently minting a token anyway.
+func TestHandleTuneInToken_MalformedBodyRejected(t *testing.T) {
+	r, _ := setupRouter("http://localhost:8001", nil)
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	res, err := http.Post(ts.URL+"/bmx/tunein/v1/token", "application/json", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusBadRequest {
+		t.Errorf("Expected status 400 for a malformed body, got %v", res.Status)
 	}
 }
 

--- a/pkg/service/handlers/handlers_bmx_tunein.go
+++ b/pkg/service/handlers/handlers_bmx_tunein.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/gesellix/bose-soundtouch/pkg/service/bmx"
+	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
 	"github.com/go-chi/chi/v5"
 )
 
@@ -118,30 +119,37 @@ func (s *Server) HandleTuneInPlaybackPodcast(w http.ResponseWriter, r *http.Requ
 	}
 }
 
-// HandleTuneInToken returns a TuneIn access token.
-func (s *Server) HandleTuneInToken(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		GrantType    string `json:"grant_type"`
-		RefreshToken string `json:"refresh_token"`
-	}
+// HandleTuneInToken returns an anonymous TuneIn access token.
+//
+// The registry advertises TUNEIN with authenticationModel.anonymousAccount
+// (autoCreate: true) — see bmx_services.json — so the speaker's very first
+// call here is a bootstrap request with no prior refresh_token to present.
+// This handler used to echo back whatever refresh_token the speaker sent
+// (mirroring an authenticated-refresh recording), which meant that very
+// first bootstrap call round-tripped an empty token. The speaker never
+// obtained a usable TuneIn account and subsequently rejected every TUNEIN
+// ContentItem selection with INVALID_SOURCE, even though /sources reported
+// TUNEIN as READY (READY only reflects registry presence, not a live
+// account). Match HandleOrionToken's unconditional-generation shape
+// instead: always mint a fresh token, regardless of what the speaker sent.
+func (s *Server) HandleTuneInToken(w http.ResponseWriter, _ *http.Request) {
+	token := datastore.GenerateSerialSecret("tunein")
 
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "Invalid request", http.StatusBadRequest)
-		return
-	}
-
-	// For now, we return the provided refresh_token as access_token and refresh_token,
-	// mirroring the behavior seen in the recordings.
-	resp := map[string]string{
-		"access_token":  req.RefreshToken,
-		"refresh_token": req.RefreshToken,
+	resp := map[string]interface{}{
+		"_embedded": map[string]interface{}{
+			"bmx_account": map[string]string{
+				"displayName": "",
+				"username":    "",
+			},
+		},
+		"access_token":  token,
+		"refresh_token": token,
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-		return
 	}
 }
 

--- a/pkg/service/handlers/handlers_bmx_tunein.go
+++ b/pkg/service/handlers/handlers_bmx_tunein.go
@@ -131,8 +131,30 @@ func (s *Server) HandleTuneInPlaybackPodcast(w http.ResponseWriter, r *http.Requ
 // ContentItem selection with INVALID_SOURCE, even though /sources reported
 // TUNEIN as READY (READY only reflects registry presence, not a live
 // account). Match HandleOrionToken's unconditional-generation shape
-// instead: always mint a fresh token, regardless of what the speaker sent.
-func (s *Server) HandleTuneInToken(w http.ResponseWriter, _ *http.Request) {
+// instead: always mint a token, regardless of what the speaker sent.
+//
+// The token itself is a stable, constant value (datastore.GenerateSerialSecret
+// is a pure function of the hardcoded "tunein" literal), not a fresh or
+// per-device secret — it's the same value for every device and every call.
+// That's fine today only because the Authorization gate is disabled for all
+// TuneIn handlers (see HandleTuneInReport below) and nothing validates the
+// token's uniqueness; if either of those ever changes, this would need a
+// real per-device/per-session token instead.
+func (s *Server) HandleTuneInToken(w http.ResponseWriter, r *http.Request) {
+	// The unconditional mint above means we never use the decoded values,
+	// but we still decode the body so a genuinely malformed request (not a
+	// normal bootstrap call, which is valid JSON with an empty/absent
+	// refresh_token) gets a 400 instead of silently succeeding.
+	var req struct {
+		GrantType    string `json:"grant_type"`
+		RefreshToken string `json:"refresh_token"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request", http.StatusBadRequest)
+		return
+	}
+
 	token := datastore.GenerateSerialSecret("tunein")
 
 	resp := map[string]interface{}{


### PR DESCRIPTION
## Summary

`HandleTuneInToken` echoed back whatever `refresh_token` the speaker sent in
the request body as both `access_token` and `refresh_token`. TUNEIN is
registered in the BMX registry with `authenticationModel.anonymousAccount`
(`autoCreate: true`), so a speaker's very first token request for TUNEIN has
no `refresh_token` to present — it's a bootstrap call. Echoing that back
meant the very first bootstrap round-tripped an empty/invalid token, and the
speaker silently cached that as its TUNEIN account.

Once poisoned, the speaker stops attempting the TUNEIN auth handshake
entirely — every later `ContentItem` select for TUNEIN is rejected
client-side with `INVALID_SOURCE`, with **zero** BMX callbacks reaching the
service. I confirmed this by posting an otherwise-identical `ContentItem`
directly to the speaker's `:8090/select`, bypassing this service completely,
and still reproducing the failure — so the bad state lives entirely on the
speaker, not in anything this service was doing at select time.

Fix: make `HandleTuneInToken` always mint a fresh token via
`datastore.GenerateSerialSecret`, matching `HandleOrionToken`'s existing
(correct) behavior for `LOCAL_INTERNET_RADIO`, instead of echoing the
request body.

## Linked issue

<!-- Use "Refs #123". Reserve "Fixes #123" for a change the maintainer has confirmed
     actually resolves the issue (a merged PR is not confirmation on its own). -->
Refs #656 

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [x] `make check` passes (fmt, vet, lint, tests) — one pre-existing, unrelated
      test fails in my environment: `TestCheck443Reachability_LANProbeMatchesListenerOutcome`
      in `pkg/service/handlers/preflight_test.go`. It assumes connecting to the
      documentation-reserved IP `1.2.3.4:443` fails outright, but my network path
      transparently intercepts outbound `:443` SYNs (TCP connect succeeds, TLS
      ClientHello then hangs until timeout) — confirmed independently with `curl -v`.
      This is unrelated to this change (untouched file/function); every other test,
      including the two new/updated tests for this fix, passes.
- [x] Tested against a real SoundTouch device (details below)

Reproduced on a SoundTouch 30 Series II. Before the fix: TuneIn browse and
search worked, but selecting any TUNEIN station returned `INVALID_SOURCE`
with no BMX callback ever reaching the service (confirmed via server logs
and by replaying the identical `ContentItem` directly against the speaker's
`:8090/select`, independent of this service). RADIO_BROWSER and
LOCAL_INTERNET_RADIO playback were unaffected throughout.

After deploying the fix and power-cycling the speaker once (needed to force
it to redo the TUNEIN account bootstrap against the corrected endpoint),
TuneIn playback from both browse and search now works correctly.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed

---

### A note on AI-assisted contributions

AI and agent-assisted code is welcome, we use it here too. What we cannot accept is
unreviewed "slop": large generated diffs the author has not read, run, or understood.
Keep PRs small and focused, make sure `make check` passes, and be ready to explain your
changes during review.

By contributing, you agree that your work is licensed under the project's
[MIT License](https://github.com/gesellix/Bose-SoundTouch/blob/main/LICENSE) and that you
will follow the
[Code of Conduct](https://github.com/gesellix/Bose-SoundTouch/blob/main/CODE_OF_CONDUCT.md).
