### PR TITLE
Make saving to a preset discoverable, and show real station artwork

### DIFF
--- a/cmd/soundtouch-player/browsable_url_test.go
+++ b/cmd/soundtouch-player/browsable_url_test.go
@@ -1,0 +1,31 @@
+package main
+
+import "testing"
+
+// TestBrowsableURL covers the startup log line: a wildcard listen address is
+// what net.Listen wants but is not something a terminal can turn into a
+// clickable link, so it has to be rewritten before it is logged.
+func TestBrowsableURL(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want string
+	}{
+		{"wildcard", ":8080", "http://localhost:8080"},
+		{"wildcard IPv4", "0.0.0.0:8080", "http://localhost:8080"},
+		{"wildcard IPv6", "[::]:8080", "http://localhost:8080"},
+		{"explicit host", "192.0.2.5:8080", "http://192.0.2.5:8080"},
+		{"loopback", "127.0.0.1:8000", "http://127.0.0.1:8000"},
+		{"hostname", "speaker.local:8080", "http://speaker.local:8080"},
+		{"IPv6 literal stays bracketed", "[2001:db8::1]:8080", "http://[2001:db8::1]:8080"},
+		{"not host:port is left alone", "nonsense", "http://nonsense"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := browsableURL(tc.addr); got != tc.want {
+				t.Errorf("browsableURL(%q) = %q, want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/soundtouch-player/main.go
+++ b/cmd/soundtouch-player/main.go
@@ -188,7 +188,7 @@ func main() {
 			r := chi.NewRouter()
 			webApp.Mount(r, discoveryService)
 
-			log.Printf("AfterTouch Web UI starting on http://%s", sanitizeLog(addr))
+			log.Printf("AfterTouch Web UI starting on %s", sanitizeLog(browsableURL(addr)))
 
 			return http.ListenAndServe(addr, r)
 		},
@@ -215,6 +215,27 @@ func defaultDiscoveryInterface(rawInterface, rawBind, resolvedBind string) strin
 	}
 
 	return ""
+}
+
+// browsableURL turns a listen address into a URL that can actually be opened.
+// A wildcard listen address is written ":8080" or "0.0.0.0:8080", which is what
+// net.Listen wants but is useless as a link, so its host becomes "localhost".
+// An IPv6 literal comes back bracketed, courtesy of net.JoinHostPort.
+func browsableURL(addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		// Not host:port after all; hand it back rather than mangle it.
+		return "http://" + addr
+	}
+
+	// SplitHostPort has already stripped any brackets, and JoinHostPort puts
+	// them back for an IPv6 literal, so neither needs handling here.
+	switch host {
+	case "", "0.0.0.0", "::":
+		host = "localhost"
+	}
+
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // resolveBindAddr returns the address to bind the HTTP listener to.

--- a/pkg/service/soundtouchweb/frontend_test/nowPlaying.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/nowPlaying.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const nowPlaying = await readFile(
+    new URL('../static/js/components/NowPlaying.js', import.meta.url), 'utf8');
+
+// Radio stations carry their logo on the ContentItem rather than in the <art>
+// element, so the now-playing card showed nothing for a TuneIn station whose
+// preset tile displayed the same logo fine. The Go model already resolves both
+// in this order (NowPlaying.GetArtworkURL); the frontend has to match it.
+test('the now-playing card falls back to the ContentItem artwork', () => {
+    assert.match(nowPlaying, /nowPlaying\.Art\?\.URL \|\| nowPlaying\.ContentItem\?\.ContainerArt/);
+});
+
+// The star used to say only "Saved as preset", leaving you to hunt for which
+// slot it meant.
+test('the preset star names the slot it is saved in', () => {
+    assert.match(nowPlaying, /Saved as preset \$\{mappedPreset\.ID\}/);
+});

--- a/pkg/service/soundtouchweb/frontend_test/presets.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/presets.test.mjs
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const presets = await readFile(new URL('../static/js/components/Presets.js', import.meta.url), 'utf8');
+const css = await readFile(new URL('../static/css/app.css', import.meta.url), 'utf8');
+
+// Regression guard for issue #646: the save-to-preset button used to be
+// rendered only while something was playing *and* revealed only on hover, so
+// two reporters concluded the feature did not exist and filed a bug against
+// something else entirely.
+test('the save button is disabled rather than hidden when nothing is playing', () => {
+    assert.match(presets, /disabled=\$\{!canSave\}/);
+    assert.doesNotMatch(presets, /\$\{canSave && html/);
+});
+
+test('the save button is not hidden behind a hover reveal', () => {
+    const rule = css.match(/\.preset-save-btn \{[^}]*\}/);
+    assert.ok(rule, 'expected a .preset-save-btn rule');
+    // Touch devices have no hover, so opacity:0 made it unreachable there.
+    assert.doesNotMatch(rule[0], /opacity:\s*0\s*[;}]/);
+    assert.doesNotMatch(css, /:hover\s+\.preset-save-btn/);
+});
+
+test('an empty slot saves the current content when clicked', () => {
+    assert.match(presets, /savableEmpty = isEmpty && canSave/);
+    assert.match(presets, /if \(savableEmpty\) store\(\)/);
+});
+
+// The grid item is .preset-slot-wrap, which stretches to the row height; the
+// tile inside it needs to be told to fill that, or a row of one- and two-line
+// preset names ends up with ragged bottom edges.
+test('preset tiles fill their grid cell so a row lines up', () => {
+    assert.match(css, /\.preset-slot-wrap \.preset-slot \{[^}]*height:\s*100%/);
+});

--- a/pkg/service/soundtouchweb/frontend_test/stationBrowsers.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/stationBrowsers.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const dir = new URL('../static/js/components/', import.meta.url);
+const tuneIn = await readFile(new URL('TuneInBrowser.js', dir), 'utf8');
+const radioBrowser = await readFile(new URL('RadioBrowser.js', dir), 'utf8');
+
+// The speaker keeps the ContainerArt it is handed at select time, and presets,
+// recents and now-playing all read the artwork back from there. Both browsers
+// display the station logo in their result list, so there is no excuse for
+// dropping it on the way to the speaker.
+test('the TuneIn browser sends the station logo with the play request', () => {
+    assert.match(tuneIn, /containerArt: pendingPlay\.image/);
+});
+
+test('the RadioBrowser browser sends the station logo with the play request', () => {
+    assert.match(radioBrowser, /image: item\.imageUrl/);
+    assert.match(radioBrowser, /containerArt: pendingPlay\.image/);
+});

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -1652,6 +1652,7 @@ func (app *WebApp) HandlePlayURL(w http.ResponseWriter, r *http.Request) {
 		Type:         "stationurl",
 		Location:     location,
 		ItemName:     req.Name,
+		ContainerArt: req.ImageURL,
 		IsPresetable: true,
 	}
 
@@ -1737,6 +1738,10 @@ func (app *WebApp) HandlePlayRadioBrowser(w http.ResponseWriter, r *http.Request
 	var req struct {
 		Location string `json:"location"`
 		Name     string `json:"name"`
+		// The speaker stores whatever art it is given at select time, and
+		// presets/recents read it back from there. Dropping it here is why
+		// saved radio stations used to show a placeholder.
+		ContainerArt string `json:"containerArt"`
 	}
 
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -1750,9 +1755,10 @@ func (app *WebApp) HandlePlayRadioBrowser(w http.ResponseWriter, r *http.Request
 	}
 
 	ci := stations.ResolveContentItem(stations.PlayItem{
-		Provider: stations.ProviderRadioBrowser,
-		Location: req.Location,
-		Name:     req.Name,
+		Provider:     stations.ProviderRadioBrowser,
+		Location:     req.Location,
+		Name:         req.Name,
+		ContainerArt: req.ContainerArt,
 	})
 
 	logPlaybackRequest("radiobrowser", deviceID, ci.Source, ci.SourceAccount, ci.Location, ci.ItemName)

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -1319,3 +1319,76 @@ func TestHandleGetZoneCandidates_UnknownDeviceNotFound(t *testing.T) {
 		t.Fatalf("expected 404 for an unknown device, got %d: %s", w.Code, w.Body.String())
 	}
 }
+
+// TestPlayHandlers_ForwardStationArt covers the gap behind the empty preset
+// and recents thumbnails: the speaker stores whatever ContainerArt it is given
+// at /select time, and presets, recents and now-playing all read the artwork
+// back from there. Two of the three station play paths used to drop it.
+// RadioBrowser never accepted the field, and the custom-URL path embedded the
+// image in the Orion location but left it off the ContentItem, so a station
+// saved as a preset came back with <containerArt></containerArt>.
+func TestPlayHandlers_ForwardStationArt(t *testing.T) {
+	const art = "http://example.com/station-logo.png"
+
+	cases := []struct {
+		name    string
+		handler func(*WebApp) http.HandlerFunc
+		body    string
+	}{
+		{
+			name:    "tunein",
+			handler: func(app *WebApp) http.HandlerFunc { return app.HandlePlayTuneIn },
+			body:    `{"location":"/v1/playback/station/s1","type":"stationurl","name":"Example","containerArt":"` + art + `"}`,
+		},
+		{
+			name:    "radiobrowser",
+			handler: func(app *WebApp) http.HandlerFunc { return app.HandlePlayRadioBrowser },
+			body:    `{"location":"/stations/byuuid/abc","name":"Example","containerArt":"` + art + `"}`,
+		},
+		{
+			// The custom-URL path names the field imageUrl, since it also goes
+			// into the Orion location blob the speaker fetches.
+			name:    "url",
+			handler: func(app *WebApp) http.HandlerFunc { return app.HandlePlayURL },
+			body:    `{"url":"http://example.com/stream.mp3","name":"Example","imageUrl":"` + art + `","serviceUrl":"http://aftertouch.example"}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var capturedBody string
+
+			speaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path == "/select" {
+					b, _ := io.ReadAll(r.Body)
+					capturedBody = string(b)
+				}
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer speaker.Close()
+
+			app := NewWebApp()
+			conn := webtypes.NewDeviceConnection(
+				client.NewClient(&client.Config{Host: speaker.URL}),
+				&models.DeviceInfo{Name: "Test Speaker"},
+			)
+			conn.SetStatus(&webtypes.DeviceStatus{IsConnected: true, LastActivity: time.Now()})
+			app.AddDevice("art-device", conn)
+
+			req := httptest.NewRequest(http.MethodPost, "/play", strings.NewReader(tc.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withChiParams(req, map[string]string{"id": "art-device"})
+			w := httptest.NewRecorder()
+
+			tc.handler(app)(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			if want := "<containerArt>" + art + "</containerArt>"; !strings.Contains(capturedBody, want) {
+				t.Errorf("XML should contain %q, got: %s", want, capturedBody)
+			}
+		})
+	}
+}

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -682,6 +682,8 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
     gap: .5rem;
     padding: .45rem 1.7rem .45rem .45rem; /* right gutter: slot number + star */
     border: 1px solid var(--border);
+    /* The source colour lives here, clear of the artwork. */
+    border-bottom: 3px solid var(--slot-color, var(--border));
     border-radius: var(--radius);
     background: var(--surface);
     cursor: pointer;
@@ -691,7 +693,12 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 }
 .preset-slot:hover:not(:disabled) { background: var(--bg); box-shadow: var(--shadow); }
 .preset-slot:disabled { opacity: .4; cursor: default; }
-.preset-slot.active { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
+.preset-slot.active {
+    border-color: var(--accent);
+    border-bottom-color: var(--slot-color, var(--accent));
+    background: var(--accent);
+    color: var(--accent-fg);
+}
 .preset-slot.active .preset-name,
 .preset-slot.active .preset-source-label,
 .preset-slot.active .preset-num { color: var(--accent-fg); }
@@ -705,19 +712,25 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 /* Artwork box, or a placeholder holding the source icon.
    The background stays the page ground in both themes, which is the inverse of
    whatever --content-icon-filter paints the icon, so the icon keeps full
-   contrast. The source colour rides on the border instead: tinting the fill
-   put a mid-tone behind a mid-tone icon and both disappeared. */
+   contrast. Tinting the fill was worse still: a mid-tone behind a mid-tone
+   icon and both disappeared.
+
+   Nothing coloured touches this box: the source colour is a bottom border on
+   the tile instead (see .preset-slot), because ringing the thumb framed real
+   album art in Spotify green or TuneIn blue and fought with the artwork. */
 .preset-thumb {
     position: relative;
     flex: 0 0 40px;
     width: 40px; height: 40px;
-    border: 1px solid var(--slot-color, var(--border));
+    border: 1px solid var(--border);
     border-radius: 4px;
     background: var(--bg);
     overflow: hidden;
     display: flex; align-items: center; justify-content: center;
 }
-.preset-slot.savable .preset-thumb { border-style: dashed; border-color: var(--fav); }
+/* An empty slot has no source to colour, so the whole box carries the
+   save invitation instead. */
+.preset-slot.savable .preset-thumb { border: 1px dashed var(--fav); }
 .preset-thumb-glyph { font-size: 1.05rem; line-height: 1; color: var(--fav); opacity: .85; }
 .preset-art { position: relative; width: 100%; height: 100%; object-fit: cover; }
 .preset-source-icon {

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -683,7 +683,7 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
     padding: .45rem 1.7rem .45rem .45rem; /* right gutter: slot number + star */
     border: 1px solid var(--border);
     /* The source colour lives here, clear of the artwork. */
-    border-bottom: 3px solid var(--slot-color, var(--border));
+    border-bottom: 2px solid var(--slot-color, var(--border));
     border-radius: var(--radius);
     background: var(--surface);
     cursor: pointer;
@@ -779,6 +779,8 @@ img.preset-source-icon { object-fit: contain; filter: var(--content-icon-filter)
     gap: .35rem;
     padding: .35rem .7rem;
     border: 1px solid var(--slot-color, var(--border));
+    /* Weighted along the bottom, matching the preset tiles. */
+    border-bottom-width: 2px;
     border-radius: 999px;
     background: var(--surface);
     /* Buttons don't inherit colour from the page, and the UA default is black

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -13,9 +13,15 @@
     --stale:     #f59e0b;
     --offline:   #9ca3af;
     --danger:    #b42318;
+    --fav:       #c9a000; /* preset star: warm gold, not too bright */
+    --fav-bright:#e0b800;
     --radius:    8px;
     --shadow:    0 1px 3px rgba(0,0,0,.10), 0 1px 2px rgba(0,0,0,.06);
     --nav-icon-filter: brightness(0) invert(1);
+    /* Mono SVGs are black on transparent. On normal content they stay as
+       they are; -alt is for inverted backgrounds like an active tile. */
+    --content-icon-filter: none;
+    --content-icon-filter-alt: brightness(0) invert(1);
 }
 
 @media (prefers-color-scheme: dark) {
@@ -28,7 +34,11 @@
         --accent:   #e0e0e0;
         --accent-fg:#111;
         --danger:   #ff8a80;
+        --fav:      #d4ae1a;
+        --fav-bright:#f0c800;
         --nav-icon-filter: none;
+        --content-icon-filter: brightness(0) invert(1);
+        --content-icon-filter-alt: none;
     }
 }
 
@@ -46,6 +56,21 @@ a { color: inherit; text-decoration: none; cursor: pointer; }
 button { cursor: pointer; font: inherit; border: none; background: none; }
 ul { list-style: none; }
 img { display: block; max-width: 100%; }
+
+/* Per-source accent colour, so one source looks the same everywhere it
+   appears. Read by the preset thumb border, the now-playing artwork
+   placeholder and the source pill border; those three are the only places
+   that set data-source. Physical inputs (aux, optical, HDMI, ...)
+   deliberately have none and fall back to --border. */
+[data-source="SPOTIFY"]              { --slot-color: #1DB954; }
+[data-source="TUNEIN"]               { --slot-color: #0082C8; }
+[data-source="LOCAL_INTERNET_RADIO"] { --slot-color: #FF6B35; }
+[data-source="RADIO_BROWSER"]        { --slot-color: #00A3A3; }
+[data-source="AMAZON"]               { --slot-color: #FF9900; }
+[data-source="PANDORA"]              { --slot-color: #4A90C2; }
+[data-source="DEEZER"]               { --slot-color: #A238FF; }
+[data-source="IHEARTRADIO"]          { --slot-color: #C6002B; }
+[data-source="BLUETOOTH"]            { --slot-color: #0082FC; }
 
 /* ── Layout ──────────────────────────────────────────────────────────────── */
 .app { display: flex; flex-direction: column; min-height: 100vh; }
@@ -473,13 +498,13 @@ img { display: block; max-width: 100%; }
     color: var(--text);
 }
 .now-playing-fav-btn.mapped {
-    color: #c9a000; /* warm gold, not too bright */
+    color: var(--fav);
     opacity: .85;
 }
 .now-playing-fav-btn.mapped:hover,
 .now-playing-fav-btn.mapped.open {
     opacity: 1;
-    color: #e0b800;
+    color: var(--fav-bright);
 }
 
 .now-playing-fav-overlay {
@@ -499,6 +524,15 @@ img { display: block; max-width: 100%; }
 }
 
 .album-art { width: 64px; height: 64px; border-radius: 4px; object-fit: cover; flex-shrink: 0; }
+/* Placeholder when neither <art> nor the ContentItem carries a picture, built
+   like the preset thumb: neutral ground for icon contrast, source colour on
+   the border. */
+.album-art-empty {
+    display: flex; align-items: center; justify-content: center;
+    background: var(--bg); border: 1px solid var(--slot-color, var(--border));
+    font-size: 1.6rem;
+}
+img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; filter: var(--content-icon-filter); opacity: .85; }
 
 .track-info { flex: 1; min-width: 0; overflow: hidden; }
 .track-title {
@@ -537,9 +571,17 @@ img { display: block; max-width: 100%; }
 
 .transport { display: flex; align-items: center; gap: .5rem; margin-bottom: .75rem; }
 
+/* Fixed squares rather than padding around the glyph. These used to be sized
+   by their content, and the content was emoji whose advance width varies per
+   glyph and per platform font, so the buttons came out different widths and
+   the play button changed size every time it toggled between play and pause,
+   shifting the whole row. The icons are SVG now, but the fixed box is what
+   keeps the row stable. */
 .ctrl-btn {
-    font-size: 1.25rem;
-    padding: .4rem .7rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    flex: 0 0 auto;
+    padding: 0;
     border-radius: 6px;
     border: 1px solid var(--border);
     background: var(--surface);
@@ -551,7 +593,8 @@ img { display: block; max-width: 100%; }
     transition: background .12s;
 }
 .ctrl-btn:hover { background: var(--bg); }
-.ctrl-btn.play-btn { font-size: 1.5rem; padding: .4rem .9rem; }
+/* The primary action is deliberately larger; everything else is uniform. */
+.ctrl-btn.play-btn { width: 3rem; height: 3rem; }
 .ctrl-btn.active { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 
 .volume-row { display: flex; align-items: center; gap: .75rem; }
@@ -617,6 +660,7 @@ img { display: block; max-width: 100%; }
 }
 .preset-picker-slot.saving { opacity: .5; cursor: wait; }
 .preset-picker-slot.saved  { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
+.preset-picker-slot.error  { border-color: var(--danger); color: var(--danger); }
 
 /* ── Presets ─────────────────────────────────────────────────────────────── */
 .presets-section, .sources-section { margin-top: 1.25rem; }
@@ -624,67 +668,94 @@ img { display: block; max-width: 100%; }
 
 .preset-grid {
     display: grid;
-    grid-template-columns: repeat(6, 1fr);
-    gap: .4rem;
+    /* Six slots divide evenly into 6, 3, 2 and 1, so there is never a ragged
+       last row: wide window 6x1, device panel 3x2, phone 2x3. */
+    grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+    gap: .5rem;
 }
 
 .preset-slot {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
-    gap: .25rem;
-    padding: .4rem .2rem;
+    text-align: left;
+    gap: .5rem;
+    padding: .45rem 1.7rem .45rem .45rem; /* right gutter: slot number + star */
     border: 1px solid var(--border);
     border-radius: var(--radius);
     background: var(--surface);
     cursor: pointer;
     position: relative;
     transition: background .1s, box-shadow .1s;
-    min-height: 72px;
+    min-height: 56px;
 }
 .preset-slot:hover:not(:disabled) { background: var(--bg); box-shadow: var(--shadow); }
 .preset-slot:disabled { opacity: .4; cursor: default; }
 .preset-slot.active { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
-.preset-slot.active .preset-name { color: var(--accent-fg); }
+.preset-slot.active .preset-name,
+.preset-slot.active .preset-source-label,
+.preset-slot.active .preset-num { color: var(--accent-fg); }
 
-.preset-slot-wrap { position: relative; }
-.preset-slot-wrap .preset-slot { width: 100%; }
+/* The grid item is the wrapper, not the tile, so the tile has to be told to
+   fill it.  Without this each tile collapses to its own content height and a
+   row of one- and two-line names ends up with ragged bottom edges. */
+.preset-slot-wrap { position: relative; display: flex; }
+.preset-slot-wrap .preset-slot { width: 100%; height: 100%; }
 
-/* Source-specific accent colour applied as a top border on text-only slots
-   (slots that have no artwork image).  Has no visible effect when art is
-   shown because the image fills the top of the slot. */
-.preset-slot[data-source="SPOTIFY"]              { --slot-color: #1DB954; }
-.preset-slot[data-source="TUNEIN"]               { --slot-color: #0082C8; }
-.preset-slot[data-source="LOCAL_INTERNET_RADIO"] { --slot-color: #FF6B35; }
-.preset-slot[data-source="RADIO_BROWSER"]        { --slot-color: #FF6B35; }
-.preset-slot[data-source="AMAZON"]               { --slot-color: #FF9900; }
-.preset-slot[data-source="PANDORA"]              { --slot-color: #005483; }
-.preset-slot:not(.active):not(.empty):not(:has(.preset-art)) {
-    border-top: 2px solid var(--slot-color, var(--border));
+/* Artwork box, or a placeholder holding the source icon.
+   The background stays the page ground in both themes, which is the inverse of
+   whatever --content-icon-filter paints the icon, so the icon keeps full
+   contrast. The source colour rides on the border instead: tinting the fill
+   put a mid-tone behind a mid-tone icon and both disappeared. */
+.preset-thumb {
+    position: relative;
+    flex: 0 0 40px;
+    width: 40px; height: 40px;
+    border: 1px solid var(--slot-color, var(--border));
+    border-radius: 4px;
+    background: var(--bg);
+    overflow: hidden;
+    display: flex; align-items: center; justify-content: center;
 }
-
-/* Save-to-preset overlay button — fades in on hover, lives outside the play
-   button to avoid invalid nested <button> elements. */
-.preset-save-btn {
-    position: absolute; top: 2px; left: 3px; z-index: 1;
-    font-size: .65rem; line-height: 1; font-weight: 700;
-    background: none; border: none; cursor: pointer; padding: 2px 3px;
-    border-radius: 2px; color: var(--text-dim);
-    opacity: 0; transition: opacity .15s, color .15s;
+.preset-slot.savable .preset-thumb { border-style: dashed; border-color: var(--fav); }
+.preset-thumb-glyph { font-size: 1.05rem; line-height: 1; color: var(--fav); opacity: .85; }
+.preset-art { position: relative; width: 100%; height: 100%; object-fit: cover; }
+.preset-source-icon {
+    position: relative; width: 20px; height: 20px;
+    font-size: 1rem; line-height: 20px; text-align: center;
 }
-.preset-slot-wrap:hover .preset-save-btn,
-.preset-save-btn:focus { opacity: .65; }
-.preset-save-btn:hover { opacity: 1; color: var(--accent); }
-.preset-save-btn.saved { opacity: 1; color: var(--accent); }
-.preset-save-btn.error { opacity: 1; color: #e55; }
+img.preset-source-icon { object-fit: contain; filter: var(--content-icon-filter); opacity: .85; }
 
-.preset-art { width: 36px; height: 36px; border-radius: 4px; object-fit: cover; }
-.preset-source-label { font-size: .6rem; font-weight: 600; text-transform: uppercase; opacity: .6; }
-.preset-name { font-size: .65rem; text-align: center; line-height: 1.2; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; word-break: break-word; color: var(--text-dim); }
+.preset-text { display: flex; flex-direction: column; gap: .1rem; min-width: 0; flex: 1 1 auto; }
+.preset-source-label { font-size: .55rem; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; opacity: .6; color: var(--text-dim); }
+.preset-name { font-size: .75rem; line-height: 1.25; overflow: hidden; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; word-break: break-word; color: var(--text-dim); }
 .preset-num {
-    position: absolute; top: 2px; right: 4px;
+    position: absolute; top: .3rem; right: .45rem;
     font-size: .6rem; font-weight: 700; color: var(--text-dim); opacity: .5;
 }
+
+/* Save-to-preset star.  Always visible - disabled, never hidden, when nothing
+   is playing - so it stays reachable on touch, which has no hover.  It lives
+   outside the play button to avoid invalid nested <button> elements.  Gold in
+   both states; only the fill carries meaning (☆ neutral, ★ currently playing),
+   matching the star on the now-playing card. */
+.preset-save-wrap { position: absolute; right: .2rem; bottom: .2rem; z-index: 1; display: flex; }
+.preset-save-btn {
+    font-size: .8rem; line-height: 1;
+    background: none; border: none; padding: 2px 3px;
+    border-radius: 3px; cursor: pointer;
+    color: var(--fav); opacity: .85;
+    transition: opacity .15s, color .15s;
+}
+.preset-save-btn:hover:not(:disabled),
+.preset-save-btn:focus-visible:not(:disabled) { opacity: 1; color: var(--fav-bright); }
+.preset-save-btn.mapped { opacity: 1; }
+.preset-save-btn:disabled { color: var(--text-dim); opacity: .3; cursor: default; }
+.preset-save-btn.saved { color: var(--fav-bright); opacity: 1; }
+.preset-save-btn.error { color: var(--danger); opacity: 1; }
+/* An active tile inverts its background, so the neutral disabled grey would
+   otherwise disappear into it. */
+.preset-slot-wrap.active .preset-save-btn:disabled { color: var(--accent-fg); }
 
 /* ── Sources ─────────────────────────────────────────────────────────────── */
 .source-list { display: flex; flex-wrap: wrap; gap: .4rem; }
@@ -694,21 +765,29 @@ img { display: block; max-width: 100%; }
     align-items: center;
     gap: .35rem;
     padding: .35rem .7rem;
-    border: 1px solid var(--border);
+    border: 1px solid var(--slot-color, var(--border));
     border-radius: 999px;
     background: var(--surface);
+    /* Buttons don't inherit colour from the page, and the UA default is black
+       whatever the theme, so this has to be spelled out. The active pill is
+       filled and overrides it below. */
+    color: var(--text);
     font-size: .8rem;
     transition: background .1s, border-color .1s;
 }
 .source-btn:hover:not(:disabled) { background: var(--bg); }
 .source-btn:disabled { cursor: not-allowed; opacity: .55; }
-.source-btn.active { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
+.source-btn.active { border-color: var(--slot-color, var(--accent)); background: var(--accent); color: var(--accent-fg); }
 .source-btn.pending { cursor: wait; }
 .source-btn.provisional-confirmed { border-style: dashed; cursor: progress; }
 .source-btn.unverified { border-color: #a76b00; }
 .source-btn.failed { border-color: var(--offline); }
 .source-btn.local { border-style: dashed; }
+/* A source icon is either a mono SVG or an emoji (see sourceIcons.js). The
+   theme filter belongs on the SVG only; it would wash an emoji out. */
 .source-icon { font-size: .9rem; line-height: 1; }
+img.source-icon { width: 16px; height: 16px; object-fit: contain; filter: var(--content-icon-filter); opacity: .9; }
+.source-btn.active img.source-icon { filter: var(--content-icon-filter-alt); }
 .source-name { font-weight: 500; }
 .source-command-status {
     min-height: 1.2em;
@@ -830,7 +909,9 @@ img { display: block; max-width: 100%; }
 .recent-art-empty {
     display: flex; align-items: center; justify-content: center;
     background: var(--bg); font-size: 1.1rem;
+    border: 1px solid var(--border);
 }
+img.recent-source-icon { width: 20px; height: 20px; object-fit: contain; filter: var(--content-icon-filter); opacity: .85; }
 .recent-info { flex: 1; overflow: hidden; }
 .recent-name { display: block; font-size: .875rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .recent-source { display: block; font-size: .75rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: .05em; margin-top: .1rem; }

--- a/pkg/service/soundtouchweb/static/img/airplay-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/airplay-mono.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="3" width="18" height="11" rx="2" stroke="black" stroke-width="2"/>
+  <path d="M12 15l5 6H7z" fill="black"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/img/aux-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/aux-mono.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M12 2v6" stroke="black" stroke-width="2" stroke-linecap="round"/>
+  <rect x="8.5" y="8" width="7" height="7" rx="1.5" stroke="black" stroke-width="2"/>
+  <path d="M12 15v7" stroke="black" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/img/bluetooth-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/bluetooth-mono.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M6.5 7.5 17.5 16.5 12 21V3l5.5 4.5L6.5 16.5" stroke="black" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/img/disc-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/disc-mono.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="9" stroke="black" stroke-width="2"/>
+  <circle cx="12" cy="12" r="2.5" fill="black"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/img/hdmi-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/hdmi-mono.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 8.5h18l-2.5 7h-13z" stroke="black" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M7.5 10v2M10.5 10v2M13.5 10v2M16.5 10v2" stroke="black" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/img/optical-mono.svg
+++ b/pkg/service/soundtouchweb/static/img/optical-mono.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3.5" y="3.5" width="17" height="17" rx="3" stroke="black" stroke-width="2"/>
+  <circle cx="12" cy="12" r="3" fill="black"/>
+</svg>

--- a/pkg/service/soundtouchweb/static/js/components/Controls.js
+++ b/pkg/service/soundtouchweb/static/js/components/Controls.js
@@ -9,6 +9,33 @@ const html = htm.bind(h);
 // follow the button's text colour in light mode, dark mode, and in the
 // accent-inverted active state — no CSS filter needed.
 
+function IconPrev() {
+    return html`<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polygon points="19 20 9 12 19 4 19 20"/>
+        <line x1="5" y1="19" x2="5" y2="5"/>
+    </svg>`;
+}
+
+function IconNext() {
+    return html`<svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polygon points="5 4 15 12 5 20 5 4"/>
+        <line x1="19" y1="5" x2="19" y2="19"/>
+    </svg>`;
+}
+
+function IconPlay() {
+    return html`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polygon points="6 3 20 12 6 21 6 3"/>
+    </svg>`;
+}
+
+function IconPause() {
+    return html`<svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <rect x="6" y="4" width="4" height="16"/>
+        <rect x="14" y="4" width="4" height="16"/>
+    </svg>`;
+}
+
 function IconVolume({ muted = false, size = 20 }) {
     if (muted) {
         return html`<svg width=${size} height=${size} viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -86,18 +113,27 @@ export function Controls({ deviceId, status }) {
     return html`
         <div class="controls">
             <div class="transport">
-                <button class="ctrl-btn" onClick=${() => send('PREV_TRACK')} title="Previous">⏮</button>
-                <button class="ctrl-btn play-btn" onClick=${() => send(isPlaying ? 'PAUSE' : 'PLAY')}>
-                    ${isPlaying ? '⏸' : '▶'}
+                <button class="ctrl-btn" onClick=${() => send('PREV_TRACK')} title="Previous" aria-label="Previous">
+                    ${IconPrev()}
                 </button>
-                <button class="ctrl-btn" onClick=${() => send('NEXT_TRACK')} title="Next">⏭</button>
-                <button class="ctrl-btn ${isMuted ? 'active' : ''}" onClick=${() => send('MUTE')} title="Mute">
+                <button
+                    class="ctrl-btn play-btn"
+                    onClick=${() => send(isPlaying ? 'PAUSE' : 'PLAY')}
+                    title=${isPlaying ? 'Pause' : 'Play'}
+                    aria-label=${isPlaying ? 'Pause' : 'Play'}
+                >
+                    ${isPlaying ? IconPause() : IconPlay()}
+                </button>
+                <button class="ctrl-btn" onClick=${() => send('NEXT_TRACK')} title="Next" aria-label="Next">
+                    ${IconNext()}
+                </button>
+                <button class="ctrl-btn ${isMuted ? 'active' : ''}" onClick=${() => send('MUTE')} title="Mute" aria-label="Mute" aria-pressed=${isMuted}>
                     ${IconVolume({ muted: isMuted })}
                 </button>
-                <button class="ctrl-btn ${shuffle === 'SHUFFLE_ON' ? 'active' : ''}" onClick=${toggleShuffle} title="Shuffle">
+                <button class="ctrl-btn ${shuffle === 'SHUFFLE_ON' ? 'active' : ''}" onClick=${toggleShuffle} title="Shuffle" aria-label="Shuffle" aria-pressed=${shuffle === 'SHUFFLE_ON'}>
                     ${IconShuffle()}
                 </button>
-                <button class="ctrl-btn ${repeat !== 'REPEAT_OFF' ? 'active' : ''}" onClick=${cycleRepeat} title=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'}>
+                <button class="ctrl-btn ${repeat !== 'REPEAT_OFF' ? 'active' : ''}" onClick=${cycleRepeat} title=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-label=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-pressed=${repeat !== 'REPEAT_OFF'}>
                     ${IconRepeat({ one: repeat === 'REPEAT_ONE' })}
                 </button>
             </div>

--- a/pkg/service/soundtouchweb/static/js/components/NowPlaying.js
+++ b/pkg/service/soundtouchweb/static/js/components/NowPlaying.js
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
+import { SourceIcon } from '../sourceIcons.js';
 
 const html = htm.bind(h);
 
@@ -14,21 +15,30 @@ function fmt(secs) {
 
 // PresetPicker — ★ star button in the top-right corner of the now-playing card.
 // Translucent when nothing is mapped; golden when the current content already
-// exists in one of the device's presets.  Click to open a slot picker (1–6).
+// exists in one of the device's presets, in which case the tooltip names the
+// slot.  Click to open a slot picker (1–6).
 function PresetPicker({ deviceId, nowPlaying, presets }) {
     const [open, setOpen] = useState(false);
     const [savingSlot, setSavingSlot] = useState(null);
     const [savedSlot, setSavedSlot] = useState(null);
+    const [errorSlot, setErrorSlot] = useState(null);
     const wrapRef = useRef(null);
 
     // Detect whether the current content is already saved as any preset.
     const currentSource   = nowPlaying?.ContentItem?.Source;
     const currentLocation = nowPlaying?.ContentItem?.Location;
     const presetList = presets?.Preset ?? [];
-    const isMapped = !!(currentLocation && presetList.some(p =>
-        p.ContentItem?.Location === currentLocation &&
-        p.ContentItem?.Source   === currentSource
-    ));
+    // Keep the matching preset, not just a boolean, so the tooltip can name
+    // the slot it landed in.
+    const mappedPreset = currentLocation
+        ? presetList.find(p =>
+            p.ContentItem?.Location === currentLocation &&
+            p.ContentItem?.Source   === currentSource)
+        : undefined;
+    const isMapped = !!mappedPreset;
+    const favTitle = isMapped
+        ? `Saved as preset ${mappedPreset.ID}. Save again to update.`
+        : 'Save as preset';
 
     // Close popover on outside click.
     useEffect(() => {
@@ -40,21 +50,23 @@ function PresetPicker({ deviceId, nowPlaying, presets }) {
         return () => document.removeEventListener('click', onDocClick, true);
     }, [open]);
 
+    // Mirrors the feedback the preset tiles give (see Presets.js): a failed
+    // save used to close the overlay silently, which looked identical to a
+    // successful one.
+    function finish(setter, slotId) {
+        setSavingSlot(null);
+        setter(slotId);
+        setTimeout(() => {
+            setter(null);
+            setOpen(false);
+        }, 900);
+    }
+
     function save(slotId) {
         setSavingSlot(slotId);
         api.storePreset(deviceId, slotId)
-            .then(res => {
-                setSavingSlot(null);
-                setSavedSlot(slotId);
-                setTimeout(() => {
-                    setSavedSlot(null);
-                    setOpen(false);
-                }, 900);
-            })
-            .catch(() => {
-                setSavingSlot(null);
-                setOpen(false);
-            });
+            .then(res => finish(res.success ? setSavedSlot : setErrorSlot, slotId))
+            .catch(() => finish(setErrorSlot, slotId));
     }
 
     return html`
@@ -62,8 +74,8 @@ function PresetPicker({ deviceId, nowPlaying, presets }) {
             <button
                 class="now-playing-fav-btn ${isMapped ? 'mapped' : ''} ${open ? 'open' : ''}"
                 onClick=${() => setOpen(o => !o)}
-                title=${isMapped ? 'Saved as preset — save again to update' : 'Save as preset'}
-                aria-label="Save as preset"
+                title=${favTitle}
+                aria-label=${favTitle}
             >★</button>
             ${open && html`
                 <div class="now-playing-fav-overlay">
@@ -72,10 +84,10 @@ function PresetPicker({ deviceId, nowPlaying, presets }) {
                         ${[1, 2, 3, 4, 5, 6].map(n => html`
                             <button
                                 key=${n}
-                                class="preset-picker-slot ${savingSlot === n ? 'saving' : savedSlot === n ? 'saved' : ''}"
+                                class="preset-picker-slot ${savingSlot === n ? 'saving' : savedSlot === n ? 'saved' : errorSlot === n ? 'error' : ''}"
                                 onClick=${() => save(n)}
                                 disabled=${savingSlot !== null}
-                            >${n}</button>
+                            >${savedSlot === n ? '✓' : errorSlot === n ? '✗' : n}</button>
                         `)}
                     </div>
                 </div>
@@ -105,14 +117,22 @@ export function NowPlaying({ nowPlaying, deviceId, presets }) {
         .some(value => value && value.length > 80);
     const isRAOP = nowPlaying.Source === 'AIRPLAY' || nowPlaying.Source === 'RAOP';
     const showFullMetadata = isRAOP || longMetadata;
-    const artURL = nowPlaying.Art?.URL;
+    // Same precedence as the model's GetArtworkURL (nowplaying.go): the <art>
+    // element first, then the ContentItem's own artwork, which is where radio
+    // stations carry their logo.
+    const artURL = nowPlaying.Art?.URL || nowPlaying.ContentItem?.ContainerArt;
     const isBuffering = nowPlaying.PlayStatus === 'BUFFERING_STATE';
     const total = nowPlaying.Time?.Total ?? 0;
     const pct = total > 0 ? Math.min(100, (position / total) * 100) : 0;
 
     return html`
         <div class="now-playing">
-            ${artURL && html`<img class="album-art" src=${artURL} alt="" />`}
+            ${artURL
+                ? html`<img class="album-art" src=${artURL} alt="" />`
+                : html`<div class="album-art album-art-empty" data-source=${nowPlaying.Source ?? ''}>
+                    <${SourceIcon} source=${nowPlaying.Source} className="now-playing-source-icon" />
+                </div>`
+            }
             <div class="track-info">
                 <div class="track-title" title=${title}>${title}</div>
                 ${nowPlaying.Artist && html`<div class="track-artist" title=${nowPlaying.Artist}>${nowPlaying.Artist}</div>`}

--- a/pkg/service/soundtouchweb/static/js/components/Presets.js
+++ b/pkg/service/soundtouchweb/static/js/components/Presets.js
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useState } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
+import { SourceIcon } from '../sourceIcons.js';
 
 const html = htm.bind(h);
 
@@ -15,11 +16,16 @@ function sourceLabel(source) {
     return SOURCE_LABELS[source] || source;
 }
 
-// PresetSlot renders a single preset button plus, when something presetable
-// is currently playing (canSave=true), an overlaid save button that stores
-// the current content to that slot.  The save button lives *outside* the
-// play button in the DOM (via the wrapper div) to avoid invalid nested
-// <button> elements.
+// PresetSlot renders a single preset button plus an overlaid save button that
+// stores the currently playing content into that slot.  The save button lives
+// *outside* the play button in the DOM (via the wrapper div) to avoid invalid
+// nested <button> elements.
+//
+// The save button is always rendered and merely disabled when nothing is
+// playing, rather than hidden.  It used to be hover-revealed, which made it
+// unreachable on touch devices and easy to miss everywhere else.  It shares
+// the star glyph and the gold --fav colour with the now-playing preset
+// picker (see NowPlaying.js) so both save paths read as the same gesture.
 function PresetSlot({ preset, deviceId, active, canSave }) {
     const [saveState, setSaveState] = useState(null); // null | 'saved' | 'error'
 
@@ -28,49 +34,85 @@ function PresetSlot({ preset, deviceId, active, canSave }) {
     const art = item?.ContainerArt;
     const name = item?.ItemName || `Preset ${preset?.ID ?? ''}`;
 
+    // An empty slot doubles as its own save target while something is
+    // playing: there is nothing to overwrite, so the whole tile can invite
+    // the save instead of hiding it behind the small corner button.
+    const savableEmpty = isEmpty && canSave;
+
+    // The star is always gold; only its fill carries meaning.  Solid ★ means
+    // "what's playing right now is this preset" - the same thing the star on
+    // the now-playing card means.  Outline ☆ is the neutral "save into this
+    // slot" state.
+    const mapped = !!active;
+
+    function flash(state) {
+        setSaveState(state);
+        setTimeout(() => setSaveState(null), 1500);
+    }
+
+    function store() {
+        api.storePreset(deviceId, preset.ID)
+            .then(res => flash(res.success ? 'saved' : 'error'))
+            .catch(() => flash('error'));
+    }
+
     function select() {
-        if (!isEmpty) api.control(deviceId, 'preset', preset.ID);
+        if (savableEmpty) store();
+        else if (!isEmpty) api.control(deviceId, 'preset', preset.ID);
     }
 
     function save(e) {
         e.stopPropagation();
-        api.storePreset(deviceId, preset.ID)
-            .then(res => {
-                setSaveState(res.success ? 'saved' : 'error');
-                setTimeout(() => setSaveState(null), 1500);
-            })
-            .catch(() => {
-                setSaveState('error');
-                setTimeout(() => setSaveState(null), 1500);
-            });
+        store();
     }
 
+    const saveTitle = !canSave
+        ? 'Play something first, then save it to a preset'
+        : mapped
+            ? `Save again to preset ${preset.ID} (already saved there)`
+            : `Save what's playing to preset ${preset.ID}`;
+
+    const slotTitle = isEmpty
+        ? (savableEmpty ? "Save what's playing here" : 'Empty')
+        : name;
+
     return html`
-        <div class="preset-slot-wrap">
+        <div class="preset-slot-wrap ${active ? 'active' : ''}">
             <button
-                class="preset-slot ${isEmpty ? 'empty' : ''} ${active ? 'active' : ''}"
+                class="preset-slot ${isEmpty ? 'empty' : ''} ${active ? 'active' : ''} ${savableEmpty ? 'savable' : ''}"
                 data-source=${item?.Source ?? ''}
                 onClick=${select}
-                disabled=${isEmpty}
-                title=${isEmpty ? 'Empty' : name}
+                disabled=${isEmpty && !savableEmpty}
+                title=${slotTitle}
             >
-                ${art
-                    ? html`<img class="preset-art" src=${art} alt="" />`
-                    : html`<span class="preset-source-label">${isEmpty ? '—' : sourceLabel(item.Source)}</span>`
-                }
-                <span class="preset-name">${isEmpty ? 'Empty' : name}</span>
+                <span class="preset-thumb">
+                    ${art
+                        ? html`<img class="preset-art" src=${art} alt="" />`
+                        : savableEmpty
+                            ? html`<span class="preset-thumb-glyph">☆</span>`
+                            : isEmpty
+                                ? null
+                                : html`<${SourceIcon} source=${item.Source} className="preset-source-icon" />`
+                    }
+                </span>
+                <span class="preset-text">
+                    ${!isEmpty && html`<span class="preset-source-label">${sourceLabel(item.Source)}</span>`}
+                    <span class="preset-name">
+                        ${isEmpty ? (savableEmpty ? 'Save current here' : 'Empty') : name}
+                    </span>
+                </span>
                 <span class="preset-num">${preset?.ID ?? ''}</span>
             </button>
-            ${canSave && html`
+            <span class="preset-save-wrap" title=${saveTitle}>
                 <button
-                    class="preset-save-btn ${saveState ?? ''}"
+                    class="preset-save-btn ${mapped ? 'mapped' : ''} ${saveState ?? ''}"
                     onClick=${save}
-                    title="Save current to preset ${preset.ID}"
-                    aria-label="Save current to preset ${preset.ID}"
+                    disabled=${!canSave}
+                    aria-label=${saveTitle}
                 >
-                    ${saveState === 'saved' ? '✓' : saveState === 'error' ? '✗' : '+'}
+                    ${saveState === 'saved' ? '✓' : saveState === 'error' ? '✗' : mapped ? '★' : '☆'}
                 </button>
-            `}
+            </span>
         </div>
     `;
 }
@@ -80,8 +122,9 @@ export function Presets({ deviceId, status }) {
     const currentSource = status?.nowPlaying?.Source;
     const currentLocation = status?.nowPlaying?.ContentItem?.Location;
 
-    // Show save buttons whenever something that isn't STANDBY is playing.
-    // The server validates IsPresetable; if it fails the button shows ✗ briefly.
+    // Enable the save buttons whenever something that isn't STANDBY is
+    // playing.  The server validates IsPresetable; if it fails the button
+    // shows ✗ briefly.
     const canSave = !!(currentSource && currentSource !== 'STANDBY');
 
     // Build a map for quick lookup, then render slots 1-6

--- a/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
@@ -32,7 +32,10 @@ export function RadioBrowser({ devices }) {
         await api.radioBrowserPlay(deviceId, {
             location: pendingPlay.location,
             type: pendingPlay.type,
-            name: pendingPlay.name
+            name: pendingPlay.name,
+            // The speaker keeps this on the ContentItem, so presets and
+            // recents saved from here show the station logo.
+            containerArt: pendingPlay.image,
         });
         setPendingPlay(null);
     }
@@ -71,7 +74,7 @@ export function RadioBrowser({ devices }) {
                                     class="tunein-play-btn"
                                     title="Play"
                                     onClick=${() => {
-                                        setPendingPlay({ location: play.href, type: play.type, name: item.name });
+                                        setPendingPlay({ location: play.href, type: play.type, name: item.name, image: item.imageUrl });
                                     }}
                                 >▶</button>
                             ` : null}

--- a/pkg/service/soundtouchweb/static/js/components/Recents.js
+++ b/pkg/service/soundtouchweb/static/js/components/Recents.js
@@ -2,14 +2,9 @@ import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
+import { SourceIcon } from '../sourceIcons.js';
 
 const html = htm.bind(h);
-
-const SOURCE_ICONS = {
-    TUNEIN: '📻', SPOTIFY: '🎵', AMAZON: '🎶', PANDORA: '🎸',
-    DEEZER: '🎵', IHEART: '📻', BLUETOOTH: '📶', AUX: '🔌',
-    LOCAL_MUSIC: '💽', STORED_MUSIC: '💽',
-};
 
 export function Recents({ deviceId }) {
     const [items, setItems] = useState(null);
@@ -54,12 +49,11 @@ export function Recents({ deviceId }) {
                 ${items.map(item => {
                     const ci = item.ContentItem;
                     if (!ci) return null;
-                    const icon = SOURCE_ICONS[ci.Source] ?? '♪';
                     return html`
                         <button class="recent-item" key=${item.ID || item.UTCTime} onClick=${() => play(item)}>
                             ${ci.ContainerArt
                                 ? html`<img class="recent-art" src=${ci.ContainerArt} alt="" />`
-                                : html`<div class="recent-art recent-art-empty">${icon}</div>`
+                                : html`<div class="recent-art recent-art-empty"><${SourceIcon} source=${ci.Source} className="recent-source-icon" /></div>`
                             }
                             <div class="recent-info">
                                 <span class="recent-name">${ci.ItemName || ci.Source}</span>

--- a/pkg/service/soundtouchweb/static/js/components/Sources.js
+++ b/pkg/service/soundtouchweb/static/js/components/Sources.js
@@ -2,15 +2,9 @@ import { h } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
+import { SourceIcon } from '../sourceIcons.js';
 
 const html = htm.bind(h);
-
-const SOURCE_ICONS = {
-    TUNEIN: '📻', SPOTIFY: '🎵', AMAZON: '🛒', PANDORA: '🎶',
-    BLUETOOTH: '📶', AUX: '🔌', OPTICAL: '💡', HDMI: '📺',
-    IHEARTRADIO: '❤️', DEEZER: '🎼', LOCAL_INTERNET_RADIO: '📡',
-    AIRPLAY: '📡', PRODUCT: '🔊',
-};
 
 const SOURCE_READBACK_DELAYS_MS = [2000, 5000, 10000];
 
@@ -410,13 +404,14 @@ export function Sources({
                         <button
                             key=${src.Source + account}
                             class="source-btn ${isActive ? 'active' : ''} ${src.IsLocal ? 'local' : ''} ${outcome}"
+                            data-source=${src.Source}
                             onClick=${() => select(src)}
                             disabled=${sourcesStale}
                             title=${availabilityMessage || (outcome ? commandMessage(command) : src.Source)}
                             aria-describedby=${availabilityId}
                             aria-busy=${outcome === 'pending' || outcome === 'provisional-confirmed' ? 'true' : null}
                         >
-                            <span class="source-icon">${SOURCE_ICONS[src.Source] || '🔊'}</span>
+                            <${SourceIcon} source=${src.Source} className="source-icon" />
                             <span class="source-name">${src.DisplayName || src.Source}</span>
                         </button>
                     `;

--- a/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
@@ -96,7 +96,14 @@ export function TuneInBrowser({ devices }) {
     }
 
     async function playOn(deviceId) {
-        await api.tuneInPlay(deviceId, { location: pendingPlay.location, type: pendingPlay.type, name: pendingPlay.name });
+        await api.tuneInPlay(deviceId, {
+            location: pendingPlay.location,
+            type: pendingPlay.type,
+            name: pendingPlay.name,
+            // The speaker keeps this on the ContentItem, so presets and
+            // recents saved from here show the station logo.
+            containerArt: pendingPlay.image,
+        });
         setPendingPlay(null);
     }
 

--- a/pkg/service/soundtouchweb/static/js/sourceIcons.js
+++ b/pkg/service/soundtouchweb/static/js/sourceIcons.js
@@ -1,0 +1,63 @@
+import { h } from 'preact';
+import htm from 'htm';
+
+const html = htm.bind(h);
+
+// One place deciding how a source is depicted, shared by the Presets, Recents
+// and Sources views (each used to keep its own divergent emoji map).
+//
+// Two kinds of icon, deliberately:
+//
+//   * Monochrome SVGs for sources we can draw ourselves - the radio providers,
+//     the physical inputs, a speaker for anything unknown. These are the same
+//     assets the top navigation uses: black on transparent, recoloured for the
+//     current theme through --content-icon-filter (and --content-icon-filter-alt
+//     on inverted backgrounds like an active preset tile).
+//
+//   * Emoji for the streaming brands. Their logos are trademarks we would
+//     rather not ship, and five identical generic notes would tell the reader
+//     less than five distinguishable emoji do.
+const SOURCE_ICON_FILES = {
+    TUNEIN: 'tunein-mono.svg',
+    RADIO_BROWSER: 'radiobrowser-mono.svg',
+    LOCAL_INTERNET_RADIO: 'link-mono.svg',
+    PRODUCT: 'speaker-mono.svg',
+    AUX: 'aux-mono.svg',
+    OPTICAL: 'optical-mono.svg',
+    HDMI: 'hdmi-mono.svg',
+    BLUETOOTH: 'bluetooth-mono.svg',
+    AIRPLAY: 'airplay-mono.svg',
+    STORED_MUSIC: 'disc-mono.svg',
+    LOCAL_MUSIC: 'disc-mono.svg',
+};
+
+const SOURCE_EMOJI = {
+    SPOTIFY: '🎵', AMAZON: '🛒', PANDORA: '🎶',
+    DEEZER: '🎼', IHEARTRADIO: '❤️', IHEART: '❤️',
+};
+
+const FALLBACK_ICON_FILE = 'speaker-mono.svg';
+
+// URL of the mono SVG for this source, or null when it is depicted by emoji.
+export function sourceIconURL(source) {
+    if (SOURCE_EMOJI[source]) return null;
+
+    return `/app/static/img/${SOURCE_ICON_FILES[source] ?? FALLBACK_ICON_FILE}`;
+}
+
+// Emoji for this source, or null when it has a mono SVG.
+export function sourceEmoji(source) {
+    return SOURCE_EMOJI[source] ?? null;
+}
+
+// SourceIcon renders whichever of the two a source uses, so callers don't
+// repeat the fallback dance.  The caller's class carries the sizing; the
+// theme filter is scoped to img in the stylesheet, since it would wash an
+// emoji out.
+export function SourceIcon({ source, className }) {
+    const url = sourceIconURL(source);
+
+    return url
+        ? html`<img class=${className} src=${url} alt="" />`
+        : html`<span class=${className}>${sourceEmoji(source)}</span>`;
+}

--- a/pkg/service/stations/stations.go
+++ b/pkg/service/stations/stations.go
@@ -142,7 +142,6 @@ func ResolveContentItem(item PlayItem) *models.ContentItem {
 		ci.IsPresetable = true
 		ci.ItemName = item.Name
 		ci.Location = item.Location
-		ci.ContainerArt = item.ContainerArt
 	case ProviderRadioBrowser:
 		// Native RADIO_BROWSER source: the speaker prepends the BMX-registry
 		// base URL (https://all.api.radio-browser.info/soundtouch) to the
@@ -168,6 +167,11 @@ func ResolveContentItem(item PlayItem) *models.ContentItem {
 		ci.ItemName = item.Name
 		ci.Location = item.Location
 	}
+
+	// The speaker stores the artwork it is handed at select time, and presets,
+	// recents and now-playing all read it back from there. Every provider needs
+	// it, so it is set here rather than per branch.
+	ci.ContainerArt = item.ContainerArt
 
 	// Apply the SourceAccount placeholder guard: if SourceAccount is non-empty
 	// and is not just the source name echoed back by the speaker, pass it through.

--- a/pkg/service/stations/stations_test.go
+++ b/pkg/service/stations/stations_test.go
@@ -225,3 +225,22 @@ func TestNavigateTuneIn_ProfilesPathDispatch(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveContentItem_RadioBrowser_ContainerArt guards the counterpart to
+// TestResolveContentItem_TuneIn_ContainerArt: the artwork used to be copied
+// only in the TuneIn branch, so RadioBrowser stations reached the speaker with
+// no art and their presets and recents showed a placeholder.
+func TestResolveContentItem_RadioBrowser_ContainerArt(t *testing.T) {
+	item := PlayItem{
+		Provider:     ProviderRadioBrowser,
+		Location:     "/stations/byuuid/abc-123",
+		Name:         "Radio Paradise",
+		ContainerArt: "http://example.com/art.png",
+	}
+
+	ci := ResolveContentItem(item)
+
+	if ci.ContainerArt != "http://example.com/art.png" {
+		t.Errorf("expected ContainerArt set, got %q", ci.ContainerArt)
+	}
+}


### PR DESCRIPTION
## Saving to a preset was invisible

The save button on a preset tile was gated twice: it was only rendered while
something was playing, and even then only appeared on hover. On a tablet or
phone, which has no hover, it could not be reached at all.

This came out of the closing comments on
[issue 646](https://github.com/gesellix/Bose-SoundTouch/issues/646), where two
people spent weeks debugging what looked like a speaker fault before
discovering that the thing they wanted was a button they had never seen.

Now the button is always there and simply disabled when there is nothing to
save, and it uses the same gold star as the now-playing card so both ways of
saving read as one gesture: an outline star means "save here", a solid one
means "this is what is playing right now". An empty slot invites the save
directly instead of just reading "Empty", and clicking anywhere on it saves.

## Presets show real station artwork

Radio stations were showing a placeholder even though their logo was available
the whole time. The speaker keeps whatever artwork it is given when playback
starts, and presets, recents and the now-playing card all read it back from
there, but two of the three station play paths were dropping it on the way to
the speaker.

Stations played from now on carry their logo into presets and recents.
Presets saved before this keep their blank artwork until they are saved again.

The now-playing card was also missing artwork for radio stations, because it
only looked at one of the two places a picture can live.

## Preset tiles line up

Tiles were sized by their own content, so a row mixing one-line and two-line
station names came out with ragged bottom edges. They now fill their grid cell,
and the grid itself is responsive: six across on a wide window, three by two in
the device panel, two by three on a phone.

## One icon vocabulary, and readable labels

Presets, Recents and Sources each had their own idea of how to depict a source,
and the two emoji maps disagreed with each other (Amazon was a shopping trolley
in one and a musical note in the other). There is now a single set: sources we
can draw get a monochrome icon that follows the light or dark theme, and the
streaming services keep an emoji rather than shipping their trademarks.

Each source also has a colour, shown along the bottom edge of a preset tile and
its pill in the Sources row, so a source looks the same wherever it appears.

Two contrast problems went with it. Source labels were rendering in near-black
whatever the theme, because buttons do not inherit the page text colour. And
the preset artwork box had a tinted fill behind a mid-tone icon, which left
both hard to make out.

## Transport buttons

The player, pause, skip and toggle buttons were a mix of emoji and drawn icons,
sized by their content. Emoji widths differ per glyph, so no two buttons were
the same size, and the play button visibly changed width every time you paused,
nudging the rest of the row sideways. They are drawn icons in fixed squares
now, and each one finally has a name for screen readers.

## Startup log

`AfterTouch Web UI starting on http://:8080` is not something a terminal will
turn into a link. When the player listens on all interfaces the line now reads
`http://localhost:8080`, while an explicit `--bind` address is left alone.

---

Covered by new tests: the artwork reaching the speaker across all three station
play paths, and guards against the save button regressing back into a
hover-only control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
