### PR TITLE
fix(tunein): profile navigate 500, empty content, and broken episode playback

### DIFF
--- a/pkg/service/bmx/tunein.go
+++ b/pkg/service/bmx/tunein.go
@@ -605,20 +605,34 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 		Layout: "classic",
 	}
 
-	// Profiles contain "pivots" (sections like "Programs", "Related", etc.)
-	pivots, _ := data["pivots"].([]interface{})
-	for _, p := range pivots {
+	// The profiles API (api.radiotime.com/profiles/...) nests everything under
+	// "Item", and its pivots ("Contents", "Related", etc.) are an *object*
+	// keyed by pivot name, e.g.:
+	//   {"Item": {..., "Pivots": {"Contents": {"DisplayName": "Broadcasts", "Url": "..."}}}}
+	// (Earlier code assumed a top-level "pivots" array with "text"/"URL"
+	// fields, which never matched this response and left bmx_sections empty.)
+	item, _ := data["Item"].(map[string]interface{})
+	pivots, _ := item["Pivots"].(map[string]interface{})
+
+	for pivotName, p := range pivots {
+		// We only care about the "Contents" pivot for now (the main list).
+		if !strings.EqualFold(pivotName, "contents") {
+			continue
+		}
+
 		pivot, ok := p.(map[string]interface{})
 		if !ok {
 			continue
 		}
 
-		pivotName, _ := pivot["text"].(string)
-		pivotURL, _ := pivot["URL"].(string)
-
-		// We only care about the "Contents" pivot for now (the main list)
-		if !strings.EqualFold(pivotName, "contents") {
+		pivotURL, _ := pivot["Url"].(string)
+		if pivotURL == "" {
 			continue
+		}
+
+		displayName, _ := pivot["DisplayName"].(string)
+		if displayName == "" {
+			displayName = pivotName
 		}
 
 		contents, err := fetchJSON(tuneInRenderJSONURI(pivotURL))
@@ -626,18 +640,92 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 			return nil, err
 		}
 
-		body, _ := contents["body"].([]interface{})
-		for idx, item := range body {
-			m, ok := item.(map[string]interface{})
+		// "Items" (v1.3 profiles/search API) first, then "body" (legacy/OPML).
+		rawItems, ok := contents["Items"].([]interface{})
+		if !ok {
+			rawItems, _ = contents["body"].([]interface{})
+		}
+
+		// The Contents pivot doesn't return playable items directly: each
+		// top-level entry is a "Container" (e.g. GuideId "v5", Title
+		// "Episodes") whose real payload is its own "Children" array. A
+		// Container also carries a "More" pivot with a follow-up URL once
+		// there are more children than fit on this page. Build one
+		// BmxNavSection per container (falling back to treating the entry
+		// itself as a leaf item if it has no children, in case some profile
+		// types ever return a flat list here).
+		for _, raw := range rawItems {
+			m, ok := raw.(map[string]interface{})
 			if !ok {
 				continue
 			}
 
-			navResp.BmxSections = append(navResp.BmxSections, tuneInSearchSection(m, idx, "", "list"))
+			children, hasChildren := m["Children"].([]interface{})
+			if !hasChildren || len(children) == 0 {
+				navResp.BmxSections = append(navResp.BmxSections, models.BmxNavSection{
+					Name:   displayName,
+					Layout: "list",
+					Items:  []models.BmxNavItem{tuneInProfileNavItem(m)},
+				})
+
+				continue
+			}
+
+			sectionName, _ := m["Title"].(string)
+			if sectionName == "" {
+				sectionName = displayName
+			}
+
+			navItems := make([]models.BmxNavItem, 0, len(children))
+
+			for _, child := range children {
+				cm, ok := child.(map[string]interface{})
+				if !ok {
+					continue
+				}
+
+				navItems = append(navItems, tuneInProfileNavItem(cm))
+			}
+
+			navResp.BmxSections = append(navResp.BmxSections, models.BmxNavSection{
+				Name:   sectionName,
+				Layout: "list",
+				Items:  navItems,
+			})
 		}
 	}
 
 	return navResp, nil
+}
+
+// tuneInProfileNavItem maps a single item found under a profile's Contents
+// pivot (or one of a Container's Children) to a BmxNavItem, based on its
+// TuneIn "Type".
+func tuneInProfileNavItem(m map[string]interface{}) models.BmxNavItem {
+	typeStr, _ := m["Type"].(string)
+
+	switch typeStr {
+	case "Program", "Profile":
+		name, _ := m["Title"].(string)
+
+		return tuneInSearchProfile(m, name)
+	default:
+		// "Topic" (individual on-demand episodes/broadcasts), "Station",
+		// "PlayItem", and anything else are all directly playable by their
+		// own GuideId via Tune.ashx, so they share tuneInSearchPlayItem's
+		// /v1/playback/station/{GuideId} link.
+		//
+		// This intentionally does NOT use /v1/playback/episodes/{GuideId}
+		// (tracklisturl): that route is backed by TuneInPodcastInfo, which
+		// is a stub that always returns an empty track list (see its
+		// doc comment) - a speaker given that location has nothing to
+		// play. /v1/playback/station/{GuideId} (bmx.TuneInPlayback) is the
+		// one path in this codebase proven to resolve a raw TuneIn GuideId
+		// - including a "t"-prefixed topic id - to an actual stream, via
+		// Tune.ashx; resolveTuneInProgramLatestEpisode+TuneInPlayback uses
+		// the exact same call for a program's latest topic.
+		return tuneInSearchPlayItem(m)
+	}
 }
 
 func parseTuneInStreamBody(body []byte, guideID string) ([]string, error) {

--- a/pkg/service/bmx/tunein.go
+++ b/pkg/service/bmx/tunein.go
@@ -393,20 +393,12 @@ func tuneInSearchSection(item map[string]interface{}, idx int, query, layout str
 
 	// Pivots.More.Url is the "load more" cursor from the TuneIn profiles API.
 	// It is only present when there are more results beyond the first page.
-	if pivots, ok := item["Pivots"].(map[string]interface{}); ok {
-		if more, ok := pivots["More"].(map[string]interface{}); ok {
-			if containerURL, _ := more["Url"].(string); strings.Contains(containerURL, "itemToken") {
-				if u, err := url.Parse(containerURL); err == nil && allowedTuneInHosts[u.Hostname()] {
-					encoded := base64.RawURLEncoding.EncodeToString([]byte(containerURL))
-
-					if section.Links == nil {
-						section.Links = &models.Links{}
-					}
-
-					section.Links.BmxNext = &models.Link{Href: "/v1/search/next?cursor=" + encoded}
-				}
-			}
+	if next := tuneInMoreCursorLink(item); next != nil {
+		if section.Links == nil {
+			section.Links = &models.Links{}
 		}
+
+		section.Links.BmxNext = next
 	}
 
 	for _, child := range children {
@@ -432,6 +424,36 @@ func tuneInSearchSection(item map[string]interface{}, idx int, query, layout str
 	}
 
 	return section
+}
+
+// tuneInMoreCursorLink builds a BmxNext pagination link from item's
+// Pivots.More.Url, the "load more" cursor the TuneIn search/profiles API
+// attaches once there are more results than fit on the first page. Returns
+// nil if there's nothing more to load.
+func tuneInMoreCursorLink(item map[string]interface{}) *models.Link {
+	pivots, ok := item["Pivots"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	more, ok := pivots["More"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	containerURL, _ := more["Url"].(string)
+	if !strings.Contains(containerURL, "itemToken") {
+		return nil
+	}
+
+	u, err := url.Parse(containerURL)
+	if err != nil || !allowedTuneInHosts[u.Hostname()] {
+		return nil
+	}
+
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(containerURL))
+
+	return &models.Link{Href: "/v1/search/next?cursor=" + encoded}
 }
 
 // TuneInSearchNext fetches the remaining results for a section using the opaque
@@ -552,7 +574,7 @@ func tuneInSearchProfile(item map[string]interface{}, _ string) models.BmxNavIte
 	// Artists/Stations/etc are typically navigated first.
 	if typeStr, _ := item["Type"].(string); typeStr == "Program" {
 		if guideID, _ := item["GuideId"].(string); guideID != "" {
-			encodedName := base64.URLEncoding.EncodeToString([]byte(profileName))
+			encodedName := base64.RawURLEncoding.EncodeToString([]byte(profileName))
 			playbackHref := fmt.Sprintf("/v1/playback/episodes/%s?encoded_name=%s", guideID, encodedName)
 
 			return models.BmxNavItem{
@@ -565,7 +587,7 @@ func tuneInSearchProfile(item map[string]interface{}, _ string) models.BmxNavIte
 						Type: "tracklisturl",
 					},
 					BmxNavigate: &models.Link{
-						Href: "/v1/navigate/profiles/" + base64.URLEncoding.EncodeToString([]byte(href)),
+						Href: "/v1/navigate/profiles/" + base64.RawURLEncoding.EncodeToString([]byte(href)),
 					},
 				},
 			}
@@ -600,7 +622,7 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 
 	navResp := &models.BmxNavResponse{
 		Links: &models.Links{
-			Self: &models.Link{Href: "/v1/navigate/profile/" + encodedURI},
+			Self: &models.Link{Href: "/v1/navigate/profiles/" + encodedURI},
 		},
 		Layout: "classic",
 	}
@@ -647,12 +669,13 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 		}
 
 		// The Contents pivot doesn't return playable items directly: each
-		// top-level entry is a "Container" (e.g. GuideId "v5", Title
-		// "Episodes") whose real payload is its own "Children" array. A
-		// Container also carries a "More" pivot with a follow-up URL once
-		// there are more children than fit on this page. Build one
-		// BmxNavSection per container (falling back to treating the entry
-		// itself as a leaf item if it has no children, in case some profile
+		// top-level entry is a "Container" (identified by a "ContainerType"
+		// field, e.g. GuideId "v5", Title "Episodes") whose real payload is
+		// its own "Children" (or legacy lowercase "children") array. A
+		// Container also carries a "Pivots.More" cursor once there are more
+		// children than fit on this page. Build one BmxNavSection per
+		// container (falling back to treating the entry itself as a leaf
+		// item only when it isn't a Container at all, in case some profile
 		// types ever return a flat list here).
 		for _, raw := range rawItems {
 			m, ok := raw.(map[string]interface{})
@@ -661,7 +684,19 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 			}
 
 			children, hasChildren := m["Children"].([]interface{})
+			if !hasChildren {
+				children, hasChildren = m["children"].([]interface{})
+			}
+
 			if !hasChildren || len(children) == 0 {
+				if _, isContainer := m["ContainerType"].(string); isContainer {
+					// An empty container (e.g. no episodes published yet)
+					// has nothing playable to show; skip it rather than
+					// mistakenly treating its own GuideId (which identifies
+					// the container, not a track) as a playback link.
+					continue
+				}
+
 				navResp.BmxSections = append(navResp.BmxSections, models.BmxNavSection{
 					Name:   displayName,
 					Layout: "list",
@@ -687,11 +722,17 @@ func TuneInNavigateProfile(encodedURI string) (*models.BmxNavResponse, error) {
 				navItems = append(navItems, tuneInProfileNavItem(cm))
 			}
 
-			navResp.BmxSections = append(navResp.BmxSections, models.BmxNavSection{
+			section := models.BmxNavSection{
 				Name:   sectionName,
 				Layout: "list",
 				Items:  navItems,
-			})
+			}
+
+			if next := tuneInMoreCursorLink(m); next != nil {
+				section.Links = &models.Links{BmxNext: next}
+			}
+
+			navResp.BmxSections = append(navResp.BmxSections, section)
 		}
 	}
 

--- a/pkg/service/bmx/tunein_test.go
+++ b/pkg/service/bmx/tunein_test.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
 )
 
 // TestTuneInSectionsAshx_UntypedContainerSurfacesStations is a regression
@@ -518,5 +520,138 @@ func TestParseTuneInProgramContents(t *testing.T) {
 				t.Errorf("got episode id %q, want %q", got, tc.wantID)
 			}
 		})
+	}
+}
+
+// TestTuneInNavigateProfileHandlesContainerShapes is a regression test for
+// four bugs found reviewing PR #677's profile-navigate fix:
+//   - an empty Container (no children, identified by "ContainerType") was
+//     misread as a leaf item and turned into a bogus playback link keyed by
+//     the container's own non-playable GuideId (it checked "Type", which
+//     only leaf items carry, instead of "ContainerType");
+//   - the legacy lowercase "children" key (as opposed to "Children") was no
+//     longer read at all, silently hiding any container using it;
+//   - the Pivots.More.Url "load more" pagination cursor was dropped
+//     entirely, so a container's BmxNext link was never built; and
+//   - the response's own self link used "/v1/navigate/profile/" (singular),
+//     which none of the route dispatchers that recognize "profiles"
+//     (plural) actually match, breaking re-navigation via that link.
+func TestTuneInNavigateProfileHandlesContainerShapes(t *testing.T) {
+	var contentsURL string
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch r.URL.Path {
+		case "/profile":
+			_, _ = w.Write([]byte(`{
+				"Item": {
+					"Pivots": {
+						"Contents": {"DisplayName": "Broadcasts", "Url": "` + contentsURL + `"}
+					}
+				}
+			}`))
+		case "/contents":
+			_, _ = w.Write([]byte(`{
+				"Items": [
+					{
+						"Title": "Episodes",
+						"GuideId": "v5",
+						"ContainerType": "Topics",
+						"Children": [
+							{"Type": "Topic", "Title": "Ep 1", "GuideId": "t100"}
+						],
+						"Pivots": {"More": {"Url": "` + contentsURL + `?itemToken=abc"}}
+					},
+					{
+						"Title": "Empty Container",
+						"GuideId": "v6",
+						"ContainerType": "Topics",
+						"Children": []
+					},
+					{
+						"Title": "Legacy Children",
+						"GuideId": "v7",
+						"ContainerType": "Topics",
+						"children": [
+							{"Type": "Topic", "Title": "Ep 2", "GuideId": "t200"}
+						]
+					},
+					{
+						"Type": "Station",
+						"Title": "Flat Leaf",
+						"GuideId": "s999"
+					}
+				]
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	contentsURL = ts.URL + "/contents"
+
+	parsed, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatalf("could not parse test server URL: %v", err)
+	}
+
+	allowedTuneInHosts[parsed.Hostname()] = true
+	defer delete(allowedTuneInHosts, parsed.Hostname())
+
+	encodedURI := base64.RawURLEncoding.EncodeToString([]byte(ts.URL + "/profile"))
+
+	navResp, err := TuneInNavigateProfile(encodedURI)
+	if err != nil {
+		t.Fatalf("TuneInNavigateProfile returned error: %v", err)
+	}
+
+	if navResp.Links == nil || navResp.Links.Self == nil {
+		t.Fatalf("response has no self link: %+v", navResp)
+	}
+
+	if want := "/v1/navigate/profiles/" + encodedURI; navResp.Links.Self.Href != want {
+		t.Errorf("self link = %q, want %q (must match the \"profiles\" prefix the dispatchers recognize)", navResp.Links.Self.Href, want)
+	}
+
+	byName := make(map[string]models.BmxNavSection, len(navResp.BmxSections))
+	for _, section := range navResp.BmxSections {
+		byName[section.Name] = section
+	}
+
+	if _, found := byName["Empty Container"]; found {
+		t.Errorf("empty container was surfaced as a section, want it skipped: %+v", navResp.BmxSections)
+	}
+
+	episodes, ok := byName["Episodes"]
+	if !ok {
+		t.Fatalf("no \"Episodes\" section found: %+v", navResp.BmxSections)
+	}
+
+	if len(episodes.Items) != 1 || episodes.Items[0].Name != "Ep 1" {
+		t.Errorf("Episodes items = %+v, want exactly [Ep 1]", episodes.Items)
+	}
+
+	if episodes.Links == nil || episodes.Links.BmxNext == nil || !strings.Contains(episodes.Links.BmxNext.Href, "/v1/search/next?cursor=") {
+		t.Errorf("Episodes section missing BmxNext pagination link: %+v", episodes.Links)
+	}
+
+	legacy, ok := byName["Legacy Children"]
+	if !ok {
+		t.Fatalf("no \"Legacy Children\" section found (lowercase \"children\" fallback not applied): %+v", navResp.BmxSections)
+	}
+
+	if len(legacy.Items) != 1 || legacy.Items[0].Name != "Ep 2" {
+		t.Errorf("Legacy Children items = %+v, want exactly [Ep 2]", legacy.Items)
+	}
+
+	broadcasts, ok := byName["Broadcasts"]
+	if !ok {
+		t.Fatalf("no \"Broadcasts\" (flat leaf, pivot display name) section found: %+v", navResp.BmxSections)
+	}
+
+	if len(broadcasts.Items) != 1 || broadcasts.Items[0].Name != "Flat Leaf" {
+		t.Errorf("Broadcasts items = %+v, want exactly [Flat Leaf]", broadcasts.Items)
 	}
 }

--- a/pkg/service/handlers/handlers_bmx_tunein.go
+++ b/pkg/service/handlers/handlers_bmx_tunein.go
@@ -288,7 +288,12 @@ func parseTuneInNavigatePath(wildcard string) (interface{}, error) {
 		// multi-segment ones decode correctly.
 		parts := strings.Split(rest, "/")
 
-		return bmx.TuneInNavigateProfile(parts[len(parts)-1])
+		encodedURI := parts[len(parts)-1]
+		if encodedURI == "" {
+			return bmx.TuneInNavigate(wildcard, nil)
+		}
+
+		return bmx.TuneInNavigateProfile(encodedURI)
 
 	default:
 		return bmx.TuneInNavigate(wildcard, nil)

--- a/pkg/service/handlers/handlers_bmx_tunein.go
+++ b/pkg/service/handlers/handlers_bmx_tunein.go
@@ -223,7 +223,7 @@ func (s *Server) HandleTuneInReport(w http.ResponseWriter, r *http.Request) {
 //   - (empty)                               → top-level browse
 //   - {encodedURI}                          → browse the given TuneIn URI
 //   - sub/{n}/{encodedURI}                  → single subsection of a browse page
-//   - profiles/{type}/{id}/{encodedURI}     → artist/program profile page
+//   - profiles/{encodedURI}                 → artist/program profile page
 func (s *Server) HandleTuneInNavigate(w http.ResponseWriter, r *http.Request) {
 	// Authorization gate temporarily disabled (was: 401 if header missing).
 	// The Stockholm browser proxy doesn't inject Authorization for requests
@@ -277,13 +277,18 @@ func parseTuneInNavigatePath(wildcard string) (interface{}, error) {
 		return bmx.TuneInNavigate(rest[secondSlash+1:], &n)
 
 	case "profiles":
-		// profiles/{type}/{id}/{encodedURI}
-		parts := strings.SplitN(rest, "/", 3)
-		if len(parts) < 3 {
-			return bmx.TuneInNavigate(wildcard, nil)
-		}
+		// Hrefs are generated as a single path segment:
+		// /v1/navigate/profiles/{encodedURI} (see tuneInSearchProfile in
+		// pkg/service/bmx/tunein.go). Requiring a profiles/{type}/{id}/{encodedURI}
+		// shape here caused every profile link to fall through to
+		// bmx.TuneInNavigate with the literal "profiles/..." prefix still
+		// attached, which is not valid base64 and produced a 500 ("illegal
+		// base64 data..."). Take the last path segment as the encoded URI so
+		// both the current single-segment hrefs and any legacy
+		// multi-segment ones decode correctly.
+		parts := strings.Split(rest, "/")
 
-		return bmx.TuneInNavigateProfile(parts[2])
+		return bmx.TuneInNavigateProfile(parts[len(parts)-1])
 
 	default:
 		return bmx.TuneInNavigate(wildcard, nil)

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -991,7 +991,7 @@ func (app *WebApp) HandleTuneInSearchNext(w http.ResponseWriter, r *http.Request
 //   - (empty)                             → top-level browse
 //   - /{encodedURI}                       → browse the given TuneIn URI
 //   - /sub/{n}/{encodedURI}               → single subsection
-//   - /profiles/{type}/{id}/{encodedURI}  → artist/program profile
+//   - /profiles/{encodedURI}              → artist/program profile
 func (app *WebApp) HandleTuneInNavigate(w http.ResponseWriter, r *http.Request) {
 	wildcard := chi.URLParam(r, "*")
 

--- a/pkg/service/stations/stations.go
+++ b/pkg/service/stations/stations.go
@@ -102,7 +102,12 @@ func navigateTuneIn(wildcard string) (*models.BmxNavResponse, error) {
 		// multi-segment ones decode correctly.
 		parts := strings.Split(rest, "/")
 
-		return bmx.TuneInNavigateProfile(parts[len(parts)-1])
+		encodedURI := parts[len(parts)-1]
+		if encodedURI == "" {
+			return bmx.TuneInNavigate(wildcard, nil)
+		}
+
+		return bmx.TuneInNavigateProfile(encodedURI)
 	default:
 		return bmx.TuneInNavigate(wildcard, nil)
 	}

--- a/pkg/service/stations/stations.go
+++ b/pkg/service/stations/stations.go
@@ -91,12 +91,18 @@ func navigateTuneIn(wildcard string) (*models.BmxNavResponse, error) {
 
 		return bmx.TuneInNavigate(rest[secondSlash+1:], &n)
 	case "profiles":
-		parts := strings.SplitN(rest, "/", 3)
-		if len(parts) < 3 {
-			return bmx.TuneInNavigate(wildcard, nil)
-		}
+		// Hrefs are generated as a single path segment:
+		// /v1/navigate/profiles/{encodedURI} (see tuneInSearchProfile in
+		// pkg/service/bmx/tunein.go). Requiring a profiles/{type}/{id}/{encodedURI}
+		// shape here caused every profile link to fall through to
+		// bmx.TuneInNavigate with the literal "profiles/..." prefix still
+		// attached, which is not valid base64 and produced a 500 ("illegal
+		// base64 data..."). Take the last path segment as the encoded URI
+		// so both the current single-segment hrefs and any legacy
+		// multi-segment ones decode correctly.
+		parts := strings.Split(rest, "/")
 
-		return bmx.TuneInNavigateProfile(parts[2])
+		return bmx.TuneInNavigateProfile(parts[len(parts)-1])
 	default:
 		return bmx.TuneInNavigate(wildcard, nil)
 	}


### PR DESCRIPTION
## Summary

Clicking into a "Show" from TuneIn search results (a Program/Profile item, e.g. searching "bbc" and opening a program) was broken end-to-end. Three separate bugs, found and fixed one at a time against a live SoundTouch speaker:

1. 500 on every profile link. navigateTuneIn / parseTuneInNavigatePath required a profiles/{type}/{id}/{encodedURI} path shape that nothing actually generates (real hrefs are a single profiles/{encodedURI} segment - see tuneInSearchProfile). Every profile link fell through to bmx.TuneInNavigate with the literal "profiles/..." prefix still attached to the string it tried to base64-decode, which reliably failed as invalid base64 and surfaced as a 500.

2. Content list came back empty after the 500 was fixed. TuneInNavigateProfile read a top-level data["pivots"] array with "text"/"URL" fields. The real API nests this under Item.Pivots, keyed by pivot name ({"Item": {"Pivots": {"Contents": {"DisplayName": "Broadcasts", "Url": "..."}}}}) - an object, not an array - so the pivot lookup never matched and bmx_sections came back null. Once that's fixed, the Contents pivot's own response also doesn't list playable items directly: each entry is a "Container" (e.g. a tile titled "Episodes") whose real payload is its Children array, which the old code didn't walk.

3. List displayed, but nothing would play. Individual episode ("Topic") items were linked to /v1/playback/episodes/{guideId} (type tracklisturl). That route is backed by TuneInPodcastInfo, which - per its own existing implementation - ignores the id entirely and always returns an empty track list, so a speaker given that link has nothing to play (confirmed against a real device: POST /play succeeded, but the speaker span its loading indicator forever with no audio). Switched episodes to /v1/playback/station/{guideId} (type stationurl) instead - the one path in this codebase already proven to resolve a raw TuneIn GuideId to a real stream via Tune.ashx (resolveTuneInProgramLatestEpisode + TuneInPlayback already do exactly this for a program's latest topic).


## Type of change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (fmt, vet, lint, tests)
- [X] Tested against a real SoundTouch device (details below)
I've tested on my Bose SoundTouch30 II
<!-- If you tested on hardware, note the model and what you observed. In any pasted
     output, use RFC-5737 documentation IPs (192.0.2.x), never your real LAN IPs. -->

make check note

make check currently fails on some machines/networks via a pre-existing, unrelated test: TestCheck443Reachability_LANProbeMatchesListenerOutcome in pkg/service/handlers/preflight_test.go (untouched by this PR - last modified in an unrelated earlier commit). It asserts that probing 1.2.3.4:8443 is unreachable, using that address as a "nothing answers here" placeholder; on networks where something along the path intercepts/ responds to arbitrary outbound :443 connections (transparent proxies, DPI, some ISPs), the probe comes back reachable and the assertion fails. Reproduces identically on a clean main with none of this PR's changes, so it's a flaky environmental assumption in that test, not a regression here. The rest of the suite (including this PR's affected packages - pkg/service/bmx, pkg/service/stations, pkg/service/handlers) passes:

`
go test -v ./... -skip TestCheck443Reachability_LANProbeMatchesListenerOutcome
`


## Checklist

- [X] My changes are focused, and I have read the diff myself
- [X] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [ ] Docs or CLI help updated if behavior changed

---

### A note on AI-assisted contributions

AI and agent-assisted code is welcome, we use it here too. What we cannot accept is
unreviewed "slop": large generated diffs the author has not read, run, or understood.
Keep PRs small and focused, make sure `make check` passes, and be ready to explain your
changes during review.

By contributing, you agree that your work is licensed under the project's
[MIT License](https://github.com/gesellix/Bose-SoundTouch/blob/main/LICENSE) and that you
will follow the
[Code of Conduct](https://github.com/gesellix/Bose-SoundTouch/blob/main/CODE_OF_CONDUCT.md).
