### PR TITLE
docs(player): explain stereo-pair AirPlay limit

### DIFF
--- a/.github/workflows/browser-tests.yml
+++ b/.github/workflows/browser-tests.yml
@@ -40,10 +40,18 @@ jobs:
       - name: Verify a Chrome/Chromium binary is available
         # chromedp (used by the browsertest-tagged tests) discovers Chrome on
         # PATH or in a standard install location; GitHub's ubuntu-latest
-        # runner image ships Google Chrome preinstalled. Fail fast with a
-        # clear message here instead of a cryptic chromedp allocator error
-        # if that image ever stops including it.
+        # runner image ships Google Chrome preinstalled. Fail fast here with a
+        # clear message instead of a cryptic chromedp allocator error if that
+        # image ever stops including it.
         run: google-chrome --version
 
       - name: Run browser-level player compatibility tests
         run: make test-browser
+
+      - name: Set up Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Run frontend unit tests
+        run: make test-frontend

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build build-cli test test-coverage test-browser test-http-client test-http-client-rotate check fmt vet lint clean dev help screenshots build-stockholm-image prepare-stockholm update-static-deps dev-docs dev-docs-tidy hugo
+.PHONY: all build build-cli test test-coverage test-browser test-frontend test-http-client test-http-client-rotate check fmt vet lint clean dev help screenshots build-stockholm-image prepare-stockholm update-static-deps dev-docs dev-docs-tidy hugo
 
 # Load .env if present (simple KEY=VALUE format, no shell quoting)
 -include .env
@@ -155,6 +155,14 @@ test-coverage:
 test-browser:
 	@echo "Running browser-level compatibility tests..."
 	$(GOTEST) -tags browsertest -v ./pkg/service/soundtouchweb/...
+
+# Unit tests for the embedded player's static JS modules (see
+# pkg/service/soundtouchweb/frontend_test/), run via Node's built-in test
+# runner. Not part of `test`/`check`, since they need a Node binary matching
+# package.json's engines field, same reasoning as test-browser needing Chrome.
+test-frontend:
+	@echo "Running frontend unit tests..."
+	node --test pkg/service/soundtouchweb/frontend_test/*.test.mjs
 
 check: fmt vet test test-http-client
 
@@ -516,6 +524,7 @@ help:
 	@echo "  test          - Run tests"
 	@echo "  test-coverage - Run tests with coverage report"
 	@echo "  test-browser             - Run browser-level (chromedp) player compatibility tests"
+	@echo "  test-frontend            - Run player static JS unit tests (Node's test runner)"
 	@echo "  test-http-client         - Run .http integration tests via Docker Compose"
 	@echo "  test-http-client-rotate  - Archive tests/integration/testdata/ before a fresh run (non-destructive)"
 	@echo "  check         - Run fmt, vet, and tests"

--- a/pkg/service/soundtouchweb/frontend_test/deviceDetail.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/deviceDetail.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const app = await readFile(new URL('../static/js/app.js', import.meta.url), 'utf8');
+
+test('explains the documented AirPlay limitation only for ST10 stereo pairs', () => {
+    assert.match(app, /isSoundTouch10StereoPair\(device\)/);
+    assert.match(app, /role="note" aria-label="Stereo pair limitation"/);
+    assert.match(app, /AirPlay unavailable while paired\./);
+    assert.match(app, /Unpair them to use AirPlay\./);
+});

--- a/pkg/service/soundtouchweb/frontend_test/stereoPresentation.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/stereoPresentation.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isSoundTouch10StereoPair } from '../static/js/stereoPresentation.mjs';
+
+test('identifies only projected SoundTouch 10 stereo pairs', () => {
+    assert.equal(isSoundTouch10StereoPair({
+        info: { type: 'SoundTouch 10' },
+        stereoPair: { masterDeviceId: 'left' },
+    }), true);
+    assert.equal(isSoundTouch10StereoPair({
+        info: { type: 'ST10' },
+        stereoPair: { masterDeviceId: 'left' },
+    }), true);
+    assert.equal(isSoundTouch10StereoPair({ info: { type: 'SoundTouch 10' } }), false);
+    assert.equal(isSoundTouch10StereoPair({
+        info: { type: 'SoundTouch 20' },
+        stereoPair: { masterDeviceId: 'left' },
+    }), false);
+});

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -693,6 +693,22 @@ img { display: block; max-width: 100%; }
 .source-icon { font-size: .9rem; line-height: 1; }
 .source-name { font-weight: 500; }
 
+.stereo-pair-note {
+    display: flex;
+    flex-direction: column;
+    gap: .2rem;
+    margin-top: 1rem;
+    padding: .65rem .75rem;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--text-dim);
+    font-size: .8rem;
+    line-height: 1.4;
+}
+.stereo-pair-note strong { color: var(--text); }
+
 /* ── Zone ────────────────────────────────────────────────────────────────── */
 .zone-section { margin-top: 1.25rem; }
 

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -16,6 +16,7 @@ import { PlayURL } from './components/PlayURL.js';
 import { TTS } from './components/TTS.js';
 import { Announcements } from './components/Announcements.js';
 import { api } from './api.js';
+import { isSoundTouch10StereoPair } from './stereoPresentation.mjs';
 
 const html = htm.bind(h);
 
@@ -53,6 +54,12 @@ function DeviceDetail({ deviceId, devices, onBack, onDevicesChanged, notify }) {
                 onChanged=${onDevicesChanged}
                 notify=${notify}
             />
+            ${isSoundTouch10StereoPair(device) ? html`
+                <aside class="stereo-pair-note" role="note" aria-label="Stereo pair limitation">
+                    <strong>AirPlay unavailable while paired.</strong>
+                    <span>SoundTouch 10 speakers cannot use AirPlay while paired. Unpair them to use AirPlay.</span>
+                </aside>
+            ` : null}
             <${Zone} deviceId=${deviceId} devices=${devices} />
             <${Recents} deviceId=${deviceId} />
         </div>

--- a/pkg/service/soundtouchweb/static/js/stereoPresentation.mjs
+++ b/pkg/service/soundtouchweb/static/js/stereoPresentation.mjs
@@ -1,0 +1,6 @@
+export function isSoundTouch10StereoPair(device) {
+    if (!device?.stereoPair) return false;
+
+    const model = String(device?.info?.type || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    return model === 'st10' || model === 'soundtouch10';
+}


### PR DESCRIPTION
## Summary

Bose documents that a SoundTouch 10 stereo pair cannot use AirPlay while the
speakers remain paired in its
[AirPlay troubleshooting guidance](https://www.boseapac.com/en_in/support/articles/HC2533/productCodes/soundtouch_10/article.html).
The embedded player currently exposes pair lifecycle controls without
explaining why the expected AirPlay target disappears.

This change adds a contextual notice to projected SoundTouch 10 stereo-pair
detail:

- states that AirPlay is unavailable while the pair exists;
- explains that dissolving the pair restores individual AirPlay targets; and
- does not show the notice for standalone speakers, malformed projections, or
  other SoundTouch models.

This is exact commit `6d936ec`, directly based on current upstream `main`
after stereo projection PR #654 was merged. It changes presentation only; it
does not alter pairing, AirPlay discovery, playback, or speaker state.

## Linked issue

Refs #252

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (fmt, vet, lint, tests)
- [ ] Tested against a real SoundTouch device (details below)

On exact commit `6d936ec`:

- `make test-browser` passes in native and forced-shim modes;
- the focused Node and `soundtouchweb` Go tests pass;
- predicate coverage verifies that only projected SoundTouch 10 stereo pairs
  receive the notice; and
- JavaScript syntax and `git diff --check 4478863..6d936ec` pass.

The documented behavior was observed on a real dissolved pair: both physical
members again appeared as separate AirPlay 2 receivers. The new notice itself
still needs visual verification in Firefox and the real iPhone/iPad player
before its presentation is marked physically verified.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Docs or CLI help updated if behavior changed
