### PR TITLE
Bump Go toolchain requirement to 1.27.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,9 +174,16 @@ test-http-client-rotate:
 
 test-http-client:
 	@echo "Starting services with docker compose (waiting for healthchecks)..."
-	@docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build --wait
-	@echo "Running .http tests..."
-	@docker run --rm --network soundtouch-test-net \
+	@docker compose -f docker-compose.yml -f docker-compose.ci.yml up -d --build --wait; \
+	UP_EXIT_CODE=$$?; \
+	if [ $$UP_EXIT_CODE -ne 0 ]; then \
+		echo "docker compose up failed (exit $$UP_EXIT_CODE); dumping container logs:"; \
+		docker compose -f docker-compose.yml -f docker-compose.ci.yml logs; \
+		docker compose -f docker-compose.yml -f docker-compose.ci.yml down; \
+		exit $$UP_EXIT_CODE; \
+	fi; \
+	echo "Running .http tests..."; \
+	docker run --rm --network soundtouch-test-net \
 		-v "$(PWD)/tests/integration/http-client:/workdir" \
 		jetbrains/intellij-http-client:2026.1 \
 		--env-file /workdir/http-client.env.json \
@@ -236,9 +243,7 @@ test-http-client:
 		/workdir/unregister_device.http \
 		--report; \
 	EXIT_CODE=$$?; \
-	docker compose -f docker-compose.yml -f docker-compose.ci.yml logs soundtouch-service; \
-	docker compose -f docker-compose.yml -f docker-compose.ci.yml logs spotify-mock; \
-	docker compose -f docker-compose.yml -f docker-compose.ci.yml logs amazon-mock; \
+	docker compose -f docker-compose.yml -f docker-compose.ci.yml logs; \
 	docker compose -f docker-compose.yml -f docker-compose.ci.yml down; \
 	exit $$EXIT_CODE
 

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -35,7 +35,7 @@ services:
       start_period: 3s
 
   spotify-mock:
-    image: golang:1.27.0-alpine
+    image: golang:1.27.1-alpine
     container_name: spotify-mock
     working_dir: /app
     volumes:
@@ -53,7 +53,7 @@ services:
       start_period: 3s
 
   amazon-mock:
-    image: golang:1.27.0-alpine
+    image: golang:1.27.1-alpine
     container_name: amazon-mock
     working_dir: /app
     volumes:
@@ -71,7 +71,7 @@ services:
       start_period: 3s
 
   tunein-mock:
-    image: golang:1.27.0-alpine
+    image: golang:1.27.1-alpine
     container_name: tunein-mock
     working_dir: /app
     volumes:

--- a/examples/navigation-station-demo/go.mod
+++ b/examples/navigation-station-demo/go.mod
@@ -1,6 +1,6 @@
 module navigation-station-demo
 
-go 1.27.0
+go 1.27.1
 
 require github.com/gesellix/bose-soundtouch v0.128.0
 

--- a/examples/preset-management/go.mod
+++ b/examples/preset-management/go.mod
@@ -1,6 +1,6 @@
 module preset-management-example
 
-go 1.27.0
+go 1.27.1
 
 require github.com/gesellix/bose-soundtouch v0.128.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gesellix/bose-soundtouch
 
-go 1.27.0
+go 1.27.1
 
 require (
 	filippo.io/age v1.3.2


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` (and the two example modules) from
  1.27.0 to 1.27.1.

## Type of change

- [X] Dependency update
- [ ] New feature
- [ ] Breaking change

## How was it tested?

- [X] `make check` passes (fmt, vet, lint, tests)