### PR TITLE
fix: address CodeQL alerts 318-320 (device-status guard, debug log, unused var)

### DIFF
--- a/cmd/example-dlna-server/logutil.go
+++ b/cmd/example-dlna-server/logutil.go
@@ -1,0 +1,13 @@
+package main
+
+import "strings"
+
+// sanitizeLog strips newline characters from s to prevent log-injection
+// (CodeQL go/log-injection). Values from HTTP requests may contain
+// attacker-controlled newlines.
+func sanitizeLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	s = strings.ReplaceAll(s, "\r", `\r`)
+
+	return s
+}

--- a/cmd/example-dlna-server/main.go
+++ b/cmd/example-dlna-server/main.go
@@ -654,8 +654,8 @@ func withAccessLog(logger *slog.Logger, next http.Handler) http.Handler {
 			r.Body = io.NopCloser(bytes.NewReader(body))
 
 			browseAttrs = []any{
-				"objectID", between(string(body), "<ObjectID>", "</ObjectID>"),
-				"browseFlag", between(string(body), "<BrowseFlag>", "</BrowseFlag>"),
+				"objectID", sanitizeLog(between(string(body), "<ObjectID>", "</ObjectID>")),
+				"browseFlag", sanitizeLog(between(string(body), "<BrowseFlag>", "</BrowseFlag>")),
 			}
 		}
 
@@ -664,7 +664,7 @@ func withAccessLog(logger *slog.Logger, next http.Handler) http.Handler {
 
 		attrs := []any{
 			"method", r.Method,
-			"path", r.URL.Path,
+			"path", sanitizeLog(r.URL.Path),
 			"status", rec.status,
 			"bytes", rec.bytes,
 			"from", r.RemoteAddr,

--- a/pkg/service/handlers/web/js/script.js
+++ b/pkg/service/handlers/web/js/script.js
@@ -1661,7 +1661,6 @@ async function fetchInteractions() {
             const path = i.path || i.Path || "";
             const status = i.status || i.Status || "";
             const category = i.category || i.Category || "";
-            const session = i.session || i.Session || "";
             const file = i.file || i.File || "";
             const scmudcData = i.scmudc_data || i.SCMUDCData || null;
 

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -115,7 +115,11 @@ function App() {
                 }
             } else if (msg.type === 'status_update' && msg.deviceId) {
                 setDevices(prev => {
-                    if (!prev[msg.deviceId]) return prev;
+                    // Object.prototype.hasOwnProperty, not a plain prev[msg.deviceId]
+                    // truthy check: a deviceId of "__proto__" or "constructor" would
+                    // otherwise resolve through the prototype chain to a truthy value
+                    // and pass the check despite not being a real, known device.
+                    if (!Object.prototype.hasOwnProperty.call(prev, msg.deviceId)) return prev;
                     return {
                         ...prev,
                         [msg.deviceId]: { ...prev[msg.deviceId], status: msg.data },

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -102,7 +102,6 @@ function App() {
             if (msg.type === 'devices') {
                 setDevices(msg.data || {});
             } else if (msg.type === 'discovery_status') {
-                console.log('[DEBUG_LOG] discovery_status:', msg.data);
                 if (msg.data?.isDiscovering !== undefined) {
                     setIsDiscovering(msg.data.isDiscovering);
                 } else if (msg.data?.status === 'starting') {


### PR DESCRIPTION
## Summary

Three small, independent fixes for open CodeQL findings, one commit each:

- [CodeQL alert 318](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/318)
  (`js/remote-property-injection`, high) — the WebSocket `status_update`
  handler guarded a device-state write with a plain `!prev[msg.deviceId]`
  truthy check. A `deviceId` of `"__proto__"` or `"constructor"` resolves
  through the prototype chain to a truthy value, bypassing the intended
  "must be a known device" guard. Not classic prototype pollution
  (computed keys in object literals use `[[DefineOwnProperty]]`, not the
  legacy `__proto__` setter), but it would let a bogus own-property
  corrupt the rendered device list. Switched to
  `Object.prototype.hasOwnProperty.call(...)` — avoided `Object.hasOwn`
  (ES2022, Safari 15.4+) given
  [PR #649](https://github.com/gesellix/Bose-SoundTouch/pull/649)'s
  recent Safari 15.0 compatibility work.
- [CodeQL alert 319](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/319)
  (`js/log-injection`, medium) — removed a leftover
  `console.log('[DEBUG_LOG] ...')` line logging WebSocket payload data
  verbatim.
- [CodeQL alert 320](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/320)
  (`js/unused-local-variable`) — removed a dead `session` variable in
  the admin interactions table (never rendered).

Also includes a follow-up fix for
[CodeQL alert 313](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/313)
(`go/log-injection`, medium) found while reviewing the same alert batch:
`cmd/example-dlna-server`'s access-log middleware logged `r.URL.Path`
and SOAP-body-derived `objectID`/`browseFlag` without sanitizing
newlines. Added the same `sanitizeLog` helper this repo already uses in
~18 other packages for this exact class of finding.

[CodeQL alert 312](https://github.com/gesellix/Bose-SoundTouch/security/code-scanning/312)
(`go/reflected-xss`, high, same file/area as alert 313) was investigated
and deliberately left open for now: `objectID` is only ever used as a
map lookup key in `pkg/dlna/dlnatest`, never echoed into the response,
and every actual output field goes through `xmlEsc`/`xmlAttr`
(`encoding/xml.EscapeText`) before being written — looks like a CodeQL
false positive (the query likely doesn't recognize a custom wrapper
around `xml.EscapeText` as a valid sanitizer for this query), but not
dismissing it without further discussion.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` clean (two pre-existing, unrelated skips:
      `TestHandleTuneInPlayback_Authorized` requires a live TuneIn
      account; `TestCheck443Reachability_LANProbeMatchesListenerOutcome`
      is network-environment-dependent)
- [x] `make lint` (golangci-lint) clean
- [x] `node --check` on both modified JS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)