### PR TITLE
chore(player): tighten shim dependency handling

### DIFF
--- a/.github/codeql-config-js.yml
+++ b/.github/codeql-config-js.yml
@@ -12,8 +12,7 @@ queries:
 # Paths to exclude from analysis
 paths-ignore:
   - "**/node_modules/**"
-  # Vendored third-party libraries (preact, htm, es-module-shims), copied
-  # verbatim from npm by scripts/update-static-deps.sh. We don't modify or
-  # control their internals, so findings here aren't actionable from this
-  # repo -- report upstream instead.
-  - "pkg/service/soundtouchweb/static/lib/**"
+  # The minified es-module-shims distribution currently triggers findings in
+  # third-party code. Keep this exception file-specific so Preact, HTM, and
+  # future files under static/lib remain covered.
+  - "pkg/service/soundtouchweb/static/lib/es-module-shims.js"

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -74,10 +74,11 @@ func TestPlayerRendersNatively(t *testing.T) {
 	}
 }
 
-// TestPlayerRendersUnderForcedShimMode exercises the actual old-Safari code
-// path -- es-module-shims resolving the same import map and vendored files
-// the real app uses -- without needing physical iPadOS 15 hardware. It
-// serves a variant of index.html that forces es-module-shims into shimMode
+// TestPlayerRendersUnderForcedShimMode exercises es-module-shims resolving the
+// same import map and vendored files the real app uses. It does not emulate
+// Safari or the production feature-detection loader; those require a target-
+// browser canary. The test serves a page that forces es-module-shims into
+// shimMode
 // (see the library's README: shimMode is triggered by
 // window.esmsInitOptions.shimMode or by using importmap-shim/module-shim
 // script types), which routes every browser -- including this ordinary

--- a/pkg/service/soundtouchweb/static/index.html
+++ b/pkg/service/soundtouchweb/static/index.html
@@ -17,10 +17,10 @@
         that already support import maps natively. Feature-detect instead,
         so only a browser that actually lacks support ever fetches it.
         Inserted via the DOM rather than document.write (deprecated, and
-        subject to browser interventions that can silently drop it).
-        After initialization, es-module-shims inspects module graphs that fail
-        static linking, so browsers without import maps can resolve the bare
-        imports below without penalizing native-capable ones.
+        subject to browser interventions that can silently drop it), with
+        async explicitly set to false so it still executes before the
+        deferred `type="module"` script below runs, without blocking the
+        parser for the vast majority that never reach this branch.
         -->
         <script>
             if (!(window.HTMLScriptElement && HTMLScriptElement.supports && HTMLScriptElement.supports('importmap'))) {

--- a/pkg/service/soundtouchweb/static/index.html
+++ b/pkg/service/soundtouchweb/static/index.html
@@ -17,10 +17,10 @@
         that already support import maps natively. Feature-detect instead,
         so only a browser that actually lacks support ever fetches it.
         Inserted via the DOM rather than document.write (deprecated, and
-        subject to browser interventions that can silently drop it), with
-        async explicitly set to false so it still executes before the
-        deferred `type="module"` script below runs, without blocking the
-        parser for the vast majority that never reach this branch.
+        subject to browser interventions that can silently drop it).
+        After initialization, es-module-shims inspects module graphs that fail
+        static linking, so browsers without import maps can resolve the bare
+        imports below without penalizing native-capable ones.
         -->
         <script>
             if (!(window.HTMLScriptElement && HTMLScriptElement.supports && HTMLScriptElement.supports('importmap'))) {

--- a/pkg/service/soundtouchweb/static/lib/LICENSES/README.md
+++ b/pkg/service/soundtouchweb/static/lib/LICENSES/README.md
@@ -1,0 +1,15 @@
+# Vendored Frontend Dependencies
+
+The JavaScript files in the parent directory are copied unmodified from the
+exact npm packages pinned in the repository's `package-lock.json`.
+
+This directory travels with the embedded web UI and contains each package's
+upstream license. Its copy of `package-lock.json` records the exact versions,
+npm tarball URLs, and integrity hashes used to generate the assets:
+
+- `preact.module.js` and `preact-hooks.module.js`: `preact`
+- `htm.module.js`: `htm`
+- `es-module-shims.js`: `es-module-shims`
+
+Run `make update-static-deps` to regenerate the assets, licenses, and package
+metadata together.

--- a/pkg/service/soundtouchweb/static/lib/LICENSES/es-module-shims-LICENSE
+++ b/pkg/service/soundtouchweb/static/lib/LICENSES/es-module-shims-LICENSE
@@ -1,0 +1,10 @@
+MIT License
+-----------
+
+Copyright (C) 2018-2021 Guy Bedford
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/pkg/service/soundtouchweb/static/lib/LICENSES/htm-LICENSE
+++ b/pkg/service/soundtouchweb/static/lib/LICENSES/htm-LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018 Google Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/service/soundtouchweb/static/lib/LICENSES/package-lock.json
+++ b/pkg/service/soundtouchweb/static/lib/LICENSES/package-lock.json
@@ -1,0 +1,49 @@
+{
+  "name": "@gesellix/bose-soundtouch",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@gesellix/bose-soundtouch",
+      "license": "MIT",
+      "dependencies": {
+        "es-module-shims": "2.8.4",
+        "htm": "3.1.1",
+        "preact": "10.29.8"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/es-module-shims": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-2.8.4.tgz",
+      "integrity": "sha512-ea5srn5L89PWVad6Qle6r2kg+HvvLiL/GHqgNx06eFrkERHkrTFWaqo1w8Sd+XI3Xr0iAG5x3ZQ7mQ/hnQzNpA==",
+      "license": "MIT"
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/preact": {
+      "version": "10.29.8",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.8.tgz",
+      "integrity": "sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/pkg/service/soundtouchweb/static/lib/LICENSES/preact-LICENSE
+++ b/pkg/service/soundtouchweb/static/lib/LICENSES/preact-LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present Jason Miller
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/service/soundtouchweb/static_compatibility_test.go
+++ b/pkg/service/soundtouchweb/static_compatibility_test.go
@@ -11,9 +11,8 @@ import (
 // (added in Safari 16.4), so the page loaded blank there. es-module-shims
 // polyfills import map resolution for such browsers, but is an ~80KB
 // uncompressed download, so it must be feature-detected and only injected
-// for a browser that actually lacks HTMLScriptElement.supports('importmap'),
-// before the import map is parsed -- not loaded unconditionally for every
-// browser.
+// for a browser that actually lacks HTMLScriptElement.supports('importmap') --
+// not loaded unconditionally for every browser.
 func TestIndexPolyfillsImportMapsForOlderBrowsers(t *testing.T) {
 	index, err := fs.ReadFile(StaticFS, "static/index.html")
 	if err != nil {
@@ -26,10 +25,6 @@ func TestIndexPolyfillsImportMapsForOlderBrowsers(t *testing.T) {
 
 	if bytes.Contains(index, []byte(`document.write(`)) {
 		t.Fatal("index.html must not call document.write() (deprecated, subject to browser interventions); use DOM insertion instead")
-	}
-
-	if !bytes.Contains(index, []byte(`.async = false`)) {
-		t.Fatal("the dynamically-inserted es-module-shims script must set async = false to preserve execution order")
 	}
 
 	shimIdx := bytes.Index(index, []byte(`esModuleShimsScript.src = '/app/static/lib/es-module-shims.js';`))
@@ -48,6 +43,22 @@ func TestIndexPolyfillsImportMapsForOlderBrowsers(t *testing.T) {
 
 	if _, err := fs.Stat(StaticFS, "static/lib/es-module-shims.js"); err != nil {
 		t.Errorf("es-module-shims is not vendored/embedded: %v", err)
+	}
+}
+
+// TestVendoredDependenciesIncludeLicenses ensures that the license and package
+// metadata copied with the embedded frontend assets are also present in release
+// binaries. scripts/update-static-deps.sh owns these generated files.
+func TestVendoredDependenciesIncludeLicenses(t *testing.T) {
+	for _, dependency := range []string{"preact", "htm", "es-module-shims"} {
+		path := "static/lib/LICENSES/" + dependency + "-LICENSE"
+		if _, err := fs.Stat(StaticFS, path); err != nil {
+			t.Errorf("vendored dependency license %q: %v", path, err)
+		}
+	}
+
+	if _, err := fs.Stat(StaticFS, "static/lib/LICENSES/package-lock.json"); err != nil {
+		t.Errorf("vendored dependency provenance: %v", err)
 	}
 }
 

--- a/pkg/service/soundtouchweb/static_compatibility_test.go
+++ b/pkg/service/soundtouchweb/static_compatibility_test.go
@@ -11,8 +11,9 @@ import (
 // (added in Safari 16.4), so the page loaded blank there. es-module-shims
 // polyfills import map resolution for such browsers, but is an ~80KB
 // uncompressed download, so it must be feature-detected and only injected
-// for a browser that actually lacks HTMLScriptElement.supports('importmap') --
-// not loaded unconditionally for every browser.
+// for a browser that actually lacks HTMLScriptElement.supports('importmap'),
+// before the import map is parsed -- not loaded unconditionally for every
+// browser.
 func TestIndexPolyfillsImportMapsForOlderBrowsers(t *testing.T) {
 	index, err := fs.ReadFile(StaticFS, "static/index.html")
 	if err != nil {
@@ -25,6 +26,10 @@ func TestIndexPolyfillsImportMapsForOlderBrowsers(t *testing.T) {
 
 	if bytes.Contains(index, []byte(`document.write(`)) {
 		t.Fatal("index.html must not call document.write() (deprecated, subject to browser interventions); use DOM insertion instead")
+	}
+
+	if !bytes.Contains(index, []byte(`.async = false`)) {
+		t.Fatal("the dynamically-inserted es-module-shims script must set async = false to preserve execution order")
 	}
 
 	shimIdx := bytes.Index(index, []byte(`esModuleShimsScript.src = '/app/static/lib/es-module-shims.js';`))

--- a/scripts/update-static-deps.sh
+++ b/scripts/update-static-deps.sh
@@ -5,18 +5,8 @@ set -e
 LIB_DIR="pkg/service/soundtouchweb/static/lib"
 mkdir -p "$LIB_DIR"
 
-echo "Updating static frontend dependencies from node_modules..."
-
-# Ensure dependencies are installed
-if [ ! -d "node_modules" ] || [ ! -d "node_modules/preact" ] || [ ! -d "node_modules/htm" ] || [ ! -d "node_modules/es-module-shims" ]; then
-    if [ "$CI" = "true" ]; then
-        echo "node_modules not found or incomplete. Running npm ci in CI environment..."
-        npm ci
-    else
-        echo "node_modules not found or incomplete. Running npm install..."
-        npm install
-    fi
-fi
+echo "Installing static frontend dependencies from package-lock.json..."
+npm ci --ignore-scripts
 
 # Copy files from node_modules
 echo "Copying Preact..."
@@ -33,5 +23,14 @@ cp node_modules/htm/dist/htm.module.js "$LIB_DIR/htm.module.js"
 # it detects native import map support and becomes a no-op there.
 echo "Copying ES Module Shims..."
 cp node_modules/es-module-shims/dist/es-module-shims.js "$LIB_DIR/es-module-shims.js"
+
+# Keep license and package provenance inside the embedded static tree so they
+# ship with release binaries, not only with source checkouts.
+LICENSE_DIR="$LIB_DIR/LICENSES"
+mkdir -p "$LICENSE_DIR"
+for dependency in preact htm es-module-shims; do
+    cp "node_modules/$dependency/LICENSE" "$LICENSE_DIR/$dependency-LICENSE"
+done
+cp package-lock.json "$LICENSE_DIR/package-lock.json"
 
 echo "All dependencies updated successfully from node_modules."


### PR DESCRIPTION
## Summary

Follow up on #649 by tightening the maintenance boundary around the vendored import-map shim:

- correct comments and test documentation that overstated what `async = false` and the forced Chrome shim test guarantee
- regenerate static dependencies deterministically with `npm ci --ignore-scripts`
- embed the upstream licenses and lockfile provenance alongside the shipped frontend assets
- narrow the JavaScript CodeQL exclusion from all of `static/lib/**` to only the current `es-module-shims.js` exception

The production loader statements are unchanged. The real iPadOS 15.8.8 canary for the merged #649 page continues to cover the target Safari behavior that Chromedp cannot emulate.

## Linked issue

Refs #649

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (fmt, vet, lint, tests)
- [ ] Tested against a real SoundTouch device (details below)

Focused validation:

- `go test ./pkg/service/soundtouchweb`
- `go test -tags=browsertest ./pkg/service/soundtouchweb`
- `go test ./...`
- `go vet ./...`
- `shellcheck scripts/update-static-deps.sh`
- `bash -n scripts/update-static-deps.sh`
- `git diff --check`

The complete test run initially encountered the existing LAN-sensitive `TestUnifiedDiscoveryCache` behavior when a real SSDP responder was visible; an isolated retry and the final complete run passed.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed
