### PR TITLE
fix(ws): parse errorUpdate, fix connectionStateUpdated, correlate setup acks exactly

### DIFF
--- a/cmd/soundtouch-cli/cmd_events.go
+++ b/cmd/soundtouch-cli/cmd_events.go
@@ -574,15 +574,23 @@ func handleDeviceError(message *models.SpecialMessage, verbose bool) {
 
 func handleUnknownEvent(event *models.WebSocketEvent, verbose bool) {
 	fmt.Printf("\n❓ Unknown Event [%s]:\n", event.DeviceID)
-	types := event.GetEventTypes()
 
-	for _, eventType := range types {
+	for _, eventType := range event.GetEventTypes() {
 		fmt.Printf("  📝 Type: %s\n", eventType)
 	}
 
+	// The interesting case is an <updates> child we don't model at all
+	// (nowSelectionUpdated, say): GetEventTypes is empty for it, and printing
+	// only that says "something arrived, and I won't tell you what".
+	// UnknownEventNames exists precisely to name it — but registering an
+	// OnUnknownEvent handler opts out of the client's own fallback log, which
+	// is the only other place it gets used.
+	for _, name := range event.UnknownEventNames() {
+		fmt.Printf("  📛 Unmodelled element: %s\n", name)
+	}
+
 	if verbose {
-		events := event.GetEvents()
-		fmt.Printf("  📱 Event count: %d\n", len(events))
+		fmt.Printf("  📱 Event count: %d\n", len(event.GetEvents()))
 		fmt.Printf("  ⏰ Timestamp: %s\n", event.Timestamp.Format(time.RFC3339))
 	}
 }

--- a/cmd/soundtouch-cli/cmd_events.go
+++ b/cmd/soundtouch-cli/cmd_events.go
@@ -209,7 +209,8 @@ func parseEventFilters(eventFilter string) map[string]bool {
 	validFilters := map[string]bool{
 		"nowPlaying": true, "volume": true, "connection": true,
 		"preset": true, "zone": true, "group": true, "bass": true,
-		"sdkInfo": true, "userActivity": true,
+		"sdkInfo": true, "userActivity": true, "userInactivity": true,
+		"errors": true,
 	}
 
 	if eventFilter == "" {
@@ -385,17 +386,16 @@ func handleVolumeEvent(event *models.VolumeUpdatedEvent, verbose bool) {
 }
 
 func handleConnectionEvent(event *models.ConnectionStateUpdatedEvent) {
-	cs := &event.ConnectionState
 	fmt.Printf("\n🌐 Connection Update [%s]:\n", event.DeviceID)
 
-	if cs.IsConnected() {
-		fmt.Println("  ✅ Connected")
+	if event.IsConnected() {
+		fmt.Printf("  ✅ Connected (%s)\n", event.State)
 	} else {
-		fmt.Printf("  ❌ State: %s\n", cs.State)
+		fmt.Printf("  ❌ State: %s\n", event.State)
 	}
 
-	if cs.Signal != "" {
-		fmt.Printf("  📶 Signal: %s\n", cs.GetSignalStrength())
+	if event.Signal != "" {
+		fmt.Printf("  📶 Signal: %s\n", event.GetSignalStrength())
 	}
 }
 
@@ -507,6 +507,10 @@ func handleSpecialMessage(message *models.SpecialMessage, filters map[string]boo
 			if !filters["userInactivity"] {
 				return
 			}
+		case models.MessageTypeErrorUpdate:
+			if !filters["errors"] {
+				return
+			}
 		}
 	}
 
@@ -529,12 +533,42 @@ func handleSpecialMessage(message *models.SpecialMessage, filters map[string]boo
 		if verbose {
 			fmt.Printf("  ⏰ Timestamp: %s\n", message.Timestamp.Format("15:04:05"))
 		}
+	case models.MessageTypeErrorUpdate:
+		handleDeviceError(message, verbose)
 	default:
 		fmt.Printf("\n❓ Unknown Special Message: %s\n", message.String())
 
 		if verbose {
 			fmt.Printf("  📱 Raw data: %s\n", string(message.RawData))
 		}
+	}
+}
+
+// handleDeviceError prints a root-level <errorUpdate> frame. These name the
+// failure precisely — numeric code, symbolic name, severity — and are the
+// most useful thing the speaker says when playback goes wrong.
+func handleDeviceError(message *models.SpecialMessage, verbose bool) {
+	errorUpdate := message.GetErrorUpdate()
+	if errorUpdate == nil {
+		return
+	}
+
+	devErr := &errorUpdate.Error
+
+	fmt.Printf("\n🚨 Device Error [%s]:\n", message.DeviceID)
+	fmt.Printf("  🔢 Code: %s\n", devErr.Value)
+	fmt.Printf("  🏷️  Name: %s\n", devErr.Name)
+
+	if devErr.Severity != "" {
+		fmt.Printf("  ⚠️  Severity: %s\n", devErr.Severity)
+	}
+
+	if text := strings.TrimSpace(devErr.Text); text != "" {
+		fmt.Printf("  💬 Detail: %s\n", text)
+	}
+
+	if verbose {
+		fmt.Printf("  ⏰ Timestamp: %s\n", message.Timestamp.Format("15:04:05"))
 	}
 }
 

--- a/cmd/soundtouch-cli/cmd_events_test.go
+++ b/cmd/soundtouch-cli/cmd_events_test.go
@@ -32,6 +32,14 @@ func TestParseEventFilters(t *testing.T) {
 			expectExit:  false,
 		},
 		{
+			// "errors" selects root-level <errorUpdate> frames (GH-701);
+			// "userInactivity" was handled but rejected by this parser.
+			name:        "device-error and inactivity filters",
+			eventFilter: "errors,userInactivity",
+			want:        map[string]bool{"errors": true, "userInactivity": true},
+			expectExit:  false,
+		},
+		{
 			name:        "filters with spaces",
 			eventFilter: "nowPlaying, volume , bass",
 			want:        map[string]bool{"nowPlaying": true, "volume": true, "bass": true},

--- a/cmd/soundtouch-cli/cmd_events_test.go
+++ b/cmd/soundtouch-cli/cmd_events_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
 )
 
 func TestParseEventFilters(t *testing.T) {
@@ -342,5 +344,33 @@ func TestWebSocketConfigDefaults(t *testing.T) {
 
 	if defaultBufferSize < 1024 {
 		t.Error("Buffer size should be at least 1024 bytes")
+	}
+}
+
+// TestHandleUnknownEventNamesTheElement pins that an <updates> child we do not
+// model is reported by name.
+//
+// GetEventTypes is empty for such a frame, so printing only that produced
+// "Unknown Event / Event count: 0" — an announcement that something arrived
+// with no hint what. models.UnknownEventNames exists to name it, but
+// registering an OnUnknownEvent handler opts out of the client's own fallback
+// log, which was the only other caller.
+func TestHandleUnknownEventNamesTheElement(t *testing.T) {
+	// Captured from a SoundTouch 10 (FW 27.0.6) when a STORED_MUSIC folder is
+	// selected. nowSelectionUpdated is not modelled yet.
+	raw := []byte(`<updates deviceID="DEVICEID01"><nowSelectionUpdated>` +
+		`<preset id="0"><ContentItem source="STORED_MUSIC" type="dir" location="4:cont2:615:part12:39"` +
+		` isPresetable="true"><itemName>Swissgroove</itemName></ContentItem></preset>` +
+		`</nowSelectionUpdated></updates>`)
+
+	event, err := models.ParseWebSocketEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent: %v", err)
+	}
+
+	out := captureStdout(t, func() { handleUnknownEvent(event, true) })
+
+	if !strings.Contains(out, "nowSelectionUpdated") {
+		t.Errorf("unknown-event output does not name the element:\n%s", out)
 	}
 }

--- a/cmd/soundtouch-cli/main.go
+++ b/cmd/soundtouch-cli/main.go
@@ -2299,7 +2299,7 @@ func main() {
 							&cli.StringFlag{
 								Name:    "filter",
 								Aliases: []string{"f"},
-								Usage:   "Filter events by type (comma-separated): nowPlaying,volume,connection,preset,zone,group,bass,sdkInfo,userActivity",
+								Usage:   "Filter events by type (comma-separated): nowPlaying,volume,connection,preset,zone,group,bass,sdkInfo,userActivity,userInactivity,errors",
 							},
 							&cli.DurationFlag{
 								Name:    "duration",

--- a/cmd/websocket-demo/main.go
+++ b/cmd/websocket-demo/main.go
@@ -47,7 +47,7 @@ func parseFilters(eventFilter string) map[string]bool {
 	validFilters := map[string]bool{
 		"nowPlaying": true, "volume": true, "connection": true,
 		"preset": true, "zone": true, "bass": true,
-		"sdkInfo": true, "userActivity": true,
+		"sdkInfo": true, "userActivity": true, "errors": true,
 	}
 
 	if eventFilter == "" {
@@ -60,7 +60,7 @@ func parseFilters(eventFilter string) map[string]bool {
 	for _, f := range filterList {
 		f = strings.TrimSpace(f)
 		if !validFilters[f] {
-			fmt.Printf("Invalid filter '%s'. Valid filters: nowPlaying, volume, connection, preset, zone, bass, sdkInfo, userActivity\n", f)
+			fmt.Printf("Invalid filter '%s'. Valid filters: nowPlaying, volume, connection, preset, zone, bass, sdkInfo, userActivity, errors\n", f)
 			os.Exit(1)
 		}
 
@@ -327,17 +327,16 @@ func handleVolume(event *models.VolumeUpdatedEvent, verbose bool) {
 }
 
 func handleConnection(event *models.ConnectionStateUpdatedEvent) {
-	cs := &event.ConnectionState
 	fmt.Printf("\n🌐 Connection Update [%s]:\n", event.DeviceID)
 
-	if cs.IsConnected() {
-		fmt.Println("  ✅ Connected")
+	if event.IsConnected() {
+		fmt.Printf("  ✅ Connected (%s)\n", event.State)
 	} else {
-		fmt.Printf("  ❌ State: %s\n", cs.State)
+		fmt.Printf("  ❌ State: %s\n", event.State)
 	}
 
-	if cs.Signal != "" {
-		fmt.Printf("  📶 Signal: %s\n", cs.GetSignalStrength())
+	if event.Signal != "" {
+		fmt.Printf("  📶 Signal: %s\n", event.GetSignalStrength())
 	}
 }
 
@@ -417,6 +416,10 @@ func handleSpecialMessage(message *models.SpecialMessage, filters map[string]boo
 			if !filters["userActivity"] {
 				return
 			}
+		case models.MessageTypeErrorUpdate:
+			if !filters["errors"] {
+				return
+			}
 		}
 	}
 
@@ -432,6 +435,16 @@ func handleSpecialMessage(message *models.SpecialMessage, filters map[string]boo
 
 		if verbose {
 			fmt.Printf("  ⏰ Timestamp: %s\n", message.Timestamp.Format("15:04:05"))
+		}
+	case models.MessageTypeErrorUpdate:
+		if errorUpdate := message.GetErrorUpdate(); errorUpdate != nil {
+			fmt.Printf("\n🚨 Device Error [%s]: %s (%s) severity=%s: %s\n",
+				message.DeviceID,
+				errorUpdate.Error.Name,
+				errorUpdate.Error.Value,
+				errorUpdate.Error.Severity,
+				strings.TrimSpace(errorUpdate.Error.Text),
+			)
 		}
 	default:
 		fmt.Printf("\n❓ Unknown Special Message: %s\n", message.String())

--- a/docs/content/docs/reference/API-ENDPOINTS.md
+++ b/docs/content/docs/reference/API-ENDPOINTS.md
@@ -451,6 +451,48 @@ Establishes a persistent connection for live updates.
 - `connectionStateUpdated`
 - `presetUpdated`
 
+#### `connectionStateUpdated`
+
+Everything is an attribute on the element itself; there is no nested
+`<connectionState>` child. The `state` and `signal` vocabularies match
+`/networkInfo`'s interface attributes.
+
+```xml
+<updates deviceID="DEVICEID01">
+  <connectionStateUpdated state="NETWORK_WIFI_CONNECTED" up="true" signal="EXCELLENT_SIGNAL" />
+</updates>
+```
+
+Captured on a SoundTouch 10 (`variant=rhino`, `moduleType=sm2`, FW 27.0.6).
+The `up` attribute is the authoritative boolean; `state` is transport-qualified
+and never equals a bare `CONNECTED`.
+
+#### `errorUpdate` (root level, not inside `<updates>`)
+
+Device-side errors arrive unwrapped, at the top level, in the present tense.
+They name the failure precisely, which makes them the most useful diagnostic
+the speaker offers for playback problems.
+
+```xml
+<errorUpdate deviceID="DEVICEID01">
+  <error value="1654" name="STORED_MUSIC_AP_TIMEOUT" severity="Unrecoverable">APServer: Timeout</error>
+</errorUpdate>
+
+<errorUpdate deviceID="DEVICEID01">
+  <error value="3103" name="AUDIO_ERROR_TIMEOUT" severity="Unknown">AudioPath error4, reason 1</error>
+</errorUpdate>
+```
+
+Observed severities: `Unrecoverable`, `Unknown`. Note this is *not* the
+`errorUpdated` (past tense) child of `<updates>` that third-party API notes
+describe; no capture has ever contained that element.
+
+Neither shape appears in Bose's published Web API document — its notification
+chapter is demonstrably incomplete for FW 27.0.6, so both are recorded here
+from captures. Both are pinned by tests in `pkg/models/websocket_test.go`.
+
+`soundtouch-cli events subscribe --filter connection,errors` prints both.
+
 ## Network and System
 
 ### GET /networkInfo ✅ **Implemented**

--- a/docs/content/docs/reference/DEVICE-PAIRING-FLOW.md
+++ b/docs/content/docs/reference/DEVICE-PAIRING-FLOW.md
@@ -73,6 +73,24 @@ All subsequent messages (except `selectLastWiFiSource`, see below) use this enve
 `requestID` is a monotonically increasing integer per connection (client-side sequence).
 `{device_id}` is the speaker's MAC address with colons removed (e.g. `AABBCCDDEE0A`).
 
+**Every response is enveloped, echoes its `requestID`, and carries
+`msgType="RESPONSE"`.** This holds for `info`, `setMargeAccount`,
+`pushCustomerSupportInfoToMarge`, `bass`, `select`, `key` and
+`webserver/pingRequest`, verified across three independent mitmproxy captures
+of the official Bose app (2026-04-16, 2026-05-02 ×2) against a SoundTouch 10
+(`variant=rhino`, `moduleType=sm2`, FW 27.0.6) and a SoundTouch 20. Earlier
+revisions of this page showed some replies unwrapped — that was an editing
+elision, not a second wire format.
+
+A payload that looks like a root element (`<info>`, `<status>/route</status>`)
+is therefore the envelope's **body**, not the frame. `selectLastWiFiSource` is
+the sole exception in both directions: a plain-text request and a bare
+`<status>` reply.
+
+That echo is what lets a client correlate a reply to the exact request that
+earned it, rather than guessing from the `url` attribute — which is ambiguous,
+since the setup state machine sends five separate steps with `url="setup"`.
+
 ---
 
 ## Phase 1 — Discovery: Is the Speaker Already Paired?
@@ -83,14 +101,19 @@ All subsequent messages (except `selectLastWiFiSource`, see below) use this enve
   <request requestID="1"><info type="new"/></request>
 </header></msg>
 
-<!-- S→C: response -->
-<info deviceID="{device_id}">
-  <name>SoundTouch 10</name>
-  <type>SoundTouch 10</type>
-  <margeAccountUUID>1000002</margeAccountUUID>   <!-- empty = unpaired -->
-  <margeURL>https://streaming.bose.com</margeURL>
-  ...
-</info>
+<!-- S→C: response — note the envelope; <info> is the BODY, not the root -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<msg><header deviceID="{device_id}" url="info" method="GET">
+  <request requestID="1" msgType="RESPONSE"><info type="new" /></request>
+</header><body>
+  <info deviceID="{device_id}">
+    <name>SoundTouch 10</name>
+    <type>SoundTouch 10</type>
+    <margeAccountUUID>1000002</margeAccountUUID>   <!-- empty = unpaired -->
+    <margeURL>https://streaming.bose.com</margeURL>
+    ...
+  </info>
+</body></msg>
 ```
 
 - **Empty `margeAccountUUID`** → device is unpaired, proceed to Phase 2
@@ -170,12 +193,18 @@ The pairing flow uses a setup state machine on the device. States must be sent i
   </PairDeviceWithAccount>
 </body></msg>
 
-<!-- S→C: device info response with margeAccountUUID now set -->
-<info deviceID="{device_id}">
-  ...
-  <margeAccountUUID>{accountId}</margeAccountUUID>
-  ...
-</info>
+<!-- S→C: device info response with margeAccountUUID now set.
+     Enveloped, echoing requestID and marked msgType="RESPONSE". -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<msg><header deviceID="{device_id}" url="setMargeAccount" method="POST">
+  <request requestID="27" msgType="RESPONSE" />
+</header><body>
+  <info deviceID="{device_id}">
+    ...
+    <margeAccountUUID>{accountId}</margeAccountUUID>
+    ...
+  </info>
+</body></msg>
 ```
 
 The server also pushes several `sourcesUpdated` events after successful pairing.
@@ -203,8 +232,11 @@ Bearer NtJDRbNtY3hDhm5K8FC2JprRhRQNH3QdZjG6aR4ASwYQg4rvZMY6dPLc3Bm6zvWNciWzCpMWZ
   <request requestID="29"></request>
 </header></msg>
 
-<!-- S→C: -->
-<status>/pushCustomerSupportInfoToMarge</status>
+<!-- S→C: also enveloped; the bare <status> below is the body -->
+<?xml version="1.0" encoding="UTF-8" ?>
+<msg><header deviceID="{device_id}" url="pushCustomerSupportInfoToMarge" method="GET">
+  <request requestID="29" msgType="RESPONSE"><info type="new" /></request>
+</header><body><status>/pushCustomerSupportInfoToMarge</status></body></msg>
 ```
 
 ---

--- a/pkg/client/websocket.go
+++ b/pkg/client/websocket.go
@@ -213,6 +213,16 @@ func (ws *WebSocketClient) OnRawMessage(handler models.RawMessageHandler) {
 	ws.handlers.OnRawMessage = handler
 }
 
+// OnDeviceError sets a handler for root-level <errorUpdate> frames — the
+// speaker's own error reports, carrying a numeric code, a symbolic name and a
+// severity. OnSpecialMessage still fires for the same frame.
+func (ws *WebSocketClient) OnDeviceError(handler models.TypedEventHandler[*models.ErrorUpdate]) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	ws.handlers.OnDeviceError = handler
+}
+
 // OnSpecialMessage sets a handler for special (non-updates) messages
 func (ws *WebSocketClient) OnSpecialMessage(handler models.SpecialMessageHandler) {
 	ws.mu.Lock()
@@ -636,10 +646,19 @@ func (ws *WebSocketClient) handleSpecialMessage(data []byte) {
 		return
 	}
 
-	// Call handler if set
+	// Call handlers if set. A device error goes to the dedicated typed
+	// handler first, then to the catch-all, so a caller may register
+	// either or both.
 	ws.mu.RLock()
 	handler := ws.handlers.OnSpecialMessage
+	deviceErrHandler := ws.handlers.OnDeviceError
 	ws.mu.RUnlock()
+
+	if deviceErrHandler != nil {
+		if errorUpdate := specialMessage.GetErrorUpdate(); errorUpdate != nil {
+			deviceErrHandler(errorUpdate)
+		}
+	}
 
 	if handler != nil {
 		handler(specialMessage)

--- a/pkg/client/websocket_test.go
+++ b/pkg/client/websocket_test.go
@@ -674,3 +674,76 @@ func TestWebSocketClient_Integration(t *testing.T) {
 
 	close(messagesChan)
 }
+
+// TestWebSocketClient_HandleDeviceError verifies that a root-level
+// <errorUpdate> frame — the shape a real speaker uses for its own error
+// reports — reaches both the dedicated OnDeviceError handler and the
+// OnSpecialMessage catch-all. Before GH-701 it reached neither: it failed to
+// parse and was only visible in the raw debug log.
+func TestWebSocketClient_HandleDeviceError(t *testing.T) {
+	client := NewClientFromHost("192.0.2.10")
+	logger := &mockLogger{}
+	wsClient := client.NewWebSocketClient(nil)
+	wsClient.logger = logger
+
+	var (
+		deviceErr *models.ErrorUpdate
+		special   *models.SpecialMessage
+	)
+
+	wsClient.OnDeviceError(func(event *models.ErrorUpdate) { deviceErr = event })
+	wsClient.OnSpecialMessage(func(message *models.SpecialMessage) { special = message })
+
+	frame := []byte(`<errorUpdate deviceID="DEVICEID01">` +
+		`<error value="1654" name="STORED_MUSIC_AP_TIMEOUT" severity="Unrecoverable">APServer: Timeout</error>` +
+		`</errorUpdate>`)
+
+	wsClient.handleMessage(frame)
+
+	if deviceErr == nil {
+		t.Fatal("OnDeviceError was not called")
+	}
+
+	if deviceErr.DeviceID != "DEVICEID01" {
+		t.Errorf("DeviceID = %q, want DEVICEID01", deviceErr.DeviceID)
+	}
+
+	if deviceErr.Error.Value != "1654" || deviceErr.Error.Name != "STORED_MUSIC_AP_TIMEOUT" {
+		t.Errorf("got %s/%s, want 1654/STORED_MUSIC_AP_TIMEOUT", deviceErr.Error.Value, deviceErr.Error.Name)
+	}
+
+	if deviceErr.Error.Severity != "Unrecoverable" {
+		t.Errorf("Severity = %q, want Unrecoverable", deviceErr.Error.Severity)
+	}
+
+	if special == nil {
+		t.Fatal("OnSpecialMessage was not called; it stays the catch-all")
+	}
+
+	if special.Type != models.MessageTypeErrorUpdate {
+		t.Errorf("SpecialMessage.Type = %q, want %q", special.Type, models.MessageTypeErrorUpdate)
+	}
+
+	for _, message := range logger.getMessages() {
+		if strings.Contains(message, "Unknown special message type") {
+			t.Errorf("errorUpdate still logged as unknown: %s", message)
+		}
+	}
+}
+
+// TestWebSocketClient_DeviceErrorHandlerIgnoresOtherSpecialMessages pins that
+// OnDeviceError only fires for actual device errors.
+func TestWebSocketClient_DeviceErrorHandlerIgnoresOtherSpecialMessages(t *testing.T) {
+	client := NewClientFromHost("192.0.2.10")
+	wsClient := client.NewWebSocketClient(nil)
+	wsClient.logger = &mockLogger{}
+
+	called := false
+	wsClient.OnDeviceError(func(*models.ErrorUpdate) { called = true })
+
+	wsClient.handleMessage([]byte(`<userActivityUpdate deviceID="DEVICEID01" />`))
+
+	if called {
+		t.Error("OnDeviceError fired for a userActivityUpdate frame")
+	}
+}

--- a/pkg/models/websocket.go
+++ b/pkg/models/websocket.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"bytes"
 	"encoding/xml"
 	"fmt"
 	"strings"
@@ -199,38 +200,58 @@ type VolumeUpdatedEvent struct {
 	Volume   Volume   `xml:"volume"`
 }
 
-// ConnectionStateUpdatedEvent represents a connection state update event
+// ConnectionStateUpdatedEvent represents a connection state update event.
+//
+// The speaker puts everything in attributes on the element itself. Captured
+// on a SoundTouch 10 (variant=rhino, moduleType=sm2, FW 27.0.6):
+//
+//	<updates deviceID="DEVICEID01">
+//	  <connectionStateUpdated state="NETWORK_WIFI_CONNECTED" up="true"
+//	                          signal="EXCELLENT_SIGNAL" />
+//	</updates>
+//
+// There is no nested <connectionState> child. This type used to model one,
+// which is why State and Signal were always empty (GH-701). The shape is not
+// in Bose's published Web API document; it only exists in captures.
 type ConnectionStateUpdatedEvent struct {
-	XMLName         xml.Name        `xml:"connectionStateUpdated"`
-	DeviceID        string          `xml:"deviceID,attr"`
-	ConnectionState ConnectionState `xml:"connectionState"`
-}
-
-// ConnectionState represents the device's network connection state
-type ConnectionState struct {
-	XMLName xml.Name `xml:"connectionState"`
-	State   string   `xml:"state,attr"`
-	Signal  string   `xml:"signal,attr"`
+	XMLName  xml.Name `xml:"connectionStateUpdated"`
+	DeviceID string   `xml:"deviceID,attr"`
+	State    string   `xml:"state,attr"`
+	Up       bool     `xml:"up,attr"`
+	Signal   string   `xml:"signal,attr"`
 }
 
 // ConnectionStateType represents connection state values
 type ConnectionStateType string
 
 const (
-	// ConnectionStateConnected indicates the device is connected
+	// ConnectionStateConnected indicates the device is connected.
+	//
+	// Kept for compatibility: no captured frame has ever carried this bare
+	// value. Real speakers report transport-qualified states such as
+	// ConnectionStateWiFiConnected, which is why IsConnected reads the
+	// up attribute rather than comparing against these constants.
 	ConnectionStateConnected ConnectionStateType = "CONNECTED"
 	// ConnectionStateDisconnected indicates the device is disconnected
 	ConnectionStateDisconnected ConnectionStateType = "DISCONNECTED"
+	// ConnectionStateWiFiConnected is the state a Wi-Fi-attached speaker
+	// actually reports (field-observed, FW 27.0.6).
+	ConnectionStateWiFiConnected ConnectionStateType = "NETWORK_WIFI_CONNECTED"
 )
 
-// IsConnected returns true if the device is connected
-func (cs *ConnectionState) IsConnected() bool {
-	return cs.State == string(ConnectionStateConnected)
+// IsConnected reports whether the speaker considers its network link up.
+//
+// This reads the up attribute rather than matching State against
+// ConnectionStateConnected: the device sends transport-qualified state names
+// ("NETWORK_WIFI_CONNECTED"), so a string comparison would never match, while
+// up is an unambiguous boolean the firmware sets on every frame we captured.
+func (e *ConnectionStateUpdatedEvent) IsConnected() bool {
+	return e.Up
 }
 
 // GetSignalStrength returns the signal strength as a string
-func (cs *ConnectionState) GetSignalStrength() string {
-	return cs.Signal
+func (e *ConnectionStateUpdatedEvent) GetSignalStrength() string {
+	return e.Signal
 }
 
 // PresetUpdatedEvent represents a preset update event
@@ -299,19 +320,30 @@ type NameUpdatedEvent struct {
 	Name     Name     `xml:"name"`
 }
 
-// ErrorUpdatedEvent represents an error state update event
+// ErrorUpdatedEvent represents an <errorUpdated> child of <updates>.
+//
+// No capture has ever contained this element. Real speakers report errors as
+// a root-level <errorUpdate> frame (present tense, outside <updates>) — see
+// ErrorUpdate, which is the shape that actually arrives on the wire. This type
+// is retained because the past-tense name appears in third-party API notes and
+// costs nothing to keep parsing.
 type ErrorUpdatedEvent struct {
 	XMLName  xml.Name `xml:"errorUpdated"`
 	DeviceID string   `xml:"deviceID,attr"`
 	Error    Error    `xml:"error"`
 }
 
-// Error represents an error state
+// Error represents an error state.
+//
+// Value is the numeric code, Name its symbolic form (e.g.
+// "STORED_MUSIC_AP_TIMEOUT"), Severity one of "Unrecoverable" / "Unknown" as
+// observed on FW 27.0.6, and Text the device's human-readable detail.
 type Error struct {
-	XMLName xml.Name `xml:"error"`
-	Value   string   `xml:"value,attr"`
-	Name    string   `xml:"name,attr"`
-	Text    string   `xml:",chardata"`
+	XMLName  xml.Name `xml:"error"`
+	Value    string   `xml:"value,attr"`
+	Name     string   `xml:"name,attr"`
+	Severity string   `xml:"severity,attr"`
+	Text     string   `xml:",chardata"`
 }
 
 // RecentsUpdatedEvent represents a recent items update event
@@ -369,6 +401,7 @@ const (
 	MessageTypeSdkInfo        SpecialMessageType = "sdkInfo"
 	MessageTypeUserActivity   SpecialMessageType = "userActivity"
 	MessageTypeUserInactivity SpecialMessageType = "userInactivity"
+	MessageTypeErrorUpdate    SpecialMessageType = "errorUpdate"
 )
 
 // SoundTouchSdkInfo represents the SDK info message sent on connection
@@ -388,6 +421,27 @@ type UserActivityUpdate struct {
 type UserInactivityUpdate struct {
 	XMLName  xml.Name `xml:"userInactivityUpdate"`
 	DeviceID string   `xml:"deviceID,attr"`
+}
+
+// ErrorUpdate is a root-level device-error notification.
+//
+// Note the present tense: this is NOT ErrorUpdatedEvent, which models an
+// <errorUpdated> child of <updates> and has never been seen on the wire. The
+// speaker sends errors unwrapped, at the top level (FW 27.0.6):
+//
+//	<errorUpdate deviceID="DEVICEID01">
+//	  <error value="1654" name="STORED_MUSIC_AP_TIMEOUT"
+//	         severity="Unrecoverable">APServer: Timeout</error>
+//	</errorUpdate>
+//
+// These frames name a failure precisely — numeric code, symbolic name,
+// severity — which makes them the most useful diagnostic the speaker offers
+// when playback goes wrong. Before GH-701 they were dropped as an unknown
+// special message type.
+type ErrorUpdate struct {
+	XMLName  xml.Name `xml:"errorUpdate"`
+	DeviceID string   `xml:"deviceID,attr"`
+	Error    Error    `xml:"error"`
 }
 
 // SpecialMessage represents non-updates WebSocket messages
@@ -424,7 +478,12 @@ type WebSocketEventHandlers struct {
 	OnRecentsUpdated      TypedEventHandler[*RecentsUpdatedEvent]
 	OnLanguageUpdated     TypedEventHandler[*LanguageUpdatedEvent]
 	OnUnknownEvent        EventHandler
-	OnSpecialMessage      SpecialMessageHandler
+	// OnDeviceError fires for root-level <errorUpdate> frames — the
+	// speaker's own error reports. OnSpecialMessage still fires for the
+	// same frame; this handler exists so callers that only care about
+	// device errors don't have to type-switch.
+	OnDeviceError    TypedEventHandler[*ErrorUpdate]
+	OnSpecialMessage SpecialMessageHandler
 	// OnRawMessage fires for every received frame before any parsing
 	// happens. Use it for debug/observability tooling that wants to see
 	// exactly what the device sent on the wire — the typed handlers
@@ -660,9 +719,51 @@ func (e *WebSocketEvent) String() string {
 	return fmt.Sprintf("WebSocket Event [Device: %s] - %d events", e.DeviceID, len(eventTypes))
 }
 
+// RootElementName returns the local name of an XML document's root element,
+// skipping any prolog or leading whitespace.
+//
+// Frame dispatch keys off this rather than substring tests: element names
+// share prefixes ("errorUpdate" / "errorUpdated"), attributes may wrap onto
+// the next line, and an element may be self-closing — all of which defeat a
+// needle like "<errorUpdate ".
+func RootElementName(data []byte) (string, error) {
+	decoder := xml.NewDecoder(bytes.NewReader(data))
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			return "", err
+		}
+
+		if start, ok := token.(xml.StartElement); ok {
+			return start.Name.Local, nil
+		}
+	}
+}
+
 // ParseSpecialMessage parses non-updates WebSocket messages
 func ParseSpecialMessage(data []byte) (*SpecialMessage, error) {
 	dataStr := string(data)
+
+	root, rootErr := RootElementName(data)
+
+	// Check for errorUpdate. Matched on the root element rather than a
+	// substring: "<errorUpdate" is also a prefix of "<errorUpdated", the
+	// (never observed) <updates> child modelled by ErrorUpdatedEvent.
+	if rootErr == nil && root == "errorUpdate" {
+		var errorUpdate ErrorUpdate
+		if err := xml.Unmarshal(data, &errorUpdate); err != nil {
+			return nil, fmt.Errorf("failed to parse errorUpdate: %w", err)
+		}
+
+		return &SpecialMessage{
+			Type:      MessageTypeErrorUpdate,
+			DeviceID:  errorUpdate.DeviceID,
+			Data:      &errorUpdate,
+			RawData:   data,
+			Timestamp: time.Now(),
+		}, nil
+	}
 
 	// Check for SoundTouchSdkInfo
 	if strings.Contains(dataStr, "<SoundTouchSdkInfo") {
@@ -736,6 +837,17 @@ func (sm *SpecialMessage) GetUserActivity() *UserActivityUpdate {
 	return nil
 }
 
+// GetErrorUpdate returns the parsed ErrorUpdate data if the message is of that type
+func (sm *SpecialMessage) GetErrorUpdate() *ErrorUpdate {
+	if sm.Type == MessageTypeErrorUpdate {
+		if errorUpdate, ok := sm.Data.(*ErrorUpdate); ok {
+			return errorUpdate
+		}
+	}
+
+	return nil
+}
+
 // GetUserInactivity returns the parsed UserInactivity data if the message is of that type
 func (sm *SpecialMessage) GetUserInactivity() *UserInactivityUpdate {
 	if sm.Type == MessageTypeUserInactivity {
@@ -758,6 +870,17 @@ func (sm *SpecialMessage) String() string {
 		return fmt.Sprintf("User Activity [Device: %s]", sm.DeviceID)
 	case MessageTypeUserInactivity:
 		return fmt.Sprintf("User Inactivity [Device: %s]", sm.DeviceID)
+	case MessageTypeErrorUpdate:
+		if errorUpdate := sm.GetErrorUpdate(); errorUpdate != nil {
+			return fmt.Sprintf(
+				"Device Error [Device: %s] - %s (%s), severity %s: %s",
+				sm.DeviceID,
+				errorUpdate.Error.Name,
+				errorUpdate.Error.Value,
+				errorUpdate.Error.Severity,
+				strings.TrimSpace(errorUpdate.Error.Text),
+			)
+		}
 	}
 
 	return fmt.Sprintf("Unknown Special Message - Type: %s", sm.Type)

--- a/pkg/models/websocket_test.go
+++ b/pkg/models/websocket_test.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -38,37 +39,87 @@ func TestWebSocketEventType_String(t *testing.T) {
 	}
 }
 
-func TestConnectionState_IsConnected(t *testing.T) {
+// TestConnectionStateUpdatedEvent_Parse pins the shape captured from a
+// SoundTouch 10 (variant=rhino, moduleType=sm2, FW 27.0.6): state, up and
+// signal are attributes on <connectionStateUpdated> itself. The type used to
+// model a nested <connectionState> child that never appears, which left State
+// and Signal permanently empty (GH-701).
+func TestConnectionStateUpdatedEvent_Parse(t *testing.T) {
 	tests := []struct {
-		name     string
-		state    string
-		expected bool
+		name       string
+		xmlData    string
+		wantState  string
+		wantUp     bool
+		wantSignal string
 	}{
-		{"Connected", "CONNECTED", true},
-		{"Disconnected", "DISCONNECTED", false},
-		{"Connecting", "CONNECTING", false},
-		{"Unknown", "UNKNOWN", false},
+		{
+			name: "captured wifi-connected frame",
+			xmlData: `<updates deviceID="DEVICEID01">` +
+				`<connectionStateUpdated state="NETWORK_WIFI_CONNECTED" up="true" signal="EXCELLENT_SIGNAL" />` +
+				`</updates>`,
+			wantState:  "NETWORK_WIFI_CONNECTED",
+			wantUp:     true,
+			wantSignal: "EXCELLENT_SIGNAL",
+		},
+		{
+			name: "link down",
+			xmlData: `<updates deviceID="DEVICEID01">` +
+				`<connectionStateUpdated state="NETWORK_WIFI_DISCONNECTED" up="false" signal="NO_SIGNAL" />` +
+				`</updates>`,
+			wantState:  "NETWORK_WIFI_DISCONNECTED",
+			wantUp:     false,
+			wantSignal: "NO_SIGNAL",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cs := &ConnectionState{State: tt.state}
+			event, err := ParseWebSocketEvent([]byte(tt.xmlData))
+			if err != nil {
+				t.Fatalf("ParseWebSocketEvent() error = %v", err)
+			}
 
-			result := cs.IsConnected()
-			if result != tt.expected {
-				t.Errorf("ConnectionState.IsConnected() = %v, want %v", result, tt.expected)
+			cs := event.ConnectionStateUpdated
+			if cs == nil {
+				t.Fatal("ConnectionStateUpdated is nil")
+			}
+
+			if cs.State != tt.wantState {
+				t.Errorf("State = %q, want %q", cs.State, tt.wantState)
+			}
+
+			if cs.Up != tt.wantUp {
+				t.Errorf("Up = %v, want %v", cs.Up, tt.wantUp)
+			}
+
+			if cs.Signal != tt.wantSignal {
+				t.Errorf("Signal = %q, want %q", cs.Signal, tt.wantSignal)
+			}
+
+			if got := cs.IsConnected(); got != tt.wantUp {
+				t.Errorf("IsConnected() = %v, want %v", got, tt.wantUp)
+			}
+
+			if got := cs.GetSignalStrength(); got != tt.wantSignal {
+				t.Errorf("GetSignalStrength() = %q, want %q", got, tt.wantSignal)
 			}
 		})
 	}
 }
 
-func TestConnectionState_GetSignalStrength(t *testing.T) {
-	cs := &ConnectionState{Signal: "EXCELLENT"}
-	result := cs.GetSignalStrength()
+// TestConnectionStateUpdatedEvent_IsConnectedReadsUp documents why
+// IsConnected does not compare State against ConnectionStateConnected: the
+// device never sends that bare value, so a string match would report every
+// healthy speaker as disconnected.
+func TestConnectionStateUpdatedEvent_IsConnectedReadsUp(t *testing.T) {
+	event := &ConnectionStateUpdatedEvent{State: "NETWORK_WIFI_CONNECTED", Up: true}
+	if !event.IsConnected() {
+		t.Error("IsConnected() = false for up=\"true\"; must read the up attribute")
+	}
 
-	expected := "EXCELLENT"
-	if result != expected {
-		t.Errorf("ConnectionState.GetSignalStrength() = %v, want %v", result, expected)
+	stale := &ConnectionStateUpdatedEvent{State: string(ConnectionStateConnected), Up: false}
+	if stale.IsConnected() {
+		t.Error("IsConnected() = true for up=\"false\"; State must not override up")
 	}
 }
 
@@ -576,5 +627,216 @@ func TestParseWebSocketEvent_KnownEventNoUnknowns(t *testing.T) {
 
 	if names := event.UnknownEventNames(); len(names) != 0 {
 		t.Errorf("expected no unknown elements for a modeled event, got %v", names)
+	}
+}
+
+// TestParseSpecialMessage covers the non-<updates> frames the speaker sends.
+//
+// The errorUpdate cases are verbatim captures from a SoundTouch 10
+// (variant=rhino, moduleType=sm2, FW 27.0.6), with the device ID replaced.
+// Before GH-701 they fell through to "unknown special message type", so every
+// device-side error was lost — which is exactly the diagnostic information
+// playback bug reports keep lacking.
+func TestParseSpecialMessage(t *testing.T) {
+	t.Run("errorUpdate — STORED_MUSIC_AP_TIMEOUT", func(t *testing.T) {
+		data := []byte(`<errorUpdate deviceID="DEVICEID01">` +
+			`<error value="1654" name="STORED_MUSIC_AP_TIMEOUT" severity="Unrecoverable">APServer: Timeout</error>` +
+			`</errorUpdate>`)
+
+		msg, err := ParseSpecialMessage(data)
+		if err != nil {
+			t.Fatalf("ParseSpecialMessage() error = %v", err)
+		}
+
+		if msg.Type != MessageTypeErrorUpdate {
+			t.Errorf("Type = %q, want %q", msg.Type, MessageTypeErrorUpdate)
+		}
+
+		if msg.DeviceID != "DEVICEID01" {
+			t.Errorf("DeviceID = %q, want DEVICEID01", msg.DeviceID)
+		}
+
+		update := msg.GetErrorUpdate()
+		if update == nil {
+			t.Fatal("GetErrorUpdate() = nil")
+		}
+
+		if update.Error.Value != "1654" {
+			t.Errorf("Error.Value = %q, want 1654", update.Error.Value)
+		}
+
+		if update.Error.Name != "STORED_MUSIC_AP_TIMEOUT" {
+			t.Errorf("Error.Name = %q, want STORED_MUSIC_AP_TIMEOUT", update.Error.Name)
+		}
+
+		if update.Error.Severity != "Unrecoverable" {
+			t.Errorf("Error.Severity = %q, want Unrecoverable", update.Error.Severity)
+		}
+
+		if update.Error.Text != "APServer: Timeout" {
+			t.Errorf("Error.Text = %q, want %q", update.Error.Text, "APServer: Timeout")
+		}
+	})
+
+	t.Run("errorUpdate — AUDIO_ERROR_TIMEOUT", func(t *testing.T) {
+		data := []byte(`<errorUpdate deviceID="DEVICEID01">` +
+			`<error value="3103" name="AUDIO_ERROR_TIMEOUT" severity="Unknown">AudioPath error4, reason 1</error>` +
+			`</errorUpdate>`)
+
+		msg, err := ParseSpecialMessage(data)
+		if err != nil {
+			t.Fatalf("ParseSpecialMessage() error = %v", err)
+		}
+
+		update := msg.GetErrorUpdate()
+		if update == nil {
+			t.Fatal("GetErrorUpdate() = nil")
+		}
+
+		if update.Error.Value != "3103" || update.Error.Name != "AUDIO_ERROR_TIMEOUT" {
+			t.Errorf("got %s/%s, want 3103/AUDIO_ERROR_TIMEOUT", update.Error.Value, update.Error.Name)
+		}
+
+		if !strings.Contains(msg.String(), "AUDIO_ERROR_TIMEOUT") {
+			t.Errorf("String() = %q, want it to name the error", msg.String())
+		}
+	})
+
+	t.Run("SoundTouchSdkInfo", func(t *testing.T) {
+		msg, err := ParseSpecialMessage([]byte(`<SoundTouchSdkInfo serverVersion="4" serverBuild="trunk r46330" />`))
+		if err != nil {
+			t.Fatalf("ParseSpecialMessage() error = %v", err)
+		}
+
+		if msg.Type != MessageTypeSdkInfo {
+			t.Errorf("Type = %q, want %q", msg.Type, MessageTypeSdkInfo)
+		}
+
+		if msg.GetErrorUpdate() != nil {
+			t.Error("GetErrorUpdate() must be nil for a non-error message")
+		}
+	})
+
+	t.Run("userActivityUpdate", func(t *testing.T) {
+		msg, err := ParseSpecialMessage([]byte(`<userActivityUpdate deviceID="DEVICEID01" />`))
+		if err != nil {
+			t.Fatalf("ParseSpecialMessage() error = %v", err)
+		}
+
+		if msg.Type != MessageTypeUserActivity {
+			t.Errorf("Type = %q, want %q", msg.Type, MessageTypeUserActivity)
+		}
+	})
+
+	t.Run("userInactivityUpdate", func(t *testing.T) {
+		msg, err := ParseSpecialMessage([]byte(`<userInactivityUpdate deviceID="DEVICEID01" />`))
+		if err != nil {
+			t.Fatalf("ParseSpecialMessage() error = %v", err)
+		}
+
+		if msg.Type != MessageTypeUserInactivity {
+			t.Errorf("Type = %q, want %q", msg.Type, MessageTypeUserInactivity)
+		}
+	})
+
+	t.Run("unknown type still reports an error", func(t *testing.T) {
+		if _, err := ParseSpecialMessage([]byte(`<somethingElse deviceID="DEVICEID01" />`)); err == nil {
+			t.Fatal("expected an error for an unmodelled special message")
+		}
+	})
+}
+
+// TestParseSpecialMessage_ErrorUpdatedIsNotErrorUpdate guards the shared
+// prefix: "<errorUpdate" is also a prefix of "<errorUpdated", the (never
+// observed) <updates> child. A bare-prefix match in ParseSpecialMessage would
+// swallow the past-tense element.
+func TestParseSpecialMessage_ErrorUpdatedIsNotErrorUpdate(t *testing.T) {
+	data := []byte(`<updates deviceID="DEVICEID01">` +
+		`<errorUpdated deviceID="DEVICEID01"><error value="7" name="SOMETHING">boom</error></errorUpdated>` +
+		`</updates>`)
+
+	event, err := ParseWebSocketEvent(data)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent() error = %v", err)
+	}
+
+	if event.ErrorUpdated == nil {
+		t.Fatal("ErrorUpdated is nil; <errorUpdated> must still parse as an <updates> child")
+	}
+
+	if event.ErrorUpdated.Error.Name != "SOMETHING" {
+		t.Errorf("Error.Name = %q, want SOMETHING", event.ErrorUpdated.Error.Name)
+	}
+
+	// The root-level branch must not claim a bare <errorUpdated> frame.
+	if _, err := ParseSpecialMessage([]byte(`<errorUpdated deviceID="DEVICEID01"/>`)); err == nil {
+		t.Error("ParseSpecialMessage accepted <errorUpdated>; only <errorUpdate> is a special message")
+	}
+}
+
+// TestParseSpecialMessage_ErrorUpdateShapeVariants guards the root-element
+// dispatch against shapes a substring needle would miss: attributes wrapped
+// onto the next line, and a self-closing element.
+func TestParseSpecialMessage_ErrorUpdateShapeVariants(t *testing.T) {
+	tests := []struct {
+		name    string
+		xmlData string
+	}{
+		{
+			name:    "attributes on the next line",
+			xmlData: "<errorUpdate\n  deviceID=\"DEVICEID01\">\n  <error value=\"1654\" name=\"STORED_MUSIC_AP_TIMEOUT\"/>\n</errorUpdate>",
+		},
+		{
+			name:    "self-closing",
+			xmlData: `<errorUpdate deviceID="DEVICEID01"/>`,
+		},
+		{
+			name:    "with an XML prolog",
+			xmlData: `<?xml version="1.0" encoding="UTF-8" ?><errorUpdate deviceID="DEVICEID01"><error value="7"/></errorUpdate>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := ParseSpecialMessage([]byte(tt.xmlData))
+			if err != nil {
+				t.Fatalf("ParseSpecialMessage() error = %v", err)
+			}
+
+			if msg.Type != MessageTypeErrorUpdate {
+				t.Errorf("Type = %q, want %q", msg.Type, MessageTypeErrorUpdate)
+			}
+
+			if msg.DeviceID != "DEVICEID01" {
+				t.Errorf("DeviceID = %q, want DEVICEID01", msg.DeviceID)
+			}
+		})
+	}
+}
+
+func TestRootElementName(t *testing.T) {
+	tests := []struct {
+		name    string
+		xmlData string
+		want    string
+		wantErr bool
+	}{
+		{"plain", `<updates deviceID="X"/>`, "updates", false},
+		{"prolog skipped", `<?xml version="1.0" ?><status>/setup</status>`, "status", false},
+		{"leading whitespace", "\n  <errorUpdate/>", "errorUpdate", false},
+		{"not xml", `not xml at all`, "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := RootElementName([]byte(tt.xmlData))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("RootElementName() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if got != tt.want {
+				t.Errorf("RootElementName() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/service/setup/setup_session.go
+++ b/pkg/service/setup/setup_session.go
@@ -5,9 +5,12 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"net/url"
+	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -116,6 +119,23 @@ type Session struct {
 	reqID         atomic.Int64
 	stepTimeout   time.Duration
 	pairingExtras MargePairingExtras
+
+	// frames carries every received frame from the reader goroutine to
+	// whichever sendStep is waiting. It is closed when the read loop ends.
+	frames chan []byte
+	// done is closed by Close to unblock a reader parked on a send.
+	done chan struct{}
+	// readErr holds the error that ended the read loop, so a step waiting
+	// on a dead connection reports the cause rather than "closed channel".
+	readErr atomic.Pointer[error]
+	// logf receives non-fatal observations (e.g. a device error pushed
+	// while a step is in flight). Tests override it.
+	logf func(format string, args ...any)
+	// closeOnce keeps Close idempotent: closing done twice panics.
+	closeOnce sync.Once
+	// routeUses counts how many times each route has been sent on this
+	// session, which is what makes a route ambiguous. See classifyEnvelope.
+	routeUses map[string]int
 }
 
 // DialSession opens a WebSocket to the speaker at deviceIP and
@@ -169,12 +189,50 @@ func DialSession(deviceIP, deviceID string, cfg SessionConfig) (*Session, error)
 		step = defaultSetupStepTimeout
 	}
 
-	return &Session{
+	s := &Session{
 		deviceID:      deviceID,
 		conn:          conn,
 		stepTimeout:   step,
 		pairingExtras: cfg.PairingExtras,
-	}, nil
+		frames:        make(chan []byte),
+		done:          make(chan struct{}),
+		logf:          log.Printf,
+		routeUses:     make(map[string]int),
+	}
+
+	go s.readLoop(conn)
+
+	return s, nil
+}
+
+// readLoop pumps received frames to sendStep.
+//
+// It deliberately sets no read deadline. gorilla/websocket treats every read
+// error as fatal — a SetReadDeadline expiry included — and returns it
+// instantly from every later read on the same connection. Using a deadline as
+// a per-step timeout therefore poisons the whole session at the first quiet
+// moment, and every subsequent step fails immediately with "i/o timeout",
+// which reads exactly like the device refusing. sendStep gets its timeout from
+// a select instead (GH-704).
+//
+// conn is passed in rather than read from s: Close nils s.conn.
+func (s *Session) readLoop(conn *websocket.Conn) {
+	defer close(s.frames)
+
+	for {
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			s.readErr.Store(&err)
+
+			return
+		}
+
+		select {
+		case s.frames <- data:
+		case <-s.done:
+			return
+		}
+	}
 }
 
 // Close sends a normal-closure frame and closes the underlying socket.
@@ -182,6 +240,8 @@ func (s *Session) Close() error {
 	if s.conn == nil {
 		return nil
 	}
+
+	s.closeOnce.Do(func() { close(s.done) })
 
 	_ = s.conn.WriteControl(
 		websocket.CloseMessage,
@@ -196,23 +256,39 @@ func (s *Session) Close() error {
 }
 
 // sendStep wraps body in the canonical <msg><header url="…" method="…">…
-// envelope, sends it, and drains incoming frames until one references the
-// same requestID, status path, or url attribute — that frame is the ack.
-// Pushed <updates> and <SoundTouchSdkInfo> frames are ignored. The ack
-// payload is consumed for error detection (<error …/>) only and never
-// returned — every caller discards it.
+// envelope, sends it, and waits for the matching ack.
+//
+// Frames are classified by their ROOT ELEMENT, never by substring. That
+// matters: the speaker pushes root-level <errorUpdate> frames for unrelated
+// asynchronous failures (source timeouts, audio-path errors), and the previous
+// "does the text contain <error" test flagged those as a rejection of the step
+// in flight — aborting the whole init plan over an event that had nothing to do
+// with it, because "<errorupdate" contains "<error" (GH-704).
+//
+// Correlation is exact for enveloped responses: a <msg> reply is this step's
+// ack only if it echoes this step's requestID. Five of the nine init-plan
+// steps use url="setup", so accepting a bare url match — as this used to —
+// let a late response to step N satisfy step N+1.
+//
+// The ack payload is consumed for error detection only and never returned —
+// every caller discards it.
 func (s *Session) sendStep(ctx context.Context, route, method, body string) error {
 	if s.conn == nil {
 		return errors.New("setup session: connection closed")
 	}
 
 	id := s.reqID.Add(1)
+	s.routeUses[route]++
 
 	envelope := fmt.Sprintf(
 		`<msg><header deviceID="%s" url="%s" method="%s"><request requestID="%d"/></header><body>%s</body></msg>`,
 		xmlAttrEscape(s.deviceID), xmlAttrEscape(route), method, id, body,
 	)
 
+	// A context deadline, when present, wins over stepTimeout. Callers rely
+	// on this: cmd_setup.go's bare-pair path deliberately grants
+	// step-timeout+2s, and ExecuteInitPlan passes one context to all nine
+	// steps as a whole-plan budget.
 	deadline, ok := ctx.Deadline()
 	if !ok {
 		deadline = time.Now().Add(s.stepTimeout)
@@ -224,35 +300,241 @@ func (s *Session) sendStep(ctx context.Context, route, method, body string) erro
 		return fmt.Errorf("send %s: %w", route, err)
 	}
 
-	idNeedle := fmt.Sprintf(`requestID="%d"`, id)
-	statusNeedle := fmt.Sprintf(`<status>/%s</status>`, route)
-	urlNeedle := fmt.Sprintf(`url="%s"`, route)
+	timer := time.NewTimer(time.Until(deadline))
+	defer timer.Stop()
 
 	for {
-		_ = s.conn.SetReadDeadline(deadline)
+		var data []byte
 
-		_, data, err := s.conn.ReadMessage()
+		select {
+		case frame, open := <-s.frames:
+			if !open {
+				return fmt.Errorf("await ack for %s: %w", route, s.readLoopErr())
+			}
+
+			data = frame
+		case <-timer.C:
+			// The connection stays usable: no read deadline was ever set,
+			// so nothing has been poisoned and a later step can still run.
+			return fmt.Errorf("await ack for %s: %w", route, context.DeadlineExceeded)
+		case <-ctx.Done():
+			return fmt.Errorf("await ack for %s: %w", route, ctx.Err())
+		}
+
+		done, err := s.classifyFrame(data, route, id)
 		if err != nil {
-			return fmt.Errorf("await ack for %s: %w", route, err)
+			return err
 		}
 
-		text := string(data)
-
-		// Pushed event frames during setup (sourcesUpdated etc.) and the
-		// SDK banner are not acks.
-		if strings.Contains(text, "<updates ") || strings.Contains(text, "<SoundTouchSdkInfo") {
-			continue
-		}
-
-		// Device-side errors surface as <error …/> in the body.
-		if strings.Contains(strings.ToLower(text), "<error") {
-			return fmt.Errorf("device rejected %s: %s", route, strings.TrimSpace(text))
-		}
-
-		if strings.Contains(text, idNeedle) || strings.Contains(text, statusNeedle) || strings.Contains(text, urlNeedle) {
+		if done {
 			return nil
 		}
 	}
+}
+
+// readLoopErr reports why the read loop ended, or a generic closure error if
+// it ended without one.
+func (s *Session) readLoopErr() error {
+	if err := s.readErr.Load(); err != nil && *err != nil {
+		return *err
+	}
+
+	return errors.New("connection closed")
+}
+
+// classifyFrame decides what a received frame means for the step identified by
+// route and id. It returns (true, nil) for this step's ack, (false, nil) for a
+// frame to skip, and a non-nil error when the device rejected the step.
+func (s *Session) classifyFrame(data []byte, route string, id int64) (bool, error) {
+	root, err := models.RootElementName(data)
+	if err != nil {
+		// Undecodable frames are not acks. Skipping keeps the step waiting
+		// for a real answer rather than failing on a truncated push.
+		s.logf("setup session: skipping undecodable frame during %s: %v", route, sanitizeLog(err.Error()))
+
+		return false, nil
+	}
+
+	switch root {
+	case "msg":
+		return s.classifyEnvelope(data, route, id)
+
+	case "status":
+		// A bare <status>/route</status> reply. These carry no requestID at
+		// all, so they can only be correlated by arrival order — acceptable
+		// because a session runs one step at a time.
+		var status struct {
+			Value string `xml:",chardata"`
+		}
+
+		if err := xml.Unmarshal(data, &status); err != nil {
+			// Not our ack, but not a rejection either: keep waiting for a
+			// frame we can actually read.
+			s.logf("setup session: skipping undecodable status frame during %s: %v", route, sanitizeLog(err.Error()))
+
+			return false, nil
+		}
+
+		return strings.TrimSpace(status.Value) == "/"+route, nil
+
+	case "error", "errors":
+		// A rejection sent unwrapped, rather than inside an envelope.
+		return false, fmt.Errorf("device rejected %s: %s", route, sanitizeLog(strings.TrimSpace(string(data))))
+
+	case "errorUpdate":
+		// An asynchronous device error, NOT a reply to this step. Report it
+		// — these name the failure precisely and are worth seeing — but keep
+		// waiting for the actual ack.
+		s.logDeviceError(data, route)
+
+		return false, nil
+
+	default:
+		// Pushed frames: <updates>, <SoundTouchSdkInfo>, userActivityUpdate,
+		// and anything the firmware invents later.
+		return false, nil
+	}
+}
+
+// classifyEnvelope handles a <msg> frame: this step's ack, another step's
+// late response, or a rejection.
+func (s *Session) classifyEnvelope(data []byte, route string, id int64) (bool, error) {
+	var envelope struct {
+		Header struct {
+			URL string `xml:"url,attr"`
+			// Real hardware answers with <request requestID="…"
+			// msgType="RESPONSE">; the shape below also picks up a
+			// <response requestID="…"/> child. Matching the attribute
+			// wherever it appears avoids pinning either spelling.
+			Request  *envelopeRequest `xml:"request"`
+			Response *envelopeRequest `xml:"response"`
+		} `xml:"header"`
+		Body struct {
+			Error  *models.Error  `xml:"error"`
+			Errors []models.Error `xml:"errors>error"`
+			Status string         `xml:"status"`
+		} `xml:"body"`
+	}
+
+	if err := xml.Unmarshal(data, &envelope); err != nil {
+		s.logf("setup session: skipping undecodable envelope during %s: %v", route, sanitizeLog(err.Error()))
+
+		return false, nil
+	}
+
+	request := envelope.Header.Request
+	if request == nil || request.RequestID == "" {
+		request = envelope.Header.Response
+	}
+
+	requestID := ""
+	if request != nil {
+		requestID = request.RequestID
+	}
+
+	// A response that names a different requestID belongs to another step —
+	// including its errors. Attributing those to the step in flight would
+	// reintroduce, on the error path, exactly the cross-step misattribution
+	// this function exists to prevent.
+	if requestID != "" && requestID != strconv.FormatInt(id, 10) {
+		return false, nil
+	}
+
+	// Rejections arrive either as a bare <error> or wrapped in <errors>
+	// (models.ErrorsResponse's shape, which some firmware versions use).
+	if devErr := firstError(&envelope.Body.Error, envelope.Body.Errors); devErr != nil {
+		return false, fmt.Errorf("device rejected %s: %s", route, describeError(devErr))
+	}
+
+	if requestID != "" {
+		// An empty msgType is accepted because not every reply shape carries
+		// one; anything else that is not a RESPONSE is not an answer to us.
+		return request.MsgType == "" || request.MsgType == msgTypeResponse, nil
+	}
+
+	// No requestID to correlate on. Fall back to the route, but only while
+	// this session has used it once: five of the nine init-plan steps share
+	// url="setup", and accepting a route match there is what let a late
+	// response to step N satisfy step N+1 (GH-704). For a route used once,
+	// a match is unambiguous and the fallback costs nothing.
+	if s.routeUses[route] > 1 {
+		return false, nil
+	}
+
+	return envelope.Header.URL == route ||
+		strings.TrimSpace(envelope.Body.Status) == "/"+route, nil
+}
+
+// firstError picks the first device error out of either body shape.
+func firstError(single **models.Error, wrapped []models.Error) *models.Error {
+	if *single != nil {
+		return *single
+	}
+
+	if len(wrapped) > 0 {
+		return &wrapped[0]
+	}
+
+	return nil
+}
+
+// msgTypeResponse is the msgType attribute a speaker sets on a reply.
+const msgTypeResponse = "RESPONSE"
+
+// describeError renders a device error for an operator: code, symbolic name,
+// severity and detail, rather than a raw XML dump.
+func describeError(devErr *models.Error) string {
+	parts := make([]string, 0, 4)
+
+	if devErr.Name != "" {
+		parts = append(parts, devErr.Name)
+	}
+
+	if devErr.Value != "" {
+		parts = append(parts, "code "+devErr.Value)
+	}
+
+	if devErr.Severity != "" {
+		parts = append(parts, "severity "+devErr.Severity)
+	}
+
+	if text := strings.TrimSpace(devErr.Text); text != "" {
+		parts = append(parts, text)
+	}
+
+	if len(parts) == 0 {
+		return "unspecified error"
+	}
+
+	// Speaker-supplied text reaches logs through this error; strip newlines
+	// so a device cannot forge log lines (go/log-injection).
+	return sanitizeLog(strings.Join(parts, ", "))
+}
+
+// envelopeRequest models the requestID-bearing child of a <msg> header,
+// whichever tag name the firmware or a test fake uses for it.
+type envelopeRequest struct {
+	RequestID string `xml:"requestID,attr"`
+	MsgType   string `xml:"msgType,attr"`
+}
+
+// logDeviceError surfaces an asynchronous <errorUpdate> pushed while a step is
+// in flight, so it is not silently dropped.
+func (s *Session) logDeviceError(data []byte, route string) {
+	var update models.ErrorUpdate
+	if err := xml.Unmarshal(data, &update); err != nil {
+		s.logf("setup session: device error during %s (unparsed): %s", route, sanitizeLog(strings.TrimSpace(string(data))))
+
+		return
+	}
+
+	s.logf("setup session: device error during %s: %s (%s) severity=%s: %s",
+		route,
+		sanitizeLog(update.Error.Name),
+		sanitizeLog(update.Error.Value),
+		sanitizeLog(update.Error.Severity),
+		sanitizeLog(strings.TrimSpace(update.Error.Text)),
+	)
 }
 
 // Start sends SETUP_START.

--- a/pkg/service/setup/setup_session_test.go
+++ b/pkg/service/setup/setup_session_test.go
@@ -266,6 +266,37 @@ func TestSession_SurfacesDeviceErrors(t *testing.T) {
 	if !strings.Contains(err.Error(), "device rejected setMargeAccount") {
 		t.Errorf("err = %v, want to mention device rejection", err)
 	}
+
+	// The message names the failure rather than dumping raw XML.
+	for _, want := range []string{"ACCOUNT_REJECTED", "code 1003"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// TestSession_IgnoresNonResponseEnvelope pins the msgType guard: a <msg>
+// frame that echoes our requestID but is not marked as a response is not an
+// ack.
+func TestSession_IgnoresNonResponseEnvelope(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(frame string) []string {
+		id := extractAttr(frame, `requestID="`, `"`)
+
+		return []string{
+			fmt.Sprintf(`<msg><header deviceID="X" url="setup" method="POST">`+
+				`<request requestID="%s" msgType="REQUEST"/></header><body/></msg>`, id),
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("a non-RESPONSE envelope must not be accepted as an ack")
+	}
 }
 
 func TestSession_RejectsEmptyDeviceID(t *testing.T) {
@@ -385,5 +416,320 @@ func mustContain(t *testing.T, s string, needles ...string) {
 		if !strings.Contains(s, n) {
 			t.Errorf("frame missing %q in: %s", n, s)
 		}
+	}
+}
+
+// TestSession_IgnoresAsyncErrorUpdateFrames is the regression for GH-704 (1).
+//
+// The speaker pushes device errors as a root-level <errorUpdate> frame, which
+// has nothing to do with the step in flight. The old classifier tested for the
+// substring "<error" after skipping <updates> and <SoundTouchSdkInfo>, and
+// "<errorupdate" contains "<error" — so an unrelated source timeout aborted
+// the whole init plan with "device rejected setup".
+func TestSession_IgnoresAsyncErrorUpdateFrames(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(frame string) []string {
+		id := extractAttr(frame, `requestID="`, `"`)
+
+		return []string{
+			`<errorUpdate deviceID="DEVICEID01">` +
+				`<error value="1654" name="STORED_MUSIC_AP_TIMEOUT" severity="Unrecoverable">APServer: Timeout</error>` +
+				`</errorUpdate>`,
+			ackWithID(id),
+		}
+	}
+
+	s := dialFakeSession(t, f, "DEVICEID01")
+
+	var logged []string
+
+	s.logf = func(format string, args ...any) { logged = append(logged, fmt.Sprintf(format, args...)) }
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start must ignore an unrelated errorUpdate, got %v", err)
+	}
+
+	// The frame is skipped, not discarded: it names the failure precisely and
+	// is worth seeing in the log.
+	if !strings.Contains(strings.Join(logged, "\n"), "STORED_MUSIC_AP_TIMEOUT") {
+		t.Errorf("device error was not logged; got %v", logged)
+	}
+}
+
+// TestSession_RejectsStaleAckForSameRoute is the regression for GH-704 (2).
+//
+// Five of the nine init-plan steps use url="setup". Ack matching used to be
+// `requestID || <status>/route || url="route"`, so a late response to step N
+// satisfied the url needle while step N+1 was waiting and was accepted as
+// N+1's ack. Correlation is now exact for enveloped replies.
+func TestSession_RejectsStaleAckForSameRoute(t *testing.T) {
+	f := newFakeSpeaker(t)
+
+	var stepCount int
+
+	f.reply = func(frame string) []string {
+		stepCount++
+		if stepCount == 1 {
+			return []string{ackWithID(extractAttr(frame, `requestID="`, `"`))}
+		}
+
+		// Step 2 gets NO genuine ack — only a late reply carrying step 1's
+		// requestID and one carrying an unrelated requestID. Both are
+		// url="setup" frames, so the old url-needle match accepted the
+		// first of them and the step wrongly succeeded.
+		return []string{
+			ackWithID("1"),
+			`<msg><header deviceID="X" url="setup" method="POST">` +
+				`<request requestID="99" msgType="RESPONSE"/></header><body/></msg>`,
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	err := s.Enter(ctx)
+	if err == nil {
+		t.Fatal("Enter accepted another step's response as its ack")
+	}
+
+	if !strings.Contains(err.Error(), "await ack for setup") {
+		t.Errorf("err = %v, want a timeout awaiting the real ack", err)
+	}
+}
+
+// TestSession_AcceptsBareStatusAck pins that a bare <status>/route</status>
+// reply — the shape documented for pushCustomerSupportInfoToMarge and
+// selectLastWiFiSource — is still accepted. These frames carry no requestID,
+// so they can only be correlated by arrival order.
+func TestSession_AcceptsBareStatusAck(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(string) []string {
+		return []string{
+			`<status>/someOtherRoute</status>`,
+			`<?xml version="1.0" encoding="UTF-8" ?><status>/pushCustomerSupportInfoToMarge</status>`,
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	if err := s.PushCustomerSupportInfo(context.Background()); err != nil {
+		t.Fatalf("PushCustomerSupportInfo: %v", err)
+	}
+}
+
+// TestSession_SurvivesStepTimeout is the regression for GH-704 (3).
+//
+// sendStep used to set a per-step read deadline on a long-lived connection.
+// gorilla/websocket treats any read error as fatal — a deadline expiry
+// included — and returns it instantly from every later read, so one timed-out
+// step made every subsequent step fail immediately with "i/o timeout", which
+// reads exactly like the device refusing.
+func TestSession_SurvivesStepTimeout(t *testing.T) {
+	f := newFakeSpeaker(t)
+
+	var stepCount int
+
+	f.reply = func(frame string) []string {
+		stepCount++
+		if stepCount == 1 {
+			return nil // silence: this step must time out
+		}
+
+		return []string{ackWithID(extractAttr(frame, `requestID="`, `"`))}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	if err := s.Start(ctx); err == nil {
+		t.Fatal("expected the first step to time out")
+	}
+
+	// The connection must still be usable.
+	if err := s.Enter(context.Background()); err != nil {
+		t.Fatalf("step after a timeout must still work, got %v", err)
+	}
+}
+
+// TestSession_ReportsClosedConnection pins that a step waiting on a dead
+// connection reports the read error rather than hanging or reporting a
+// closed channel.
+func TestSession_ReportsClosedConnection(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(string) []string { return nil }
+
+	s := dialFakeSession(t, f, "X")
+
+	// Drop the server side out from under the session.
+	f.server.CloseClientConnections()
+
+	err := s.Start(context.Background())
+	if err == nil {
+		t.Fatal("expected an error once the connection is gone")
+	}
+
+	if !strings.Contains(err.Error(), "await ack for setup") {
+		t.Errorf("err = %v, want it to name the step being awaited", err)
+	}
+}
+
+// ackWithID builds an ack in the shape real hardware uses: the requestID
+// echoed on <request> together with msgType="RESPONSE".
+func ackWithID(id string) string {
+	return fmt.Sprintf(
+		`<msg><header deviceID="X" url="setup" method="POST">`+
+			`<request requestID="%s" msgType="RESPONSE"><info type="new"/></request>`+
+			`</header><body><status>ok</status></body></msg>`, id)
+}
+
+// TestSession_SurfacesWrappedDeviceErrors covers the <errors> wrapper shape
+// that some firmware versions use (models.ErrorsResponse). Matching only a
+// direct <error> child of <body> would let the rejection through as an
+// uncorrelated frame, turning a clear refusal into a step timeout.
+func TestSession_SurfacesWrappedDeviceErrors(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(frame string) []string {
+		id := extractAttr(frame, `requestID="`, `"`)
+
+		return []string{fmt.Sprintf(
+			`<msg><header deviceID="X" url="setMargeAccount" method="POST">`+
+				`<request requestID="%s" msgType="RESPONSE"/></header>`+
+				`<body><errors deviceID="X">`+
+				`<error value="1003" name="ACCOUNT_REJECTED" severity="Unrecoverable">no</error>`+
+				`</errors></body></msg>`, id)}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := s.SetMargeAccount(ctx, "1234567", "")
+	if err == nil {
+		t.Fatal("expected an error from an <errors>-wrapped rejection")
+	}
+
+	for _, want := range []string{"device rejected setMargeAccount", "ACCOUNT_REJECTED", "code 1003"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// TestSession_IgnoresOtherStepsErrors pins that a late error response to an
+// earlier step does not abort the step in flight. Without the requestID gate
+// this would be the same cross-step misattribution as
+// TestSession_RejectsStaleAckForSameRoute, just on the error path.
+func TestSession_IgnoresOtherStepsErrors(t *testing.T) {
+	f := newFakeSpeaker(t)
+
+	var stepCount int
+
+	f.reply = func(frame string) []string {
+		stepCount++
+
+		id := extractAttr(frame, `requestID="`, `"`)
+		if stepCount == 1 {
+			return []string{ackWithID(id)}
+		}
+
+		return []string{
+			// A rejection carrying step 1's requestID, then our real ack.
+			`<msg><header deviceID="X" url="setup" method="POST">` +
+				`<request requestID="1" msgType="RESPONSE"/></header>` +
+				`<body><error value="1003" name="ACCOUNT_REJECTED">no</error></body></msg>`,
+			ackWithID(id),
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+	ctx := context.Background()
+
+	if err := s.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	if err := s.Enter(ctx); err != nil {
+		t.Fatalf("Enter must ignore another step's error response, got %v", err)
+	}
+}
+
+// TestSession_AcceptsRouteMatchForUniqueRoute pins the fallback for a reply
+// that carries no requestID at all. It is allowed only while a route has been
+// used once: unique routes (language, name, setMargeAccount, telemetry) cannot
+// cross-talk, whereas url="setup" is shared by five steps and must not match
+// on the route alone.
+func TestSession_AcceptsRouteMatchForUniqueRoute(t *testing.T) {
+	f := newFakeSpeaker(t)
+	f.reply = func(string) []string {
+		return []string{
+			`<msg><header deviceID="X" url="name" method="POST"/>` +
+				`<body><status>/name</status></body></msg>`,
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := s.SetName(ctx, "Kitchen"); err != nil {
+		t.Fatalf("SetName: %v", err)
+	}
+}
+
+// TestSession_RouteMatchIsRefusedForRepeatedRoute is the other half: once a
+// route has been used twice, an uncorrelated reply naming it is not enough.
+func TestSession_RouteMatchIsRefusedForRepeatedRoute(t *testing.T) {
+	f := newFakeSpeaker(t)
+
+	var stepCount int
+
+	f.reply = func(frame string) []string {
+		stepCount++
+		if stepCount == 1 {
+			return []string{ackWithID(extractAttr(frame, `requestID="`, `"`))}
+		}
+
+		return []string{
+			`<msg><header deviceID="X" url="setup" method="POST"/>` +
+				`<body><status>/setup</status></body></msg>`,
+		}
+	}
+
+	s := dialFakeSession(t, f, "X")
+
+	if err := s.Start(context.Background()); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	if err := s.Enter(ctx); err == nil {
+		t.Fatal("an uncorrelated url=\"setup\" reply must not ack the second setup step")
+	}
+}
+
+// TestSession_CloseIsIdempotent guards the reader-goroutine teardown: closing
+// the done channel twice would panic.
+func TestSession_CloseIsIdempotent(t *testing.T) {
+	f := newFakeSpeaker(t)
+	s := dialFakeSession(t, f, "X")
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+
+	if err := s.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
 	}
 }

--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -554,11 +554,25 @@ func (app *WebApp) ConnectDeviceWebSocket(deviceID string, conn *webtypes.Device
 				return
 			}
 
-			app.applyConnectionStateEvent(conn, event.ConnectionState.IsConnected())
+			app.applyConnectionStateEvent(conn, event.IsConnected())
 			conn.ApplySpeakerConnectionEvent(webtypes.SpeakerConnectionState{
-				State:  event.ConnectionState.State,
-				Signal: event.ConnectionState.Signal,
+				State:  event.State,
+				Up:     event.Up,
+				Signal: event.Signal,
 			}, time.Now())
+		})
+
+		// Device errors are the speaker's own diagnosis of a failure —
+		// code, symbolic name, severity. Logging them costs nothing and is
+		// exactly the evidence issue reports keep lacking (GH-701).
+		wsClient.OnDeviceError(func(event *models.ErrorUpdate) {
+			log.Printf("Speaker %s reported error %s (%s) severity=%s: %s",
+				sanitizeLog(deviceID),
+				sanitizeLog(event.Error.Name),
+				sanitizeLog(event.Error.Value),
+				sanitizeLog(event.Error.Severity),
+				sanitizeLog(strings.TrimSpace(event.Error.Text)),
+			)
 		})
 
 		wsClient.OnPresetUpdated(func(event *models.PresetUpdatedEvent) {

--- a/pkg/service/soundtouchweb/webtypes/speaker_connection_test.go
+++ b/pkg/service/soundtouchweb/webtypes/speaker_connection_test.go
@@ -1,0 +1,88 @@
+package webtypes
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+// TestApplySpeakerConnectionEvent classifies the frames a real speaker sends.
+//
+// Before GH-701 the switch compared State against a bare "CONNECTED", which no
+// captured frame carries — so every real event fell through to "unknown" and
+// the speaker-reported state was never usable. Up is now the only positive
+// evidence, which also keeps this in step with
+// models.ConnectionStateUpdatedEvent.IsConnected: the same event feeds both.
+func TestApplySpeakerConnectionEvent(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         SpeakerConnectionState
+		wantKnown     bool
+		wantConnected bool
+	}{
+		{
+			name:          "captured wifi-connected frame",
+			state:         SpeakerConnectionState{State: "NETWORK_WIFI_CONNECTED", Up: true, Signal: "EXCELLENT_SIGNAL"},
+			wantKnown:     true,
+			wantConnected: true,
+		},
+		{
+			name:          "wifi disconnected",
+			state:         SpeakerConnectionState{State: "NETWORK_WIFI_DISCONNECTED", Up: false},
+			wantKnown:     true,
+			wantConnected: false,
+		},
+		{
+			// up wins over a state string that claims otherwise. Accepting
+			// the state here would contradict IsConnected() on the very same
+			// event and hold the device out of the offline path.
+			name:          "up=false outranks a CONNECTED state name",
+			state:         SpeakerConnectionState{State: "NETWORK_WIFI_CONNECTED", Up: false},
+			wantKnown:     false,
+			wantConnected: false,
+		},
+		{
+			name:          "no usable evidence",
+			state:         SpeakerConnectionState{State: "", Up: false},
+			wantKnown:     false,
+			wantConnected: false,
+		},
+		{
+			name:          "bare CONNECTED with up set",
+			state:         SpeakerConnectionState{State: string(models.ConnectionStateConnected), Up: true},
+			wantKnown:     true,
+			wantConnected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			conn := NewDeviceConnection(nil, &models.DeviceInfo{DeviceID: "DEVICEID01"})
+
+			conn.ApplySpeakerConnectionEvent(tt.state, time.Now())
+
+			conn.healthMu.Lock()
+			gotKnown := conn.speakerConnectionKnown
+			gotConnected := conn.speakerConnectionConnected
+			conn.healthMu.Unlock()
+
+			if gotKnown != tt.wantKnown {
+				t.Errorf("speakerConnectionKnown = %v, want %v", gotKnown, tt.wantKnown)
+			}
+
+			if gotConnected != tt.wantConnected {
+				t.Errorf("speakerConnectionConnected = %v, want %v", gotConnected, tt.wantConnected)
+			}
+
+			reported := conn.Status().SpeakerConnectionState
+			if reported == nil {
+				t.Fatal("SpeakerConnectionState not surfaced on the status")
+			}
+
+			if reported.Up != tt.state.Up || reported.State != tt.state.State {
+				t.Errorf("reported = %+v, want %+v", reported, tt.state)
+			}
+		})
+	}
+}

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -171,8 +171,14 @@ const (
 const staleSourcesFailureThreshold = 2
 
 // SpeakerConnectionState is the network state reported by the speaker.
+//
+// Up is the speaker's own boolean for "the link is up". State is the
+// transport-qualified name it ships alongside ("NETWORK_WIFI_CONNECTED"), kept
+// for display only — it is not a value worth matching on, see
+// ApplySpeakerConnectionEvent.
 type SpeakerConnectionState struct {
 	State  string `json:"state"`
+	Up     bool   `json:"up"`
 	Signal string `json:"signal,omitempty"`
 }
 
@@ -606,11 +612,21 @@ func (c *DeviceConnection) ApplySpeakerConnectionEvent(state SpeakerConnectionSt
 	c.markEventStreamActivityLocked(at)
 	c.speakerConnectionObserved = at
 
-	switch strings.ToUpper(strings.TrimSpace(state.State)) {
-	case string(models.ConnectionStateConnected):
+	// Up is the only positive evidence accepted, matching
+	// models.ConnectionStateUpdatedEvent.IsConnected — the two must agree,
+	// because websocket.go feeds the same event to both.
+	//
+	// Matching on State used to be the only test here, and it fell to the
+	// default branch for every real frame: speakers report
+	// "NETWORK_WIFI_CONNECTED", never a bare "CONNECTED" (GH-701). State is
+	// now consulted only to tell a confirmed disconnect apart from "we
+	// cannot tell" — deliberately with no symmetric CONNECTED case, since
+	// reaching it would mean the state string claims a link that up denies.
+	switch upper := strings.ToUpper(strings.TrimSpace(state.State)); {
+	case state.Up:
 		c.speakerConnectionKnown = true
 		c.speakerConnectionConnected = true
-	case string(models.ConnectionStateDisconnected):
+	case strings.HasSuffix(upper, string(models.ConnectionStateDisconnected)):
 		c.speakerConnectionKnown = true
 		c.speakerConnectionConnected = false
 	default:


### PR DESCRIPTION
Fixes two WebSocket bugs found while capturing frames from a SoundTouch 10 (`variant=rhino`, `moduleType=sm2`, FW 27.0.6). Neither shape is in Bose's published Web API document, whose notification chapter is demonstrably incomplete for this firmware.

Closes [issue 701](https://github.com/gesellix/Bose-SoundTouch/issues/701) and [issue 704](https://github.com/gesellix/Bose-SoundTouch/issues/704) once confirmed on hardware.

## [701](https://github.com/gesellix/Bose-SoundTouch/issues/701) — `errorUpdate` was never parsed, `connectionStateUpdated` was modelled wrong

The speaker reports its own errors as a **root-level** frame:

```xml
<errorUpdate deviceID="DEVICEID01">
  <error value="1654" name="STORED_MUSIC_AP_TIMEOUT"
         severity="Unrecoverable">APServer: Timeout</error>
</errorUpdate>
```

We modelled `errorUpdated` (past tense, inside `<updates>`), which no capture has ever contained, so every device-side error arrived as `unknown special message type` and was visible only in the raw debug log. These frames name the failure precisely — code, symbolic name, severity — which is exactly the evidence playback bug reports keep lacking.

Adds `models.ErrorUpdate`, a `severity` attribute on `models.Error`, a typed `OnDeviceError` handler (`OnSpecialMessage` stays the catch-all), a `soundtouch-cli events subscribe --filter errors` printer, and a log line in the service's per-device subscriber.

`connectionStateUpdated` puts everything in attributes on the element itself:

```xml
<connectionStateUpdated state="NETWORK_WIFI_CONNECTED" up="true" signal="EXCELLENT_SIGNAL" />
```

The nested `<connectionState>` child we expected never appears, so `State` and `Signal` were always empty (the CLI printed a bare `State:` line) and `up` was not modelled at all. Flattened onto the event; `IsConnected()` reads `up`, because the device sends transport-qualified state names that never equal the bare `CONNECTED` constant.

**Three further bugs found from the same root cause:**

- `ApplySpeakerConnectionEvent` compared `State` against `CONNECTED`/`DISCONNECTED`, so every real frame fell to the default branch and left `speakerConnectionKnown` false. The web UI has never had usable speaker-reported connection state.
- The CLI handled `userInactivity` in `handleSpecialMessage` but its filter parser rejected it, so `--filter userInactivity` always exited with "Invalid filter".
- `handleUnknownEvent` printed `❓ Unknown Event / 📱 Event count: 0` for an `<updates>` child we do not model — an announcement that something arrived with no hint what. It listed `GetEventTypes()`, empty by definition for an unmodelled child, while `models.UnknownEventNames()` (which exists for exactly this) was only ever called by the client's fallback log — a branch that registering an `OnUnknownEvent` handler opts out of. It now names the element, e.g. `nowSelectionUpdated`.

## [704](https://github.com/gesellix/Bose-SoundTouch/issues/704) — `sendStep` pattern-matched raw frame text

1. **An unrelated `errorUpdate` aborted the whole init plan.** The loop skipped `<updates ` and `<SoundTouchSdkInfo`, then treated anything containing `<error` as a rejection — and `"<errorupdate"` contains `"<error"`. An asynchronous device event with nothing to do with the step in flight was reported as `device rejected setup`. These fire on source timeouts and audio-path failures, exactly what can happen while a speaker is being set up. Frames are now classified by root element, so pushed frames are skipped whatever they are and future notification types cost nothing.

2. **The ack could be another step's response.** Matching was `requestID || <status>/route || url="route"`. Five of the nine init-plan steps use `url="setup"`, so a late response to step N satisfied step N+1. Correlation is now exact: an enveloped reply is this step's ack only if it echoes this step's `requestID`, with `msgType` (when present) `RESPONSE`. Rejections are correlated the same way, and are additionally recognised in the `<errors>` wrapper shape that some firmware versions use.

3. **A read timeout poisoned the session.** gorilla/websocket treats any read error as fatal, a `SetReadDeadline` expiry included, and returns it instantly from every later read. After one step timed out, every subsequent step failed immediately with `i/o timeout` — which reads exactly like the device refusing. Reads now happen in a session-owned goroutine with no deadline; the timeout comes from a `select`, which also makes `sendStep` honour context cancellation for the first time.

Not reached here: the general WebSocket request/response helper from [issue 699](https://github.com/gesellix/Bose-SoundTouch/issues/699), which would let `sendStep` become a thin wrapper.

## Documentation

`DEVICE-PAIRING-FLOW.md` showed three replies as bare root elements (`<info …>`, `<status>/pushCustomerSupportInfoToMarge</status>`). All three are wrapped in the standard `<msg>` envelope; the page had elided it. Read literally, it said a client cannot correlate a `setMargeAccount` reply at all — precisely the property this PR depends on.

Verified across three independent mitmproxy captures of the official Bose app (2026-04-16, 2026-05-02 x2) against an ST-10 and an ST-20: every response is enveloped, echoes its `requestID` and carries `msgType="RESPONSE"`. `selectLastWiFiSource` remains the sole exception in both directions.

## Verification

Six new regression tests; each was confirmed to fail without its fix and pass with it. The three from the issues reproduce the reported symptoms verbatim:

```
device rejected setup: <errorUpdate ... STORED_MUSIC_AP_TIMEOUT ...>
Enter accepted another step's response as its ack
step after a timeout must still work, got await ack for setup: ... i/o timeout
```

`make lint` clean, full unit suite and `-race` green.

### Confirmed on hardware

Reproduced on the ST-10 (FW 27.0.6) by selecting a FRITZ!Box `Internetradio / Swissgroove` folder over `STORED_MUSIC`, which buffers and then collapses to `INVALID_SOURCE` after ~21-24 s. Run three times; identical each time.

`main` loses all three errors — they surface only because `--verbose` dumps raw frames:

```
[WebSocket] Unknown special message type: unknown special message type: <errorUpdate …STORED_MUSIC_AP_TIMEOUT…>
[WebSocket] Unknown special message type: unknown special message type: <errorUpdate …AUDIO_ERROR_TIMEOUT…>
[WebSocket] Unknown special message type: unknown special message type: <errorUpdate …AUDIO_ERROR_TIMEOUT…>
```

This branch, same speaker, four minutes later:

```
🚨 Device Error [DEVICEID01]:
  🔢 Code: 1654
  🏷️  Name: STORED_MUSIC_AP_TIMEOUT
  ⚠️  Severity: Unrecoverable
  💬 Detail: APServer: Timeout

🚨 Device Error [DEVICEID01]:
  🔢 Code: 3103   Name: AUDIO_ERROR_TIMEOUT   Severity: Unknown
  💬 Detail: AudioPath error4, reason 1

🚨 Device Error [DEVICEID01]:
  🔢 Code: 3103   Name: AUDIO_ERROR_TIMEOUT   Severity: Unknown
```

All three frames in the captured order, including the third with an empty body, which parses cleanly and simply omits the Detail line.

**Not yet confirmed live:** no `connectionStateUpdated` frame arrived in ~6 minutes of watching, so that half rests on the captures (12 frames across three of them, April to September 2026) rather than a live run — they appear to be signal-change-driven rather than periodic. The `setup pair --mode=full` path also has not been exercised against a factory-reset speaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
