### PR TITLE
Escalate to the WebSocket pairing when a speaker stays in SETUP

### DIFF
--- a/cmd/soundtouch-cli/cmd_setup.go
+++ b/cmd/soundtouch-cli/cmd_setup.go
@@ -609,7 +609,7 @@ func runEnableSSHInjection(m *setup.Manager, host, serviceURL string, fullConfig
 // unpaired device never polls margeServerUrl is not yet confirmed on every
 // device this command targets, so the injection is still worth attempting
 // even if the pairing step itself couldn't be verified.
-func ensureMargeAccountPaired(m *setup.Manager, deviceIP, wantAccountID string) {
+func ensureMargeAccountPaired(ctx context.Context, m *setup.Manager, deviceIP, wantAccountID string) {
 	var t setup.TelnetClient
 
 	if m.NewTelnet != nil {
@@ -622,7 +622,7 @@ func ensureMargeAccountPaired(m *setup.Manager, deviceIP, wantAccountID string) 
 		}
 	}
 
-	accountID, alreadyPaired, logs, err := m.EnsureMargeAccountPaired(deviceIP, wantAccountID, t)
+	accountID, alreadyPaired, logs, err := m.EnsureMargeAccountPaired(ctx, deviceIP, wantAccountID, t)
 	if logs != "" {
 		fmt.Print(logs)
 	}
@@ -713,7 +713,7 @@ func setupEnableSSHCmd() *cli.Command {
 			}
 
 			if !c.Bool("no-auto-pair") {
-				ensureMargeAccountPaired(m, cfg.Host, c.String("account"))
+				ensureMargeAccountPaired(c.Context, m, cfg.Host, c.String("account"))
 			}
 
 			if err := runEnableSSHInjection(m, cfg.Host, serviceURL, c.Bool("full-config"), c.Duration("command-delay")); err != nil {

--- a/pkg/service/handlers/handlers_pairing.go
+++ b/pkg/service/handlers/handlers_pairing.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -100,7 +101,7 @@ func (s *Server) HandlePairAccount(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	result, output, err := s.sm.PairAccount(deviceIP, accountID, t)
+	result, output, err := s.sm.PairAccount(r.Context(), deviceIP, accountID, t)
 
 	w.Header().Set("Content-Type", "application/json")
 
@@ -167,7 +168,10 @@ func (s *Server) completeSpeakerPairingFix(target health.Target) (string, error)
 		}
 	}
 
-	result, output, err := s.sm.PairAccount(deviceIP, accountID, t)
+	// completeSpeakerPairingFix is registered as a health FixFunc
+	// (server.go), whose signature carries no context, so there is no
+	// request scope to inherit here.
+	result, output, err := s.sm.PairAccount(context.Background(), deviceIP, accountID, t)
 	if err != nil {
 		return "", fmt.Errorf("pair speaker %s with account %s: %w (path output: %s)", target.Device, accountID, err, strings.TrimSpace(output))
 	}

--- a/pkg/service/setup/marge_pairing.go
+++ b/pkg/service/setup/marge_pairing.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"encoding/xml"
 	"errors"
@@ -22,7 +23,14 @@ const (
 	supportedURLsTimeout = 3 * time.Second
 	setMargeAccountConn  = 5 * time.Second
 	setMargeAccountTotal = 12 * time.Second
+	// wsEscalationStep bounds each WebSocket step of the escalation below.
+	wsEscalationStep = 8 * time.Second
 )
+
+// wsSettleDelay gives the firmware a moment to act on the WS pairing before
+// the state is re-read. runPairBare uses the same 2 s. A var so tests do not
+// have to sit through it.
+var wsSettleDelay = 2 * time.Second
 
 // PairAccountResult records what was attempted, so the UI can show a
 // breadcrumb of which path actually succeeded (or that both failed).
@@ -32,7 +40,17 @@ type PairAccountResult struct {
 	HTTPError                string `json:"http_error,omitempty"`
 	TelnetAttempted          bool   `json:"telnet_attempted"`
 	TelnetError              string `json:"telnet_error,omitempty"`
-	Method                   string `json:"method"` // "http" | "telnet" | ""
+
+	// StuckInSetup records that the account was written but the speaker was
+	// still reporting source="SETUP" afterwards, which is the condition the
+	// WebSocket escalation exists for. WSAttempted/WSError/LeftSetup describe
+	// that escalation. LeftSetup is only meaningful when WSAttempted is true.
+	StuckInSetup bool   `json:"stuck_in_setup"`
+	WSAttempted  bool   `json:"ws_attempted"`
+	WSError      string `json:"ws_error,omitempty"`
+	LeftSetup    bool   `json:"left_setup"`
+
+	Method string `json:"method"` // "http" | "telnet" | "ws" | ""
 }
 
 // PairAccount associates the speaker at deviceIP with accountID. It tries
@@ -41,7 +59,22 @@ type PairAccountResult struct {
 // `envswitch accountid set <id>` over the supplied client. If telnet is nil
 // or also fails, PairAccount returns a structured error explaining the next
 // step a user can take.
-func (m *Manager) PairAccount(deviceIP, accountID string, t TelnetClient) (PairAccountResult, string, error) {
+//
+// Both of those paths write the account ID without going through the
+// firmware's own SETUP state machine, and there is reason to think that is
+// not always enough: a speaker can end up with a populated
+// margeAccountUUID while its firmware stays in source="SETUP", refusing to
+// play anything (issue #646). So on success PairAccount checks whether the
+// speaker actually left SETUP, and if it did not, escalates to the
+// WebSocket setMargeAccount that `soundtouch-cli setup pair --mode=bare`
+// uses, which is the path with positive precedent for moving a speaker out
+// of that state.
+//
+// The escalation is deliberately gated on the observed failure rather than
+// reordered ahead of the existing paths. Adding it as another fallback arm
+// would not have helped: the case being targeted is one where the HTTP call
+// *succeeds*, so a fallback chain never reaches it.
+func (m *Manager) PairAccount(ctx context.Context, deviceIP, accountID string, t TelnetClient) (PairAccountResult, string, error) {
 	var (
 		result PairAccountResult
 		logs   strings.Builder
@@ -74,6 +107,8 @@ func (m *Manager) PairAccount(deviceIP, accountID string, t TelnetClient) (PairA
 			result.Method = "http"
 
 			logs.WriteString("HTTP /setMargeAccount succeeded\n")
+
+			m.escalateIfStuckInSetup(ctx, deviceIP, accountID, &result, &logs)
 
 			return result, logs.String(), nil
 		}
@@ -111,7 +146,126 @@ func (m *Manager) PairAccount(deviceIP, accountID string, t TelnetClient) (PairA
 
 	result.Method = "telnet"
 
+	m.escalateIfStuckInSetup(ctx, deviceIP, accountID, &result, &logs)
+
 	return result, logs.String(), nil
+}
+
+// nowPlayingXML is the slice of /now_playing this package cares about: the
+// source attribute, which reads "SETUP" while the firmware is still in
+// onboarding.
+type nowPlayingXML struct {
+	XMLName xml.Name `xml:"nowPlaying"`
+	Source  string   `xml:"source,attr"`
+}
+
+// readNowPlayingSource returns the speaker's current source, e.g. "STANDBY",
+// "TUNEIN", or "SETUP".
+func (m *Manager) readNowPlayingSource(deviceIP string) (string, error) {
+	url := fmt.Sprintf("http://%s:8090/now_playing", deviceIP)
+	if _, _, err := net.SplitHostPort(deviceIP); err == nil {
+		url = fmt.Sprintf("http://%s/now_playing", deviceIP)
+	}
+
+	resp, err := m.httpGet(url)
+	if err != nil {
+		return "", fmt.Errorf("fetch now_playing from %s: %w", url, err)
+	}
+
+	defer func() { _ = resp.Body.Close() }()
+
+	var np nowPlayingXML
+	if err := xml.NewDecoder(resp.Body).Decode(&np); err != nil {
+		return "", fmt.Errorf("decode now_playing from %s: %w", url, err)
+	}
+
+	return np.Source, nil
+}
+
+// escalateIfStuckInSetup runs after the account ID has been written by one of
+// the paths above. If the speaker still reports source="SETUP" it drives the
+// WebSocket setMargeAccount, which goes through the firmware's own setup state
+// machine rather than around it.
+//
+// It never returns an error: the pairing itself already succeeded, and a
+// speaker that cannot be coaxed out of SETUP is not a reason to report the
+// pairing as failed. Everything observed lands in result and logs instead, so
+// a field report says which path ran and whether it helped.
+func (m *Manager) escalateIfStuckInSetup(ctx context.Context, deviceIP, accountID string, result *PairAccountResult, logs *strings.Builder) {
+	source, err := m.readNowPlayingSource(deviceIP)
+	if err != nil {
+		fmt.Fprintf(logs, "post-pair SETUP check failed (continuing): %v\n", err)
+		return
+	}
+
+	if !strings.EqualFold(source, "SETUP") {
+		fmt.Fprintf(logs, "post-pair source=%q — speaker is out of SETUP\n", source)
+		return
+	}
+
+	result.StuckInSetup = true
+
+	logs.WriteString("post-pair source=\"SETUP\" — account written but firmware still onboarding, " +
+		"escalating to the WebSocket setMargeAccount\n")
+
+	if err := m.pairOverWebSocket(ctx, deviceIP, accountID); err != nil {
+		result.WSAttempted = true
+		result.WSError = err.Error()
+
+		fmt.Fprintf(logs, "WebSocket setMargeAccount failed: %v\n", err)
+
+		return
+	}
+
+	result.WSAttempted = true
+	result.Method = "ws"
+
+	logs.WriteString("WebSocket setMargeAccount succeeded\n")
+
+	time.Sleep(wsSettleDelay)
+
+	switch after, err := m.readNowPlayingSource(deviceIP); {
+	case err != nil:
+		fmt.Fprintf(logs, "could not re-read source after escalation: %v\n", err)
+	case strings.EqualFold(after, "SETUP"):
+		logs.WriteString("speaker still reports SETUP after the escalation\n")
+	default:
+		result.LeftSetup = true
+
+		fmt.Fprintf(logs, "speaker left SETUP after the escalation (source=%q)\n", after)
+	}
+}
+
+// pairOverWebSocket sends setMargeAccount through the speaker's own setup
+// WebSocket. The payload is deliberately minimal (account ID plus the default
+// auth token, no boseServer extras): this is an escalation of the same request
+// the HTTP endpoint just took, not a migration, and it should not quietly
+// rewrite the speaker's configured server URLs as a side effect.
+func (m *Manager) pairOverWebSocket(ctx context.Context, deviceIP, accountID string) error {
+	info, err := m.GetLiveDeviceInfo(deviceIP)
+	if err != nil {
+		return fmt.Errorf("read /info for device ID: %w", err)
+	}
+
+	if info.DeviceID == "" {
+		return errors.New("device reported no deviceID, cannot route WebSocket messages")
+	}
+
+	session, err := m.NewSession(deviceIP, info.DeviceID, wsEscalationStep)
+	if err != nil {
+		return fmt.Errorf("dial setup WebSocket: %w", err)
+	}
+
+	defer func() { _ = session.Close() }()
+
+	stepCtx, cancel := context.WithTimeout(ctx, wsEscalationStep+2*time.Second)
+	defer cancel()
+
+	if err := session.SetMargeAccount(stepCtx, accountID, ""); err != nil {
+		return fmt.Errorf("setMargeAccount over WebSocket: %w", err)
+	}
+
+	return nil
 }
 
 // EnsureMargeAccountPaired reads the device's /info and, if margeAccountUUID
@@ -123,7 +277,7 @@ func (m *Manager) PairAccount(deviceIP, accountID string, t TelnetClient) (PairA
 // one. accountID is empty when GetLiveDeviceInfo itself fails; otherwise it
 // is either the device's existing margeAccountUUID (alreadyPaired=true) or
 // the account ID just paired with.
-func (m *Manager) EnsureMargeAccountPaired(deviceIP, wantAccountID string, t TelnetClient) (accountID string, alreadyPaired bool, logs string, err error) {
+func (m *Manager) EnsureMargeAccountPaired(ctx context.Context, deviceIP, wantAccountID string, t TelnetClient) (accountID string, alreadyPaired bool, logs string, err error) {
 	info, infoErr := m.GetLiveDeviceInfo(deviceIP)
 	if infoErr != nil {
 		return "", false, "", fmt.Errorf("read /info: %w", infoErr)
@@ -145,7 +299,7 @@ func (m *Manager) EnsureMargeAccountPaired(deviceIP, wantAccountID string, t Tel
 		return "", false, "", fmt.Errorf("invalid account id %q: must be a non-empty, path-safe identifier", target)
 	}
 
-	_, pairLogs, pairErr := m.PairAccount(deviceIP, target, t)
+	_, pairLogs, pairErr := m.PairAccount(ctx, deviceIP, target, t)
 	if pairErr != nil {
 		return target, false, pairLogs, pairErr
 	}

--- a/pkg/service/setup/marge_pairing_test.go
+++ b/pkg/service/setup/marge_pairing_test.go
@@ -26,14 +26,21 @@ type fakeDevice struct {
 	gotPostBody         string
 	margeAccountUUID    string // served by /info; empty means "unpaired"
 	configurationStatus string // served by /soundTouchConfigurationStatus; empty = route not served (404)
+
+	// nowPlayingSources is the sequence of source attributes served by
+	// /now_playing, one per request, repeating the last entry once exhausted.
+	// A speaker that is not stuck reports something like "STANDBY"; one still
+	// onboarding reports "SETUP".
+	nowPlayingSources []string
 }
 
 func newFakeDevice(t *testing.T) *fakeDevice {
 	t.Helper()
 
 	d := &fakeDevice{
-		supportsSetMarge: true,
-		postStatus:       http.StatusOK,
+		supportsSetMarge:  true,
+		postStatus:        http.StatusOK,
+		nowPlayingSources: []string{"STANDBY"},
 	}
 
 	mux := http.NewServeMux()
@@ -63,6 +70,20 @@ func newFakeDevice(t *testing.T) *fakeDevice {
 	mux.HandleFunc("/info", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/xml")
 		fmt.Fprintf(w, `<info deviceID="AABBCCDDEE0A"><margeAccountUUID>%s</margeAccountUUID></info>`, d.margeAccountUUID)
+	})
+
+	mux.HandleFunc("/now_playing", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/xml")
+
+		source := "STANDBY"
+		if len(d.nowPlayingSources) > 0 {
+			source = d.nowPlayingSources[0]
+			if len(d.nowPlayingSources) > 1 {
+				d.nowPlayingSources = d.nowPlayingSources[1:]
+			}
+		}
+
+		fmt.Fprintf(w, `<nowPlaying deviceID="AABBCCDDEE0A" source="%s"><ContentItem source="%s"/></nowPlaying>`, source, source)
 	})
 
 	mux.HandleFunc("/soundTouchConfigurationStatus", func(w http.ResponseWriter, _ *http.Request) {
@@ -96,7 +117,7 @@ func TestPairAccount_HappyPathHTTP(t *testing.T) {
 
 	m := &Manager{}
 
-	res, _, err := m.PairAccount(d.addr, "1234567", nil)
+	res, _, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
 	if err != nil {
 		t.Fatalf("PairAccount: %v", err)
 	}
@@ -132,7 +153,7 @@ func TestPairAccount_FallsBackWhenSetMargeAccountMissing(t *testing.T) {
 
 	m := &Manager{}
 
-	res, _, err := m.PairAccount(d.addr, "1234567", f)
+	res, _, err := m.PairAccount(t.Context(), d.addr, "1234567", f)
 	if err != nil {
 		t.Fatalf("PairAccount: %v", err)
 	}
@@ -168,7 +189,7 @@ func TestPairAccount_FallsBackWhenHTTPReturnsServerError(t *testing.T) {
 
 	m := &Manager{}
 
-	res, _, err := m.PairAccount(d.addr, "7654321", f)
+	res, _, err := m.PairAccount(t.Context(), d.addr, "7654321", f)
 	if err != nil {
 		t.Fatalf("PairAccount: %v", err)
 	}
@@ -193,7 +214,7 @@ func TestPairAccount_HTTPSuccessSkipsTelnet(t *testing.T) {
 
 	m := &Manager{}
 
-	res, _, err := m.PairAccount(d.addr, "1234567", f)
+	res, _, err := m.PairAccount(t.Context(), d.addr, "1234567", f)
 	if err != nil {
 		t.Fatalf("PairAccount: %v", err)
 	}
@@ -213,7 +234,7 @@ func TestPairAccount_NoTelnetAndHTTPMissingReturnsClearError(t *testing.T) {
 
 	m := &Manager{}
 
-	_, _, err := m.PairAccount(d.addr, "1234567", nil)
+	_, _, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
 	if err == nil {
 		t.Fatal("expected error when both paths are unavailable")
 	}
@@ -233,7 +254,7 @@ func TestPairAccount_TelnetCommandNotFoundReportsBothPaths(t *testing.T) {
 
 	m := &Manager{}
 
-	_, _, err := m.PairAccount(d.addr, "1234567", f)
+	_, _, err := m.PairAccount(t.Context(), d.addr, "1234567", f)
 	if err == nil {
 		t.Fatal("expected error when telnet rejects the fallback")
 	}
@@ -247,7 +268,7 @@ func TestPairAccount_RejectsInvalidAccountID(t *testing.T) {
 	m := &Manager{}
 
 	for _, badID := range []string{"", "12345", "12345678", "abcdefg", "12345 6"} {
-		_, _, err := m.PairAccount("127.0.0.1:9999", badID, nil)
+		_, _, err := m.PairAccount(t.Context(), "127.0.0.1:9999", badID, nil)
 		if err == nil {
 			t.Errorf("PairAccount accepted invalid ID %q", badID)
 		}
@@ -264,7 +285,7 @@ func TestPairAccount_TelnetTransportErrorReturned(t *testing.T) {
 
 	m := &Manager{}
 
-	_, _, err := m.PairAccount(d.addr, "1234567", f)
+	_, _, err := m.PairAccount(t.Context(), d.addr, "1234567", f)
 	if err == nil {
 		t.Fatal("expected telnet transport error to be surfaced")
 	}
@@ -282,7 +303,7 @@ func TestEnsureMargeAccountPaired_AlreadyPairedSkipsPairing(t *testing.T) {
 
 	m := NewManager("", nil, nil)
 
-	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(d.addr, "", f)
+	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(t.Context(), d.addr, "", f)
 	if err != nil {
 		t.Fatalf("EnsureMargeAccountPaired: %v", err)
 	}
@@ -306,7 +327,7 @@ func TestEnsureMargeAccountPaired_UnpairedGeneratesAndPairs(t *testing.T) {
 
 	m := NewManager("", nil, nil)
 
-	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(d.addr, "", nil)
+	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(t.Context(), d.addr, "", nil)
 	if err != nil {
 		t.Fatalf("EnsureMargeAccountPaired: %v", err)
 	}
@@ -330,7 +351,7 @@ func TestEnsureMargeAccountPaired_UnpairedUsesWantAccountID(t *testing.T) {
 
 	m := NewManager("", nil, nil)
 
-	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(d.addr, "7654321", nil)
+	accountID, alreadyPaired, _, err := m.EnsureMargeAccountPaired(t.Context(), d.addr, "7654321", nil)
 	if err != nil {
 		t.Fatalf("EnsureMargeAccountPaired: %v", err)
 	}
@@ -354,7 +375,7 @@ func TestEnsureMargeAccountPaired_RejectsInvalidWantAccountID(t *testing.T) {
 
 	m := NewManager("", nil, nil)
 
-	_, _, _, err := m.EnsureMargeAccountPaired(d.addr, "not/valid", nil)
+	_, _, _, err := m.EnsureMargeAccountPaired(t.Context(), d.addr, "not/valid", nil)
 	if err == nil {
 		t.Fatal("expected an error for an invalid --account value")
 	}
@@ -367,7 +388,7 @@ func TestEnsureMargeAccountPaired_PropagatesPairingFailure(t *testing.T) {
 
 	m := NewManager("", nil, nil)
 
-	_, _, _, err := m.EnsureMargeAccountPaired(d.addr, "1234567", nil)
+	_, _, _, err := m.EnsureMargeAccountPaired(t.Context(), d.addr, "1234567", nil)
 	if err == nil {
 		t.Fatal("expected an error when HTTP pairing is unsupported and no telnet client is given")
 	}
@@ -505,5 +526,177 @@ func TestGenerateAccountID_AvoidsCollisions(t *testing.T) {
 				t.Errorf("generated %q collides with known list %v", got, known)
 			}
 		}
+	}
+}
+
+// withFastSettle shrinks the post-escalation settle so the stuck-path tests
+// do not sit through the production 2 s.
+func withFastSettle(t *testing.T) {
+	t.Helper()
+
+	prev := wsSettleDelay
+	wsSettleDelay = time.Millisecond
+
+	t.Cleanup(func() { wsSettleDelay = prev })
+}
+
+// TestPairAccount_NoEscalationWhenSpeakerLeftSetup is the ordinary case: the
+// account was written and the speaker is playing (or idle), so nothing extra
+// should happen. In particular no WebSocket session is opened against a
+// perfectly healthy speaker.
+func TestPairAccount_NoEscalationWhenSpeakerLeftSetup(t *testing.T) {
+	d := newFakeDevice(t)
+	d.nowPlayingSources = []string{"STANDBY"}
+
+	var dialled bool
+
+	m := &Manager{NewSession: func(_, _ string, _ time.Duration) (StateMachine, error) {
+		dialled = true
+		return &fakeSession{errors: map[string]error{}}, nil
+	}}
+
+	res, logs, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
+	if err != nil {
+		t.Fatalf("PairAccount: %v", err)
+	}
+
+	if dialled {
+		t.Error("opened a setup WebSocket against a speaker that was not stuck")
+	}
+
+	if res.StuckInSetup || res.WSAttempted {
+		t.Errorf("unexpected escalation: %+v", res)
+	}
+
+	if res.Method != "http" {
+		t.Errorf("Method = %q, want http", res.Method)
+	}
+
+	if !strings.Contains(logs, "out of SETUP") {
+		t.Errorf("logs should record the check, got: %s", logs)
+	}
+}
+
+// TestPairAccount_EscalatesWhenStuckInSetup is the #646 shape: the HTTP call
+// succeeds and the account ID lands, but the firmware stays in onboarding. A
+// plain fallback chain would never reach the WebSocket path here, because
+// nothing failed.
+func TestPairAccount_EscalatesWhenStuckInSetup(t *testing.T) {
+	withFastSettle(t)
+
+	d := newFakeDevice(t)
+	// Stuck on the post-pair check, recovered on the re-read afterwards.
+	d.nowPlayingSources = []string{"SETUP", "STANDBY"}
+
+	session := &fakeSession{errors: map[string]error{}}
+	m := &Manager{NewSession: func(_, _ string, _ time.Duration) (StateMachine, error) {
+		return session, nil
+	}}
+
+	res, logs, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
+	if err != nil {
+		t.Fatalf("PairAccount: %v", err)
+	}
+
+	if !res.StuckInSetup {
+		t.Error("StuckInSetup should be set when the speaker still reports SETUP")
+	}
+
+	if !res.WSAttempted {
+		t.Error("WSAttempted should be set")
+	}
+
+	if !res.LeftSetup {
+		t.Error("LeftSetup should be set once the speaker reports a different source")
+	}
+
+	if res.Method != "ws" {
+		t.Errorf("Method = %q, want ws (the WebSocket call is what completed the pairing)", res.Method)
+	}
+
+	// The escalation sends the minimal payload: no boseServer extras, since
+	// this is an escalation of the same request, not a migration.
+	want := "SetMargeAccount(1234567,)"
+	if len(session.calls) != 1 || session.calls[0] != want {
+		t.Errorf("session calls = %v, want exactly [%s]", session.calls, want)
+	}
+
+	if !session.closed {
+		t.Error("session should be closed")
+	}
+
+	if !strings.Contains(logs, "escalating") {
+		t.Errorf("logs should explain the escalation, got: %s", logs)
+	}
+}
+
+// TestPairAccount_EscalationFailureDoesNotFailPairing covers a speaker that is
+// stuck and also refuses the WebSocket. The account ID was still written, so
+// reporting the whole call as failed would be wrong and would push the UI into
+// an error state over a best-effort extra step.
+func TestPairAccount_EscalationFailureDoesNotFailPairing(t *testing.T) {
+	d := newFakeDevice(t)
+	d.nowPlayingSources = []string{"SETUP"}
+
+	m := &Manager{NewSession: func(_, _ string, _ time.Duration) (StateMachine, error) {
+		return nil, errors.New("connection refused")
+	}}
+
+	res, _, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
+	if err != nil {
+		t.Fatalf("PairAccount should still succeed, got: %v", err)
+	}
+
+	if !res.StuckInSetup || !res.WSAttempted {
+		t.Errorf("escalation should be recorded as attempted: %+v", res)
+	}
+
+	if res.WSError == "" {
+		t.Error("WSError should explain why the escalation failed")
+	}
+
+	if res.LeftSetup {
+		t.Error("LeftSetup must stay false when the escalation never ran")
+	}
+
+	if res.Method != "http" {
+		t.Errorf("Method = %q, want http (the HTTP call is what wrote the account)", res.Method)
+	}
+}
+
+// TestPairAccount_UnreadableNowPlayingSkipsEscalation covers firmware that
+// does not answer /now_playing. Not being able to check is not evidence of
+// being stuck, so nothing should escalate on the strength of it.
+func TestPairAccount_UnreadableNowPlayingSkipsEscalation(t *testing.T) {
+	d := newFakeDevice(t)
+	d.nowPlayingSources = nil
+
+	var dialled bool
+
+	m := &Manager{
+		HTTPGet: func(url string) (*http.Response, error) {
+			if strings.HasSuffix(url, "/now_playing") {
+				return nil, errors.New("connection reset")
+			}
+
+			return http.Get(url) //nolint:gosec,noctx // test-local httptest URL
+		},
+		NewSession: func(_, _ string, _ time.Duration) (StateMachine, error) {
+			dialled = true
+			return &fakeSession{errors: map[string]error{}}, nil
+		},
+	}
+
+	res, logs, err := m.PairAccount(t.Context(), d.addr, "1234567", nil)
+	if err != nil {
+		t.Fatalf("PairAccount: %v", err)
+	}
+
+	if dialled || res.StuckInSetup || res.WSAttempted {
+		t.Errorf("must not escalate when the SETUP state is unknown: %+v", res)
+	}
+
+	if !strings.Contains(logs, "SETUP check failed") {
+		t.Errorf("logs should note the failed check, got: %s", logs)
 	}
 }

--- a/pkg/service/setup/setup.go
+++ b/pkg/service/setup/setup.go
@@ -260,6 +260,17 @@ type DeviceInfoXML struct {
 	SerialNumber string `xml:"-" json:"serialNumber"`
 }
 
+// httpGet performs a bounded GET, honouring the HTTPGet override when a
+// caller set one. HTTPGet is documented as optional, so a Manager built as a
+// plain struct literal (as tests do) must not panic here.
+func (m *Manager) httpGet(url string) (*http.Response, error) {
+	if m.HTTPGet != nil {
+		return m.HTTPGet(url)
+	}
+
+	return (&http.Client{Timeout: liveDeviceHTTPTimeout}).Get(url)
+}
+
 // GetLiveDeviceInfo fetches live information from the speaker's :8090/info endpoint.
 func (m *Manager) GetLiveDeviceInfo(deviceIP string) (*DeviceInfoXML, error) {
 	infoURL := fmt.Sprintf("http://%s:8090/info", deviceIP)
@@ -269,7 +280,7 @@ func (m *Manager) GetLiveDeviceInfo(deviceIP string) (*DeviceInfoXML, error) {
 		_ = host
 	}
 
-	resp, err := m.HTTPGet(infoURL)
+	resp, err := m.httpGet(infoURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch info from %s: %w", infoURL, err)
 	}
@@ -2921,7 +2932,7 @@ func (m *Manager) fetchLivePresets(deviceIP string) ([]models.ServicePreset, err
 		presetsURL = fmt.Sprintf("http://%s/presets", deviceIP)
 	}
 
-	resp, err := m.HTTPGet(presetsURL)
+	resp, err := m.httpGet(presetsURL)
 	if err != nil {
 		return nil, err
 	}
@@ -3005,7 +3016,7 @@ func (m *Manager) fetchLiveRecents(deviceIP string) ([]models.ServiceRecent, err
 		recentsURL = fmt.Sprintf("http://%s/recents", deviceIP)
 	}
 
-	resp, err := m.HTTPGet(recentsURL)
+	resp, err := m.httpGet(recentsURL)
 	if err != nil {
 		return nil, err
 	}
@@ -3097,7 +3108,7 @@ func (m *Manager) syncSources(deviceIP, accountID, deviceID string) int {
 		sourcesURL = fmt.Sprintf("http://%s/sources", deviceIP)
 	}
 
-	resp, err := m.HTTPGet(sourcesURL)
+	resp, err := m.httpGet(sourcesURL)
 	if err != nil {
 		return -1
 	}


### PR DESCRIPTION
> **Draft: unverified against hardware.** The decision logic is tested, but
> whether the WebSocket bracket actually clears `source="SETUP"` on real
> firmware rests on a single prior observation. See the caveat at the bottom.

`PairAccount` writes the account ID over HTTP `/setMargeAccount`, falling back
to the telnet `envswitch accountid set` command. Neither goes through the
firmware's own SETUP state machine, and there is reason to think that is
sometimes not enough: in
[issue 646](https://github.com/gesellix/Bose-SoundTouch/issues/646) a speaker
ended up with a populated `margeAccountUUID` while its firmware stayed in
`source="SETUP"`, refusing to play anything.

## Why this is not another fallback arm

The obvious change would be to append the WebSocket path to the existing
fallback chain. That would not have helped. The case being targeted is one
where the HTTP call **succeeds**, so `PairAccount` returns early
(`marge_pairing.go:77`) and a third arm never runs. The chain is not the
problem; the successful path being insufficient is.

So this checks, after a successful pair, whether the speaker actually left
SETUP, and escalates to the WebSocket `setMargeAccount` only when it did not.

Gating on the observed failure rather than reordering means:

- Nothing changes for anyone whose current path already works.
- A healthy speaker never has a setup WebSocket opened against it.
- The untestable hypothesis becomes something the code observes at runtime.
  `PairAccountResult` now reports `StuckInSetup`, `WSAttempted` and
  `LeftSetup`, so the next field report says whether the escalation fired and
  whether it helped, instead of us guessing an ordering.

The escalation sends the minimal payload, account ID plus the default auth
token, with no `boseServer` extras. It is an escalation of the request the
HTTP endpoint just took, not a migration, and should not quietly rewrite a
speaker's configured server URLs as a side effect. A failed escalation is
logged but never fails the call, since the account ID was written regardless.

## Two things that came along

- **Context threading.** `PairAccount` and `EnsureMargeAccountPaired` now take
  a `context.Context`, threaded from the HTTP request and the CLI command.
  Opening a WebSocket from a request-scoped call with `context.Background()`
  is what `contextcheck` objected to, and it was right; suppressing it would
  have meant annotating `handlers_pairing.go`, which is not the file at fault.
  The health `FixFunc` path keeps `context.Background()`, since that signature
  carries no context to inherit.
- **`Manager.httpGet`.** `HTTPGet` is documented as an optional override, but
  all four readers dereferenced it directly, so a `Manager` built as a plain
  struct literal nil-panicked. The new code hit that immediately.

## Tests

Four cases over the package's existing `fakeSession`: no escalation when the
speaker is healthy, escalation when it is stuck, a failed escalation not
failing the pairing, and an unreadable `/now_playing` not being treated as
evidence of being stuck.

## Caveat

I have no speaker stuck in SETUP to try this against. The prior evidence that
the WebSocket bracket moves a speaker out of that state is a single
observation on a SoundTouch 10 running firmware 27.0.6. It also remains
unknown what cleared that state on the 646 reporter's speaker, because they
never said, so this fixes a hypothesis rather than a confirmed bug.

What would settle it: any speaker that reports a populated `margeAccountUUID`
and `source="SETUP"` at the same time. With this branch the pairing log says
which arm ran and whether the speaker left SETUP afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
