### PR TITLE
fix(stereo): stop treating an unreachable external Marge as a hard block

### DIFF
--- a/cmd/soundtouch-cli/cmd_group.go
+++ b/cmd/soundtouch-cli/cmd_group.go
@@ -182,19 +182,49 @@ func newGroupCoordinator(config *ClientConfig) *stereopair.Coordinator {
 	}
 
 	cleanupClient := &http.Client{Timeout: lifecycleConfig.Timeout}
+	cleanup, preflight, rename := cliStereoPairGenerationPersistence(cleanupClient)
 
 	return stereopair.NewWithGenerationLifecyclePersistence(
 		groupClientFactory(&lifecycleConfig),
-		func(ref stereopair.GenerationRef) error {
-			return stereopair.DeleteMargeGroupGeneration(cleanupClient, ref)
-		},
-		func(refs []stereopair.GenerationRef) error {
-			return stereopair.EnsureMargeNoGroupGenerations(cleanupClient, refs)
-		},
-		func(ref stereopair.GenerationRef, name string) error {
-			return stereopair.RenameMargeGroupGeneration(cleanupClient, ref, name)
-		},
+		cleanup, preflight, rename,
 	)
+}
+
+// cliStereoPairGenerationPersistence wires generation-lifecycle hooks for
+// the CLI: cleanup and rename are no-ops, and preflight's read-only
+// dangling-generation check is advisory (mirrors -service's and -player's
+// own equivalents).
+//
+// A speaker self-reports its own group create/rename/teardown to whatever
+// Marge backend it's configured with -- that's the entire reason
+// HandleMargeAddGroup/HandleMargeModifyGroup/HandleMargeDeleteGroup exist,
+// they're only ever called by speakers, never by us. Proactively pushing the
+// same update ourselves would duplicate that against a backend we generally
+// can't authenticate to anyway (real Bose cloud, another AfterTouch/SoundCork
+// instance, ...). The one part with a distinct purpose -- checking for a
+// dangling stale generation before a new Create -- is still attempted, but
+// its failure must not block Create: it's a best-effort safety net on top of
+// the coordinator's own physical preflight, not the primary guard.
+func cliStereoPairGenerationPersistence(
+	cleanupClient *http.Client,
+) (stereopair.GenerationCleanup, stereopair.GenerationPreflight, stereopair.GenerationRename) {
+	cleanup := func(stereopair.GenerationRef) error {
+		return nil
+	}
+
+	preflight := func(refs []stereopair.GenerationRef) error {
+		if err := stereopair.EnsureMargeNoGroupGenerations(cleanupClient, refs); err != nil {
+			PrintWarning(fmt.Sprintf("stereo-pair external generation preflight inconclusive, proceeding: %v", err))
+		}
+
+		return nil
+	}
+
+	rename := func(stereopair.GenerationRef, string) error {
+		return nil
+	}
+
+	return cleanup, preflight, rename
 }
 
 // groupClientFactory addresses every member directly while retaining the

--- a/cmd/soundtouch-cli/cmd_group_test.go
+++ b/cmd/soundtouch-cli/cmd_group_test.go
@@ -209,3 +209,47 @@ func testServerHostPort(t *testing.T, serverURL string) (string, int) {
 
 	return host, port
 }
+
+// TestCLIStereoPairGenerationPersistenceSkipsWritesButAttemptsRead covers
+// the CLI's generation-lifecycle wiring: cleanup and rename must never push
+// to a Marge backend -- the speaker itself self-reports its own group
+// teardown/rename to whatever backend it's configured with (see
+// HandleMargeDeleteGroup/HandleMargeModifyGroup, only ever called by
+// speakers). Preflight still attempts its read-only dangling-generation
+// check, but a failure there (network error, wrong credentials, real Bose
+// cloud rejecting us, ...) must not block Create.
+func TestCLIStereoPairGenerationPersistenceSkipsWritesButAttemptsRead(t *testing.T) {
+	getCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/device/LEFT-ID/group") {
+			getCalls++
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+			return
+		}
+
+		t.Fatalf("unexpected external %s %s: cleanup/rename must not write to a backend the CLI doesn't own", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	cleanup, preflight, rename := cliStereoPairGenerationPersistence(server.Client())
+
+	ref := stereopair.GenerationRef{
+		DeviceID: "LEFT-ID", AccountID: "ACCOUNT1", MargeURL: server.URL + "/marge",
+		GroupID: "7654321",
+	}
+
+	if err := rename(ref, "Renamed living room"); err != nil {
+		t.Fatalf("rename = %v, want nil (speaker self-reports its own rename)", err)
+	}
+	if err := cleanup(ref); err != nil {
+		t.Fatalf("cleanup = %v, want nil (speaker self-reports its own teardown)", err)
+	}
+	if err := preflight([]stereopair.GenerationRef{ref}); err != nil {
+		t.Fatalf("preflight = %v, want nil: an unauthenticated external check must not block Create", err)
+	}
+	if getCalls != 1 {
+		t.Fatalf("external GET calls = %d, want exactly 1 (preflight must still attempt the read)", getCalls)
+	}
+}

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1515,6 +1515,25 @@ func newEmbeddedWebApp(server *handlers.Server, serverURL, internalURL string, d
 			localServerURL, localHTTPSServerURL := server.GetSettings()
 			return []string{localServerURL, localHTTPSServerURL}
 		},
+		func(margeURL string) bool {
+			if !server.DNSHijackEnabled() {
+				return false
+			}
+
+			parsed, err := url.Parse(strings.TrimSpace(margeURL))
+			if err != nil || parsed.Hostname() == "" {
+				return false
+			}
+
+			host := parsed.Hostname()
+			for _, hijacked := range discovery.InterceptedBoseHosts {
+				if strings.Contains(host, hijacked) {
+					return true
+				}
+			}
+
+			return false
+		},
 		&http.Client{Timeout: stereopair.RequestTimeout},
 	)
 	webApp.SetStereoPairGenerationPersistence(cleanup, preflight, rename)
@@ -1549,6 +1568,7 @@ func newEmbeddedWebApp(server *handlers.Server, serverURL, internalURL string, d
 func embeddedStereoPairGenerationPersistence(
 	ds *datastore.DataStore,
 	localMargeURLs func() []string,
+	dnsHijackedMargeHost func(margeURL string) bool,
 	httpClient *http.Client,
 ) (stereopair.GenerationCleanup, stereopair.GenerationPreflight, stereopair.GenerationRename) {
 	isLocal := func(margeURL string, localURLs []string) bool {
@@ -1558,7 +1578,14 @@ func embeddedStereoPairGenerationPersistence(
 			}
 		}
 
-		return false
+		// DNS-level migration never changes a speaker's own reported
+		// MargeURL -- only how that Bose hostname resolves on the network --
+		// so a speaker reporting e.g. https://streaming.bose.com can still be
+		// pointed at this very service. Treating it as "external" instead
+		// sends the generation-conflict check out over the real internet,
+		// where Bose's still-live Apigee gateway rejects it (HTTP 401),
+		// hard-blocking Create for a normal DNS-migrated setup.
+		return dnsHijackedMargeHost(margeURL)
 	}
 
 	cleanup := func(ref stereopair.GenerationRef) error {

--- a/cmd/soundtouch-service/main.go
+++ b/cmd/soundtouch-service/main.go
@@ -1598,7 +1598,12 @@ func embeddedStereoPairGenerationPersistence(
 			return err
 		}
 
-		return stereopair.DeleteMargeGroupGeneration(httpClient, ref)
+		// The speaker itself self-reports its own group teardown to
+		// whatever Marge backend it's configured with -- that's the entire
+		// reason HandleMargeDeleteGroup/HandleMargeDeleteAccountGroups
+		// exist, they're only ever called by speakers, never by us.
+		// Nothing for us to push to a backend we don't own.
+		return nil
 	}
 
 	preflight := func(refs []stereopair.GenerationRef) error {
@@ -1621,7 +1626,14 @@ func embeddedStereoPairGenerationPersistence(
 		}
 
 		if len(externalRefs) > 0 {
-			return stereopair.EnsureMargeNoGroupGenerations(httpClient, externalRefs)
+			// Best-effort dangling-generation check against a backend we
+			// don't own (real Bose cloud, another AfterTouch/SoundCork
+			// instance, ...): attempt it, but never let it being
+			// unreachable or unauthenticated block a Create the
+			// coordinator's own physical preflight already verified safe.
+			if err := stereopair.EnsureMargeNoGroupGenerations(httpClient, externalRefs); err != nil {
+				log.Printf("Stereo-pair external generation preflight inconclusive, proceeding: %v", err)
+			}
 		}
 
 		return nil
@@ -1637,7 +1649,9 @@ func embeddedStereoPairGenerationPersistence(
 			return err
 		}
 
-		return stereopair.RenameMargeGroupGeneration(httpClient, ref, name)
+		// See cleanup's comment above: the speaker self-reports its own
+		// rename to whatever Marge backend it's configured with.
+		return nil
 	}
 
 	return cleanup, preflight, rename

--- a/cmd/soundtouch-service/stereo_pair_persistence_test.go
+++ b/cmd/soundtouch-service/stereo_pair_persistence_test.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"encoding/xml"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -19,9 +17,18 @@ import (
 // TestEmbeddedStereoPairPersistenceTreatsDNSHijackedBoseHostAsLocal).
 func neverDNSHijacked(string) bool { return false }
 
-type rejectingRoundTripper struct{}
+// rejectingRoundTripper errors on every request and counts how many it saw.
+// A preflight failure is now logged and swallowed rather than propagated
+// (see TestEmbeddedStereoPairPersistenceSkipsExternalWritesButAttemptsRead),
+// so tests that need to prove an external dispatch actually happened check
+// calls rather than the returned error.
+type rejectingRoundTripper struct {
+	calls int
+}
 
-func (rejectingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+func (r *rejectingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	r.calls++
+
 	return nil, errors.New("unexpected HTTP persistence request")
 }
 
@@ -50,7 +57,7 @@ func TestEmbeddedStereoPairPersistenceUsesLocalDatastoreAcrossAccounts(t *testin
 		ds,
 		func() []string { return []string{localURL} },
 		neverDNSHijacked,
-		&http.Client{Transport: rejectingRoundTripper{}},
+		&http.Client{Transport: &rejectingRoundTripper{}},
 	)
 
 	err = preflight([]stereopair.GenerationRef{{
@@ -93,7 +100,7 @@ func TestEmbeddedStereoPairCleanupMapsAmbiguousGenerationToConflict(t *testing.T
 		ds,
 		func() []string { return []string{localURL} },
 		neverDNSHijacked,
-		&http.Client{Transport: rejectingRoundTripper{}},
+		&http.Client{Transport: &rejectingRoundTripper{}},
 	)
 	wrongTopology := persistenceTestGroup(groupID)
 	wrongTopology.Roles.Roles[1].DeviceID = "SUBSTITUTE-RIGHT-ID"
@@ -107,64 +114,54 @@ func TestEmbeddedStereoPairCleanupMapsAmbiguousGenerationToConflict(t *testing.T
 	}
 }
 
-func TestEmbeddedStereoPairPersistenceUsesExternalMargeBackend(t *testing.T) {
-	active := true
-	deleteCalls := 0
-	postCalls := 0
-	expected := persistenceTestGroup("7654321")
+// TestEmbeddedStereoPairPersistenceSkipsExternalWritesButAttemptsRead covers
+// an external (non-local) MargeURL: cleanup and rename must never push to a
+// backend we don't own -- the speaker itself self-reports its own group
+// teardown/rename to whatever Marge backend it's configured with, which is
+// the entire reason HandleMargeDeleteGroup/HandleMargeModifyGroup exist
+// (they're only ever called by speakers). Preflight still attempts its
+// read-only dangling-generation check, but a failure there (network error,
+// wrong credentials, real Bose cloud rejecting us, ...) must not block
+// Create, since it's a best-effort check on top of the coordinator's own
+// physical preflight, not the primary guard.
+func TestEmbeddedStereoPairPersistenceSkipsExternalWritesButAttemptsRead(t *testing.T) {
+	getCalls := 0
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/device/LEFT-ID/group"):
-			if !active {
-				_, _ = w.Write([]byte(`<group/>`))
-				return
-			}
-			_, _ = fmt.Fprintf(w, `<group id="%s"><name>%s</name><masterDeviceId>%s</masterDeviceId><roles><groupRole><deviceId>LEFT-ID</deviceId><role>LEFT</role><ipAddress>192.0.2.10</ipAddress></groupRole><groupRole><deviceId>RIGHT-ID</deviceId><role>RIGHT</role><ipAddress>192.0.2.11</ipAddress></groupRole></roles></group>`, expected.ID, expected.Name, expected.MasterDeviceID)
-		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/group/"+expected.ID):
-			deleteCalls++
-			active = false
-			w.WriteHeader(http.StatusOK)
-		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/group/"+expected.ID):
-			postCalls++
-			var update models.Group
-			if err := xml.NewDecoder(r.Body).Decode(&update); err != nil {
-				http.Error(w, err.Error(), http.StatusBadRequest)
-				return
-			}
-			expected = &update
-			w.WriteHeader(http.StatusOK)
-		default:
-			http.NotFound(w, r)
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/device/LEFT-ID/group") {
+			getCalls++
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+			return
 		}
+
+		t.Fatalf("unexpected external %s %s: cleanup/rename must not write to a backend we don't own", r.Method, r.URL.Path)
 	}))
 	defer server.Close()
 
-	cleanup, _, rename := embeddedStereoPairGenerationPersistence(
+	cleanup, preflight, rename := embeddedStereoPairGenerationPersistence(
 		datastore.NewDataStore(t.TempDir()),
 		func() []string { return []string{"http://aftertouch.invalid:18000"} },
 		neverDNSHijacked,
 		server.Client(),
 	)
-	if err := rename(stereopair.GenerationRef{
+
+	ref := stereopair.GenerationRef{
 		DeviceID: "LEFT-ID", AccountID: "ACCOUNT1", MargeURL: server.URL + "/marge",
-		GroupID: expected.ID, ExpectedGroup: persistenceTestGroup(expected.ID),
-	}, "Renamed living room"); err != nil {
-		t.Fatalf("rename: %v", err)
-	}
-	if postCalls != 1 || expected.Name != "Renamed living room" {
-		t.Fatalf("external POST calls = %d, name = %q; want 1, Renamed living room", postCalls, expected.Name)
+		GroupID: "7654321", ExpectedGroup: persistenceTestGroup("7654321"),
 	}
 
-	if err := cleanup(stereopair.GenerationRef{
-		DeviceID: "LEFT-ID", AccountID: "ACCOUNT1", MargeURL: server.URL + "/marge",
-		GroupID: expected.ID, ExpectedGroup: expected,
-	}); err != nil {
-		t.Fatalf("cleanup: %v", err)
+	if err := rename(ref, "Renamed living room"); err != nil {
+		t.Fatalf("rename = %v, want nil (speaker self-reports its own rename)", err)
 	}
-
-	if deleteCalls != 1 || active {
-		t.Fatalf("external DELETE calls = %d, active = %v; want 1, false", deleteCalls, active)
+	if err := cleanup(ref); err != nil {
+		t.Fatalf("cleanup = %v, want nil (speaker self-reports its own teardown)", err)
+	}
+	if err := preflight([]stereopair.GenerationRef{ref}); err != nil {
+		t.Fatalf("preflight = %v, want nil: an unauthenticated external check must not block Create", err)
+	}
+	if getCalls != 1 {
+		t.Fatalf("external GET calls = %d, want exactly 1 (preflight must still attempt the read)", getCalls)
 	}
 }
 
@@ -178,6 +175,7 @@ func TestEmbeddedStereoPairPersistenceReadsOneCurrentURLSnapshot(t *testing.T) {
 
 	currentURL := "http://old.invalid:18000"
 	providerCalls := 0
+	transport := &rejectingRoundTripper{}
 	_, preflight, _ := embeddedStereoPairGenerationPersistence(
 		ds,
 		func() []string {
@@ -185,7 +183,7 @@ func TestEmbeddedStereoPairPersistenceReadsOneCurrentURLSnapshot(t *testing.T) {
 			return []string{currentURL}
 		},
 		neverDNSHijacked,
-		&http.Client{Transport: rejectingRoundTripper{}},
+		&http.Client{Transport: transport},
 	)
 
 	currentURL = "http://new.invalid:18000"
@@ -200,11 +198,18 @@ func TestEmbeddedStereoPairPersistenceReadsOneCurrentURLSnapshot(t *testing.T) {
 		t.Fatalf("URL provider calls = %d, want one coherent snapshot", providerCalls)
 	}
 
+	// The old URL no longer matches localMargeURLs()'s current snapshot, so
+	// this ref is external. Preflight still attempts the read (proven by the
+	// transport call count) but no longer propagates its failure -- an
+	// external check failing must not block Create.
 	err = preflight([]stereopair.GenerationRef{{
 		DeviceID: "LEFT-ID", AccountID: "OLD-ACCOUNT", MargeURL: "http://old.invalid:18000",
 	}})
-	if err == nil || !strings.Contains(err.Error(), "unexpected HTTP persistence request") {
-		t.Fatalf("old URL preflight error = %v, want external HTTP dispatch", err)
+	if err != nil {
+		t.Fatalf("old URL preflight error = %v, want nil (external check failure must not block)", err)
+	}
+	if transport.calls != 1 {
+		t.Fatalf("external HTTP dispatch calls = %d, want exactly 1", transport.calls)
 	}
 }
 
@@ -228,7 +233,7 @@ func TestEmbeddedStereoPairPersistenceTreatsDNSHijackedBoseHostAsLocal(t *testin
 		ds,
 		func() []string { return []string{"https://aftertouch.invalid:18443"} },
 		func(margeURL string) bool { return strings.Contains(margeURL, "streaming.bose.com") },
-		&http.Client{Transport: rejectingRoundTripper{}},
+		&http.Client{Transport: &rejectingRoundTripper{}},
 	)
 
 	err = preflight([]stereopair.GenerationRef{{

--- a/cmd/soundtouch-service/stereo_pair_persistence_test.go
+++ b/cmd/soundtouch-service/stereo_pair_persistence_test.go
@@ -14,6 +14,11 @@ import (
 	"github.com/gesellix/bose-soundtouch/pkg/stereopair"
 )
 
+// neverDNSHijacked is the default DNS-hijack predicate for tests that don't
+// exercise the DNS-migrated-speaker path (see
+// TestEmbeddedStereoPairPersistenceTreatsDNSHijackedBoseHostAsLocal).
+func neverDNSHijacked(string) bool { return false }
+
 type rejectingRoundTripper struct{}
 
 func (rejectingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
@@ -44,6 +49,7 @@ func TestEmbeddedStereoPairPersistenceUsesLocalDatastoreAcrossAccounts(t *testin
 	cleanup, preflight, rename := embeddedStereoPairGenerationPersistence(
 		ds,
 		func() []string { return []string{localURL} },
+		neverDNSHijacked,
 		&http.Client{Transport: rejectingRoundTripper{}},
 	)
 
@@ -86,6 +92,7 @@ func TestEmbeddedStereoPairCleanupMapsAmbiguousGenerationToConflict(t *testing.T
 	cleanup, _, _ := embeddedStereoPairGenerationPersistence(
 		ds,
 		func() []string { return []string{localURL} },
+		neverDNSHijacked,
 		&http.Client{Transport: rejectingRoundTripper{}},
 	)
 	wrongTopology := persistenceTestGroup(groupID)
@@ -136,6 +143,7 @@ func TestEmbeddedStereoPairPersistenceUsesExternalMargeBackend(t *testing.T) {
 	cleanup, _, rename := embeddedStereoPairGenerationPersistence(
 		datastore.NewDataStore(t.TempDir()),
 		func() []string { return []string{"http://aftertouch.invalid:18000"} },
+		neverDNSHijacked,
 		server.Client(),
 	)
 	if err := rename(stereopair.GenerationRef{
@@ -176,6 +184,7 @@ func TestEmbeddedStereoPairPersistenceReadsOneCurrentURLSnapshot(t *testing.T) {
 			providerCalls++
 			return []string{currentURL}
 		},
+		neverDNSHijacked,
 		&http.Client{Transport: rejectingRoundTripper{}},
 	)
 
@@ -196,5 +205,36 @@ func TestEmbeddedStereoPairPersistenceReadsOneCurrentURLSnapshot(t *testing.T) {
 	}})
 	if err == nil || !strings.Contains(err.Error(), "unexpected HTTP persistence request") {
 		t.Fatalf("old URL preflight error = %v, want external HTTP dispatch", err)
+	}
+}
+
+// TestEmbeddedStereoPairPersistenceTreatsDNSHijackedBoseHostAsLocal covers a
+// speaker migrated at the DNS level: its own reported MargeURL is still the
+// literal Bose cloud hostname (DNS migration never changes it), but this
+// service's DNS hijack redirects that hostname to itself on the network.
+// Routing it through the external HTTP path instead would reach the real,
+// still-live Bose cloud and 401 there, hard-blocking Create for a normal
+// DNS-migrated setup. Uses rejectingRoundTripper to prove no HTTP call is
+// attempted at all.
+func TestEmbeddedStereoPairPersistenceTreatsDNSHijackedBoseHostAsLocal(t *testing.T) {
+	ds := datastore.NewDataStore(t.TempDir())
+	group := persistenceTestGroup("")
+	groupID, err := ds.AddGroup("OLD-ACCOUNT", group)
+	if err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	_, preflight, _ := embeddedStereoPairGenerationPersistence(
+		ds,
+		func() []string { return []string{"https://aftertouch.invalid:18443"} },
+		func(margeURL string) bool { return strings.Contains(margeURL, "streaming.bose.com") },
+		&http.Client{Transport: rejectingRoundTripper{}},
+	)
+
+	err = preflight([]stereopair.GenerationRef{{
+		DeviceID: "LEFT-ID", AccountID: "NEW-ACCOUNT", MargeURL: "https://streaming.bose.com",
+	}})
+	if err == nil || !strings.Contains(err.Error(), groupID) {
+		t.Fatalf("preflight error = %v, want local generation %s found via datastore, not an external HTTP call", err, groupID)
 	}
 }

--- a/pkg/service/handlers/server.go
+++ b/pkg/service/handlers/server.go
@@ -1352,6 +1352,19 @@ func (s *Server) GetSettings() (string, string) {
 	return s.serverURL, s.httpsServerURL
 }
 
+// DNSHijackEnabled reports whether this server's DNS-hijack redirection
+// (SetDNSSettings) is currently active. DNS-level migration never changes a
+// speaker's own reported MargeURL -- only how a Bose cloud hostname resolves
+// on the network -- so callers use this alongside
+// discovery.InterceptedBoseHosts to recognize such a speaker as effectively
+// local despite its MargeURL literally being a Bose hostname.
+func (s *Server) DNSHijackEnabled() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.dnsEnabled
+}
+
 // IsSpotifyConfigured returns whether Spotify integration is configured.
 func (s *Server) IsSpotifyConfigured() bool {
 	s.mu.RLock()

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -170,20 +170,48 @@ func NewWebApp() *WebApp {
 			CheckOrigin: checkWebSocketOrigin,
 		},
 	}
-	app.StereoPairs = stereopair.NewWithGenerationLifecyclePersistence(
-		app.stereoPairClient,
-		func(ref stereopair.GenerationRef) error {
-			return stereopair.DeleteMargeGroupGeneration(app.stereoPairPersistenceClient(), ref)
-		},
-		func(refs []stereopair.GenerationRef) error {
-			return stereopair.EnsureMargeNoGroupGenerations(app.stereoPairPersistenceClient(), refs)
-		},
-		func(ref stereopair.GenerationRef, name string) error {
-			return stereopair.RenameMargeGroupGeneration(app.stereoPairPersistenceClient(), ref, name)
-		},
-	)
+	cleanup, preflight, rename := playerStereoPairGenerationPersistence(app.stereoPairPersistenceClient)
+	app.StereoPairs = stereopair.NewWithGenerationLifecyclePersistence(app.stereoPairClient, cleanup, preflight, rename)
 
 	return app
+}
+
+// playerStereoPairGenerationPersistence wires generation-lifecycle hooks for
+// contexts with no local datastore of their own (the standalone player, and
+// the player component embedded in -service before SetStereoPairGenerationPersistence
+// overrides it): cleanup and rename are no-ops, and preflight's read-only
+// dangling-generation check is advisory.
+//
+// A speaker self-reports its own group create/rename/teardown to whatever
+// Marge backend it's configured with -- that's the entire reason
+// HandleMargeAddGroup/HandleMargeModifyGroup/HandleMargeDeleteGroup exist,
+// they're only ever called by speakers, never by us. Proactively pushing the
+// same update ourselves would duplicate that against a backend we generally
+// can't authenticate to anyway (real Bose cloud, another AfterTouch/SoundCork
+// instance, ...). The one part with a distinct purpose -- checking for a
+// dangling stale generation before a new Create -- is still attempted, but
+// its failure must not block Create: it's a best-effort safety net on top of
+// the coordinator's own physical preflight, not the primary guard.
+func playerStereoPairGenerationPersistence(
+	persistenceClient func() *http.Client,
+) (stereopair.GenerationCleanup, stereopair.GenerationPreflight, stereopair.GenerationRename) {
+	cleanup := func(stereopair.GenerationRef) error {
+		return nil
+	}
+
+	preflight := func(refs []stereopair.GenerationRef) error {
+		if err := stereopair.EnsureMargeNoGroupGenerations(persistenceClient(), refs); err != nil {
+			log.Printf("Stereo-pair external generation preflight inconclusive, proceeding: %v", err)
+		}
+
+		return nil
+	}
+
+	rename := func(stereopair.GenerationRef, string) error {
+		return nil
+	}
+
+	return cleanup, preflight, rename
 }
 
 func (app *WebApp) stereoPairPersistenceClient() *http.Client {

--- a/pkg/service/soundtouchweb/stereo_pair_persistence_test.go
+++ b/pkg/service/soundtouchweb/stereo_pair_persistence_test.go
@@ -1,0 +1,56 @@
+package soundtouchweb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/stereopair"
+)
+
+// TestPlayerStereoPairGenerationPersistenceSkipsWritesButAttemptsRead covers
+// the standalone player's (and embedded player's default) generation
+// lifecycle wiring: cleanup and rename must never push to a Marge backend --
+// the speaker itself self-reports its own group teardown/rename to whatever
+// backend it's configured with (see HandleMargeDeleteGroup/HandleMargeModifyGroup,
+// only ever called by speakers). Preflight still attempts its read-only
+// dangling-generation check, but a failure there (network error, wrong
+// credentials, real Bose cloud rejecting us, ...) must not block Create.
+func TestPlayerStereoPairGenerationPersistenceSkipsWritesButAttemptsRead(t *testing.T) {
+	getCalls := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/device/LEFT-ID/group") {
+			getCalls++
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+			return
+		}
+
+		t.Fatalf("unexpected external %s %s: cleanup/rename must not write to a backend the player doesn't own", r.Method, r.URL.Path)
+	}))
+	defer server.Close()
+
+	cleanup, preflight, rename := playerStereoPairGenerationPersistence(func() *http.Client {
+		return server.Client()
+	})
+
+	ref := stereopair.GenerationRef{
+		DeviceID: "LEFT-ID", AccountID: "ACCOUNT1", MargeURL: server.URL + "/marge",
+		GroupID: "7654321",
+	}
+
+	if err := rename(ref, "Renamed living room"); err != nil {
+		t.Fatalf("rename = %v, want nil (speaker self-reports its own rename)", err)
+	}
+	if err := cleanup(ref); err != nil {
+		t.Fatalf("cleanup = %v, want nil (speaker self-reports its own teardown)", err)
+	}
+	if err := preflight([]stereopair.GenerationRef{ref}); err != nil {
+		t.Fatalf("preflight = %v, want nil: an unauthenticated external check must not block Create", err)
+	}
+	if getCalls != 1 {
+		t.Fatalf("external GET calls = %d, want exactly 1 (preflight must still attempt the read)", getCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Reported against real hardware: creating a stereo pair failed with a 502 and `HTTP 401: Unauthorized` from `streaming.bose.com`, even though both speakers were DNS-migrated to this AfterTouch instance. Root cause was two separate issues in the stereo-pair generation-persistence layer added by the #654/#655 stack:

- **DNS migration isn't detectable from a speaker's reported `MargeURL` alone.** DNS-level migration only changes how a Bose hostname resolves on the network, never the device's own advertised URL, so a DNS-migrated speaker still reports `MargeURL: https://streaming.bose.com`. The generation preflight's `isLocal()` check only matched against this service's own advertised server URL, so it misclassified such a speaker as "external" and queried the *real* Bose cloud instead of the local datastore.
- **The external-Marge path duplicated work the speaker already does itself, unreliably.** A speaker's own firmware self-reports its group create/rename/teardown to whatever Marge backend it's configured with — that's the entire reason `HandleMargeAddGroup`/`HandleMargeModifyGroup`/`HandleMargeDeleteGroup` exist; they're only ever called by speakers, never by us. The coordinator's `GenerationCleanup`/`GenerationRename` proactively pushed the same update to an external backend it generally can't authenticate to (real Bose cloud, another instance), and `GenerationPreflight`'s read-only dangling-generation check hard-blocked `Create`/`Dissolve` if that push/check failed — even though the coordinator's own physical preflight (capability/zone/reachability against the live speakers) is the real safety net.

## Changes

1. Recognize a DNS-hijacked speaker's `MargeURL` as local (via the existing `discovery.InterceptedBoseHosts` list + this service's own DNS-hijack setting), routing it through the reliable local datastore check instead.
2. Stop pushing cleanup/rename to an external Marge backend — no-op, since the speaker self-reports on its own.
3. Make the external preflight's dangling-generation check advisory: still attempted, but a failure (network error, wrong credentials, unreachable backend) no longer blocks `Create`/`Dissolve`.
4. Applied consistently across `soundtouch-service`, the standalone/embedded player, and the CLI.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `gofmt -l` clean
- [x] `go test ./...` full repo pass
- [x] `make lint` — 0 issues
- [x] New unit tests per binary proving: cleanup/rename never call the external backend, preflight still attempts the read but tolerates failure, and a DNS-hijacked Bose hostname resolves to the local (not external) path
- [x] Confirmed against real hardware (Create + Dissolve, DNS-migrated speakers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
