### PR TITLE
Stabilize browser compatibility tests against chromedp startup flakiness

### DIFF
--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -33,6 +33,12 @@ func newHeadlessChromeContext(t *testing.T) context.Context {
 			// permissions Chrome's sandbox needs; harmless to also set
 			// locally.
 			chromedp.Flag("no-sandbox", true),
+			// chromedp's default is 20s; a loaded shared CI runner can be
+			// slower than that to fork/exec Chrome and print its DevTools
+			// websocket URL, which otherwise surfaces as a flaky "websocket
+			// url timeout reached" test failure unrelated to the page under
+			// test.
+			chromedp.WSURLReadTimeout(45*time.Second),
 		)...,
 	)
 	t.Cleanup(cancelAlloc)
@@ -40,7 +46,7 @@ func newHeadlessChromeContext(t *testing.T) context.Context {
 	ctx, cancelCtx := chromedp.NewContext(allocCtx)
 	t.Cleanup(cancelCtx)
 
-	ctx, cancelTimeout := context.WithTimeout(ctx, 30*time.Second)
+	ctx, cancelTimeout := context.WithTimeout(ctx, 60*time.Second)
 	t.Cleanup(cancelTimeout)
 
 	return ctx


### PR DESCRIPTION
## Summary

- CI's "Player browser tests" job intermittently failed with
  `chromedp run: websocket url timeout reached` in
  `TestPlayerRendersNatively` (e.g. run
  [33779974031](https://github.com/gesellix/Bose-SoundTouch/actions/runs/33779974031/job/100730977853)).
  chromedp's exec allocator has a hardcoded 20s `wsURLReadTimeout`
  before it gives up waiting for headless Chrome to print its
  DevTools websocket URL, which a loaded shared CI runner can
  occasionally exceed on Chrome startup alone, unrelated to the page
  under test.
- Raise that timeout to 45s via `chromedp.WSURLReadTimeout(...)` in
  `newHeadlessChromeContext` (`pkg/service/soundtouchweb/browser_compatibility_test.go`),
  and widen the outer per-test context from 30s to 60s to match.

## Type of change

- [ ] New feature
- [ ] Breaking change
- [X] CI/test reliability fix

## How was it tested?

- [X] `make test-browser` passes locally (both
  `TestPlayerRendersNatively` and `TestPlayerRendersUnderForcedShimMode`).
- `go vet -tags browsertest ./pkg/service/soundtouchweb/...` passes.
- The original failure was intermittent, so this raises the ceiling
  on the known root cause rather than reproducing the exact CI
  timing; the fix should reduce recurrence, not eliminate it with
  certainty.