### PR TITLE
fix(player): reconcile discrete command outcomes

### DIFF
--- a/cmd/soundtouch-cli/cmd_playback_capabilities.go
+++ b/cmd/soundtouch-cli/cmd_playback_capabilities.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"text/tabwriter"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/urfave/cli/v2"
+)
+
+// The player has to decide, per source, whether a track skip can be verified
+// at all: it confirms a skip by watching `trackID` change, because track and
+// stationName move on their own while a live stream rewrites its metadata.
+// Sources with no track concept report no trackID, and there nothing can be
+// verified.
+//
+// Which sources report what is a question only hardware answers, and answering
+// it means walking every source on a real speaker. This command exists to make
+// that walk one pass instead of one `play now --verbose` per source and a
+// manual diff: it prints one row per observation and, with --watch, a new row
+// whenever the speaker reports something different, so switching sources on
+// the speaker (or in the app) fills in the matrix as you go.
+//
+// See docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md, "Track skips:
+// what can be verified", for the table these rows are collected into.
+
+// capabilityObservation is one speaker answer, reduced to the fields that
+// decide whether a skip is verifiable.
+type capabilityObservation struct {
+	Source        string
+	SourceAccount string
+	PlayStatus    string
+	StreamType    string
+	TrackID       string
+	Track         string
+	CanSkip       bool
+	CanSkipPrev   bool
+	SeekSupported bool
+}
+
+func observeCapabilities(nowPlaying *models.NowPlaying) capabilityObservation {
+	if nowPlaying == nil {
+		return capabilityObservation{}
+	}
+
+	return capabilityObservation{
+		Source:        nowPlaying.Source,
+		SourceAccount: nowPlaying.SourceAccount,
+		PlayStatus:    nowPlaying.PlayStatus.String(),
+		StreamType:    nowPlaying.StreamType,
+		TrackID:       nowPlaying.TrackID,
+		Track:         nowPlaying.Track,
+		CanSkip:       nowPlaying.CanSkip(),
+		CanSkipPrev:   nowPlaying.CanSkipPrevious(),
+		SeekSupported: nowPlaying.IsSeekSupported(),
+	}
+}
+
+// skipVerdict states, for this observation, what the player can do with a
+// skip command against this source. It is the whole point of the sweep.
+func (o capabilityObservation) skipVerdict() string {
+	switch {
+	case o.Source == "" || o.Source == "STANDBY":
+		return "n/a (nothing playing)"
+	case o.TrackID != "":
+		return "verifiable by trackID"
+	case o.CanSkip || o.CanSkipPrev:
+		return "claims skip, no trackID"
+	default:
+		return "no track concept"
+	}
+}
+
+// reportsSameCapabilities compares only what the matrix records, so a row is
+// not reprinted every poll while a track's elapsed time ticks along. A new
+// trackID is a change: that is what a skip is expected to produce.
+func reportsSameCapabilities(previous, current capabilityObservation) bool {
+	return previous == current
+}
+
+func placeholder(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return "-"
+	}
+
+	return value
+}
+
+func capabilityHeader() []string {
+	return []string{"TIME", "SOURCE", "ACCOUNT", "STATUS", "STREAMTYPE", "TRACKID", "SKIP", "SKIPPREV", "SEEK", "SKIP VERDICT"}
+}
+
+func capabilityRow(observed time.Time, o capabilityObservation) []string {
+	return []string{
+		observed.Format("15:04:05"),
+		placeholder(o.Source),
+		placeholder(o.SourceAccount),
+		placeholder(o.PlayStatus),
+		placeholder(o.StreamType),
+		placeholder(o.TrackID),
+		fmt.Sprintf("%t", o.CanSkip),
+		fmt.Sprintf("%t", o.CanSkipPrev),
+		fmt.Sprintf("%t", o.SeekSupported),
+		o.skipVerdict(),
+	}
+}
+
+// playbackCapabilities polls now-playing and reports the skip-relevant
+// capabilities, once or until the watch window closes.
+func playbackCapabilities(c *cli.Context) error {
+	clientConfig := GetClientConfig(c)
+
+	soundTouchClient, err := CreateSoundTouchClient(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	PrintDeviceHeader("Observing playback capabilities", clientConfig.Host, clientConfig.Port)
+
+	writer := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(writer, strings.Join(capabilityHeader(), "\t"))
+
+	printObservation := func(o capabilityObservation) {
+		fmt.Fprintln(writer, strings.Join(capabilityRow(time.Now(), o), "\t"))
+		_ = writer.Flush()
+	}
+
+	nowPlaying, err := soundTouchClient.GetNowPlaying()
+	if err != nil {
+		return fmt.Errorf("failed to get now playing: %w", err)
+	}
+
+	previous := observeCapabilities(nowPlaying)
+	printObservation(previous)
+
+	if !c.Bool("watch") {
+		return nil
+	}
+
+	interval := c.Duration("interval")
+	duration := c.Duration("duration")
+
+	fmt.Printf("\nWatching every %s. Switch sources on the speaker; a row is printed whenever the report changes.\n", interval)
+
+	if duration > 0 {
+		fmt.Printf("Stopping after %s. Press Ctrl+C to stop sooner.\n\n", duration)
+	} else {
+		fmt.Print("Press Ctrl+C to stop.\n\n")
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	if duration > 0 {
+		var cancel context.CancelFunc
+
+		ctx, cancel = context.WithTimeout(ctx, duration)
+		defer cancel()
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			fmt.Println("\nObservation finished.")
+
+			return nil
+		case <-ticker.C:
+			nowPlaying, err := soundTouchClient.GetNowPlaying()
+			if err != nil {
+				// A speaker that is briefly unreachable is not a reason to
+				// abandon a sweep that may run for minutes.
+				PrintWarning(fmt.Sprintf("readback failed: %v", err))
+
+				continue
+			}
+
+			current := observeCapabilities(nowPlaying)
+			if reportsSameCapabilities(previous, current) {
+				continue
+			}
+
+			previous = current
+
+			printObservation(current)
+		}
+	}
+}

--- a/cmd/soundtouch-cli/cmd_playback_capabilities.go
+++ b/cmd/soundtouch-cli/cmd_playback_capabilities.go
@@ -111,6 +111,77 @@ func capabilityRow(observed time.Time, o capabilityObservation) []string {
 	}
 }
 
+// classifySkipProbe reports what a real skip did to the fields a readback
+// could confirm it with. This is the decisive measurement: observing that a
+// source reports a trackID says nothing until a skip has been seen to move it,
+// and a source whose title changes while the trackID stays put is exactly the
+// case that made the player's first confirmation rule wrong.
+func classifySkipProbe(before, after capabilityObservation) string {
+	switch {
+	case before.Source != after.Source:
+		return "source changed during the probe, so nothing can be concluded; rerun while one source stays put"
+	case before.TrackID == "" && after.TrackID == "":
+		return "no trackID before or after: a readback has nothing to verify, so the player settles on the write"
+	case before.TrackID != after.TrackID:
+		return "trackID changed: skips are verifiable on this source"
+	case before.Track != after.Track:
+		return "trackID unchanged while the title changed: the title moves on its own and cannot confirm a skip"
+	default:
+		return "nothing changed within the probe window: either the skip did not land, or this source reports no change for one"
+	}
+}
+
+// probeSkip sends one NEXT_TRACK and reports what changed, polling rather than
+// sleeping once, so a slow source is given its time without making a fast one
+// wait for it.
+func probeSkip(c *cli.Context, soundTouchClient skipProbeClient, before capabilityObservation,
+	report func(capabilityObservation),
+) error {
+	if before.Source == "" || before.Source == "STANDBY" {
+		return fmt.Errorf("nothing is playing, so a skip would measure nothing")
+	}
+
+	fmt.Printf("\nProbing: sending %s and watching what changes. This really does skip a track.\n\n",
+		models.KeyNextTrack)
+
+	if err := soundTouchClient.SendKeyPressOnly(models.KeyNextTrack); err != nil {
+		return fmt.Errorf("failed to send next track command: %w", err)
+	}
+
+	wait := c.Duration("probe-wait")
+	interval := c.Duration("interval")
+	deadline := time.Now().Add(wait)
+	after := before
+
+	for time.Now().Before(deadline) {
+		time.Sleep(interval)
+
+		nowPlaying, err := soundTouchClient.GetNowPlaying()
+		if err != nil {
+			PrintWarning(fmt.Sprintf("readback failed: %v", err))
+
+			continue
+		}
+
+		after = observeCapabilities(nowPlaying)
+		if !reportsSameCapabilities(before, after) {
+			break
+		}
+	}
+
+	report(after)
+
+	fmt.Printf("\nVerdict: %s\n", classifySkipProbe(before, after))
+
+	return nil
+}
+
+// skipProbeClient is the slice of the SoundTouch client a probe needs.
+type skipProbeClient interface {
+	GetNowPlaying() (*models.NowPlaying, error)
+	SendKeyPressOnly(key string) error
+}
+
 // playbackCapabilities polls now-playing and reports the skip-relevant
 // capabilities, once or until the watch window closes.
 func playbackCapabilities(c *cli.Context) error {
@@ -138,6 +209,10 @@ func playbackCapabilities(c *cli.Context) error {
 
 	previous := observeCapabilities(nowPlaying)
 	printObservation(previous)
+
+	if c.Bool("probe-skip") {
+		return probeSkip(c, soundTouchClient, previous, printObservation)
+	}
 
 	if !c.Bool("watch") {
 		return nil

--- a/cmd/soundtouch-cli/cmd_playback_capabilities_test.go
+++ b/cmd/soundtouch-cli/cmd_playback_capabilities_test.go
@@ -119,6 +119,59 @@ func TestReportsSameCapabilitiesDetectsTheChangesThatMatter(t *testing.T) {
 	}
 }
 
+// The probe is the measurement the matrix actually turns on: a trackID is only
+// worth trusting once a real skip has been seen to move it.
+func TestClassifySkipProbe(t *testing.T) {
+	observe := func(source, trackID, track string) capabilityObservation {
+		return observeCapabilities(&models.NowPlaying{Source: source, TrackID: trackID, Track: track})
+	}
+
+	tests := []struct {
+		name          string
+		before, after capabilityObservation
+		want          string
+	}{
+		{
+			name:   "a real skip moves the trackID",
+			before: observe("SPOTIFY", "track:one", "First"),
+			after:  observe("SPOTIFY", "track:two", "Second"),
+			want:   "trackID changed: skips are verifiable on this source",
+		},
+		{
+			name:   "a rolling stream title is not a skip",
+			before: observe("TUNEIN", "station:one", "Song A"),
+			after:  observe("TUNEIN", "station:one", "Song B"),
+			want:   "trackID unchanged while the title changed: the title moves on its own and cannot confirm a skip",
+		},
+		{
+			name:   "a source with no track concept has nothing to verify",
+			before: observe("AUX", "", ""),
+			after:  observe("AUX", "", ""),
+			want:   "no trackID before or after: a readback has nothing to verify, so the player settles on the write",
+		},
+		{
+			name:   "a frozen trackID is reported, not glossed over",
+			before: observe("STORED_MUSIC", "track:one", "First"),
+			after:  observe("STORED_MUSIC", "track:one", "First"),
+			want:   "nothing changed within the probe window: either the skip did not land, or this source reports no change for one",
+		},
+		{
+			name:   "a source change invalidates the probe",
+			before: observe("SPOTIFY", "track:one", "First"),
+			after:  observe("AUX", "", ""),
+			want:   "source changed during the probe, so nothing can be concluded; rerun while one source stays put",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := classifySkipProbe(test.before, test.after); got != test.want {
+				t.Errorf("classifySkipProbe() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestCapabilityRowFillsEveryColumn(t *testing.T) {
 	observed := time.Date(2026, 9, 12, 14, 30, 15, 0, time.UTC)
 	row := capabilityRow(observed, observeCapabilities(&models.NowPlaying{

--- a/cmd/soundtouch-cli/cmd_playback_capabilities_test.go
+++ b/cmd/soundtouch-cli/cmd_playback_capabilities_test.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+// The two fixtures under pkg/client/testdata and pkg/service/setup/testdata are
+// the only captured now-playing responses in the tree, both Spotify, and both
+// carry skipEnabled and a trackID. The radio and physical-input cases below are
+// what the sweep is meant to confirm or refute on hardware, so they are written
+// as the shapes the matrix expects, not as measurements.
+func TestSkipVerdictClassifiesSources(t *testing.T) {
+	tests := []struct {
+		name       string
+		nowPlaying *models.NowPlaying
+		want       string
+	}{
+		{
+			name: "track source with a trackID is verifiable",
+			nowPlaying: &models.NowPlaying{
+				Source:      "SPOTIFY",
+				TrackID:     "spotify:track:3LX0dk3YT8cUgp7XxUJgTB",
+				SkipEnabled: &models.SkipEnabled{},
+			},
+			want: "verifiable by trackID",
+		},
+		{
+			name: "source claiming skip without a trackID cannot be verified",
+			nowPlaying: &models.NowPlaying{
+				Source:      "TUNEIN",
+				SkipEnabled: &models.SkipEnabled{},
+			},
+			want: "claims skip, no trackID",
+		},
+		{
+			name:       "source with no track concept",
+			nowPlaying: &models.NowPlaying{Source: "AUX"},
+			want:       "no track concept",
+		},
+		{
+			name:       "standby has nothing to say",
+			nowPlaying: &models.NowPlaying{Source: "STANDBY"},
+			want:       "n/a (nothing playing)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := observeCapabilities(test.nowPlaying).skipVerdict(); got != test.want {
+				t.Errorf("skipVerdict() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+// A sweep is useless if it reprints the same source every poll, and equally
+// useless if it misses the change a skip produces.
+func TestReportsSameCapabilitiesDetectsTheChangesThatMatter(t *testing.T) {
+	base := observeCapabilities(&models.NowPlaying{
+		Source:      "SPOTIFY",
+		TrackID:     "spotify:track:one",
+		Track:       "First track",
+		SkipEnabled: &models.SkipEnabled{},
+	})
+
+	tests := []struct {
+		name    string
+		current *models.NowPlaying
+		same    bool
+	}{
+		{
+			name: "same track reported again",
+			current: &models.NowPlaying{
+				Source:      "SPOTIFY",
+				TrackID:     "spotify:track:one",
+				Track:       "First track",
+				SkipEnabled: &models.SkipEnabled{},
+			},
+			same: true,
+		},
+		{
+			name: "a skip changes the trackID",
+			current: &models.NowPlaying{
+				Source:      "SPOTIFY",
+				TrackID:     "spotify:track:two",
+				Track:       "Second track",
+				SkipEnabled: &models.SkipEnabled{},
+			},
+			same: false,
+		},
+		{
+			name: "switching source changes everything",
+			current: &models.NowPlaying{
+				Source: "AUX",
+			},
+			same: false,
+		},
+		{
+			name: "a stream rewriting only its title is still a new row",
+			current: &models.NowPlaying{
+				Source:      "SPOTIFY",
+				TrackID:     "spotify:track:one",
+				Track:       "Rolling title",
+				SkipEnabled: &models.SkipEnabled{},
+			},
+			same: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := reportsSameCapabilities(base, observeCapabilities(test.current)); got != test.same {
+				t.Errorf("reportsSameCapabilities() = %t, want %t", got, test.same)
+			}
+		})
+	}
+}
+
+func TestCapabilityRowFillsEveryColumn(t *testing.T) {
+	observed := time.Date(2026, 9, 12, 14, 30, 15, 0, time.UTC)
+	row := capabilityRow(observed, observeCapabilities(&models.NowPlaying{
+		Source:              "LOCAL_INTERNET_RADIO",
+		PlayStatus:          models.PlayStatusPlaying,
+		StreamType:          "RADIO_STREAMING",
+		SkipPreviousEnabled: &models.SkipPreviousEnabled{},
+	}))
+
+	if len(row) != len(capabilityHeader()) {
+		t.Fatalf("row has %d columns, header has %d", len(row), len(capabilityHeader()))
+	}
+
+	// Empty fields must not collapse the columns of a tab-separated row.
+	for i, cell := range row {
+		if cell == "" {
+			t.Errorf("column %q is empty, want a placeholder", capabilityHeader()[i])
+		}
+	}
+
+	if row[0] != "14:30:15" {
+		t.Errorf("time column = %q, want %q", row[0], "14:30:15")
+	}
+
+	if row[5] != "-" {
+		t.Errorf("trackID column = %q, want the %q placeholder", row[5], "-")
+	}
+}

--- a/cmd/soundtouch-cli/main.go
+++ b/cmd/soundtouch-cli/main.go
@@ -304,6 +304,28 @@ func main() {
 						},
 					},
 					{
+						Name:   "capabilities",
+						Usage:  "Report what the current source says about skipping (trackID, skipEnabled, seek)",
+						Action: playbackCapabilities,
+						Before: RequireHost,
+						Flags: []cli.Flag{
+							&cli.BoolFlag{
+								Name:    "watch",
+								Aliases: []string{"w"},
+								Usage:   "Keep polling and print a row whenever the speaker reports something different",
+							},
+							&cli.DurationFlag{
+								Name:  "interval",
+								Value: 2 * time.Second,
+								Usage: "Poll interval while watching",
+							},
+							&cli.DurationFlag{
+								Name:  "duration",
+								Usage: "Stop watching after this long (default: until interrupted)",
+							},
+						},
+					},
+					{
 						Name:   "start",
 						Usage:  "Start playback",
 						Action: playCommand,

--- a/cmd/soundtouch-cli/main.go
+++ b/cmd/soundtouch-cli/main.go
@@ -323,6 +323,15 @@ func main() {
 								Name:  "duration",
 								Usage: "Stop watching after this long (default: until interrupted)",
 							},
+							&cli.BoolFlag{
+								Name:  "probe-skip",
+								Usage: "Send one NEXT_TRACK and report what it changed (this really skips a track)",
+							},
+							&cli.DurationFlag{
+								Name:  "probe-wait",
+								Value: 6 * time.Second,
+								Usage: "How long to watch for a change after the probe's skip",
+							},
 						},
 					},
 					{

--- a/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
+++ b/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
@@ -143,33 +143,63 @@ confirmed. `trackID` is a stable per-track identity (`spotify:track:...` in the
 captured firmware responses), so it stays put through a title rewrite and moves
 on a real skip.
 
-Sources with no track concept report no `trackID` at all. There a readback can
-never say anything, so the player settles the command on a write the speaker
-accepted rather than holding the transport disabled for the whole readback
-window only to report "unverified".
+Not every source reports one. A media library skips perfectly well while
+reporting no `trackID` at all, and there its track metadata is the signal,
+because a library's title changes only when the track really changes. Live
+radio changes its title on its own and can skip nothing, so there no readback
+can ever say anything, and the player settles the command on a write the
+speaker accepted rather than holding the transport disabled for the whole
+readback window only to report "unverified".
 
-| What the speaker reports | Player behaviour             |
-|--------------------------|------------------------------|
-| a `trackID`              | verify the skip against it   |
-| no `trackID`             | settle on the accepted write |
+| What the speaker reports          | Player behaviour                  |
+|-----------------------------------|-----------------------------------|
+| a `trackID`                       | verify the skip against it        |
+| no `trackID`, but `skipEnabled`   | verify against the track metadata |
+| neither                           | settle on the accepted write      |
 
-The firmware also reports `skipEnabled` and `skipPreviousEnabled` on
-now-playing (parsed as `models.CanSkip` / `models.CanSkipPrevious`). The player
-does not use them yet: they say whether a source can skip at all, which is a
-question about whether to *offer* the buttons, not about how to verify a press.
+The middle row is why `skipEnabled` / `skipPreviousEnabled` (parsed as
+`models.CanSkip` / `models.CanSkipPrevious`) matter: a media library changes
+its track title only when the track really changes, and says so by claiming
+skip support, while live radio rewrites its title with the same stream playing
+on and claims no skip support at all. The claim is what tells the two apart,
+and without it a whole source would be unverifiable. The metadata identity is
+`track`, `artist`, `album` and the ContentItem's `location` together.
 
-### The unmeasured part
+The flags are **not** used to enable or disable the skip buttons, deliberately:
+they flap while a source buffers. The same Spotify track reported
+`skipPreviousEnabled` false mid-buffer and true a few seconds later, and
+Spotify reported no `trackID` at all during one buffering window, so buttons
+driven by them would flicker.
 
-The only captured now-playing responses in the tree are Spotify, and both carry
-`skipEnabled`, `skipPreviousEnabled` and a `trackID`. "Sources with no track
-concept report no `trackID`" is therefore reasoned from the model, not measured
-across sources. The failure mode if a source reports a `trackID` that never
-changes across a skip is "unverified", not a false confirmation, which is the
-safe direction to be wrong in.
+### What the hardware reports
 
-Filling this in needs a speaker and two passes. The first collects what each
-source *reports*, by watching while you switch sources on the speaker or in the
-Bose app:
+Measured on a SoundTouch 10 (server version 4) by walking its sources:
+
+| Source                 | `trackID` | `skipEnabled` | `skipPreviousEnabled` | Skip confirmed by  |
+|------------------------|-----------|---------------|-----------------------|--------------------|
+| `SPOTIFY`              | yes       | yes           | yes                   | `trackID`          |
+| `STORED_MUSIC`         | no        | yes           | yes                   | track metadata     |
+| `TUNEIN`               | no        | no            | no                    | nothing: the write |
+| `RADIO_BROWSER`        | no        | no            | no                    | nothing: the write |
+| `AUX`                  | no        | no            | no                    | nothing: the write |
+| `LOCAL_INTERNET_RADIO` | ?         | ?             | ?                     | ?                  |
+| `BLUETOOTH`            | ?         | ?             | ?                     | ?                  |
+
+`STORED_MUSIC` is the case the design turns on: it skips perfectly well and
+says so, but reports no `trackID`, so a trackID-only rule would leave an entire
+source unverifiable. It was measured against this repository's own
+`cmd/example-dlna-server`; another media server may report a `trackID`, and
+nothing guarantees either way. That is why a `trackID` is preferred wherever
+one is present and the metadata path is only the fallback.
+
+The reports are not stable moment to moment. Mid-buffer, the same Spotify track
+reported `skipPreviousEnabled` false and, in a later buffering window, no
+`trackID` at all. The player reads these only at the moment the button is
+pressed, so a press inside such a window simply settles on the write.
+
+Both passes below are worth repeating on other hardware, other firmware and
+other media servers. The first collects what each source *reports*, by watching
+while you switch sources on the speaker or in the Bose app:
 
 ```bash
 soundtouch-cli --host <speaker> play capabilities --watch
@@ -191,26 +221,23 @@ soundtouch-cli --host <speaker> play capabilities --probe-skip
 That really does skip a track: it sends one `NEXT_TRACK`, watches for up to
 `--probe-wait` (6s by default), prints the before and after rows, and states
 whether the `trackID` moved, whether only the title moved, or whether nothing
-changed. Record both passes here:
+changed. Add what you find to the table above.
 
-| Source                 | `trackID` | `skipEnabled` | `skipPreviousEnabled` | Skip moves `trackID` | Skip verifiable |
-|------------------------|-----------|---------------|-----------------------|----------------------|-----------------|
-| `SPOTIFY`              | yes       | yes           | yes                   | ?                    | expected        |
-| `TUNEIN`               | ?         | ?             | ?                     | ?                    | ?               |
-| `RADIO_BROWSER`        | ?         | ?             | ?                     | ?                    | ?               |
-| `LOCAL_INTERNET_RADIO` | ?         | ?             | ?                     | ?                    | ?               |
-| `STORED_MUSIC`         | ?         | ?             | ?                     | ?                    | ?               |
-| `BLUETOOTH`            | ?         | ?             | ?                     | ?                    | ?               |
-| `AUX` / `PRODUCT`      | ?         | ?             | ?                     | ?                    | ?               |
+Still open:
 
-The `SPOTIFY` row's first three columns come from the captured fixtures; its
-probe has not been run either, so "skip verifiable" is an expectation until it
-is.
+- `LOCAL_INTERNET_RADIO` and `BLUETOOTH` have not been observed at all.
+- The probe pass has not been run per source. Reporting a `trackID` is not the
+  same as that `trackID` moving on a skip, and the table's right-hand column is
+  so far an inference from the first pass rather than a measurement.
+- Media servers other than this repository's `cmd/example-dlna-server` may
+  report a `trackID` for `STORED_MUSIC`, which would simply move that source
+  onto the `trackID` path.
 
 Two findings would change the player: a source reporting a `trackID` that does
-not change across a real skip (the readback would have to stop trusting it for
-that source), and a source whose `skipEnabled` is absent while skipping works
-anyway (which would rule out using the flag to hide the buttons).
+not move across a real skip (the readback would have to stop trusting it
+there), and a source that claims `skipEnabled` while rewriting its track
+metadata on its own (that would break the metadata fallback the way the title
+broke the original rule).
 
 ## Ordering: revisions and epochs
 

--- a/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
+++ b/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
@@ -171,6 +171,26 @@ they flap while a source buffers. The same Spotify track reported
 Spotify reported no `trackID` at all during one buffering window, so buttons
 driven by them would flicker.
 
+### Previous-track restarts before it steps back
+
+The first `PREV_TRACK` restarts the track that is playing; only a second press
+moves to the previous one. Measured on a SoundTouch 10 against a media library:
+at position 97s a press left the track and the queue offset untouched and reset
+the position to 0, and a press five seconds later stepped from track 10 to
+track 09. Pressing from a track that has just begun steps back immediately,
+since there is nothing to restart: a walk back through a whole album, each
+press landing at position 0 or 1, moved one track per press from 10 down to 01.
+
+`NEXT_TRACK` has no such rule and always advances.
+
+This matters twice over. It looks like a broken Previous button when a track is
+well under way, and it defeats any confirmation based on identity, because a
+restart changes no track, no `trackID` and no metadata. The player therefore
+also accepts a play position that has moved backwards as a confirmed
+`previous-track`. Nothing about it is specific to a source or a queue position:
+there is no "first track of the queue" border, and an album selected as a
+container keeps every track before the current one available.
+
 ### What the hardware reports
 
 Measured on a SoundTouch 10 (server version 4) by walking its sources:

--- a/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
+++ b/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
@@ -133,6 +133,65 @@ A rejected write is not always proof the command never landed:
   already switched looks identical to one it never received. The readbacks
   keep running and the reason is carried into whatever outcome they reach.
 
+## Track skips: what can be verified
+
+A skip is confirmed by watching *what is playing* change, and picking the wrong
+field gets it wrong in both directions. `track` and `stationName` are the
+obvious candidates and the wrong ones: a live stream rewrites its own title
+while the same stream keeps playing, so a skip that did nothing looks
+confirmed. `trackID` is a stable per-track identity (`spotify:track:...` in the
+captured firmware responses), so it stays put through a title rewrite and moves
+on a real skip.
+
+Sources with no track concept report no `trackID` at all. There a readback can
+never say anything, so the player settles the command on a write the speaker
+accepted rather than holding the transport disabled for the whole readback
+window only to report "unverified".
+
+| What the speaker reports | Player behaviour             |
+|--------------------------|------------------------------|
+| a `trackID`              | verify the skip against it   |
+| no `trackID`             | settle on the accepted write |
+
+The firmware also reports `skipEnabled` and `skipPreviousEnabled` on
+now-playing (parsed as `models.CanSkip` / `models.CanSkipPrevious`). The player
+does not use them yet: they say whether a source can skip at all, which is a
+question about whether to *offer* the buttons, not about how to verify a press.
+
+### The unmeasured part
+
+The only captured now-playing responses in the tree are Spotify, and both carry
+`skipEnabled`, `skipPreviousEnabled` and a `trackID`. "Sources with no track
+concept report no `trackID`" is therefore reasoned from the model, not measured
+across sources. The failure mode if a source reports a `trackID` that never
+changes across a skip is "unverified", not a false confirmation, which is the
+safe direction to be wrong in.
+
+Filling this in needs a speaker and one pass through its sources:
+
+```bash
+soundtouch-cli --host <speaker> play capabilities --watch
+```
+
+It prints one row per observation and a new row whenever the report changes, so
+switching sources on the speaker (or in the Bose app) collects the matrix in a
+single run. Record the results here:
+
+| Source                 | `trackID` | `skipEnabled` | `skipPreviousEnabled` | Skip verifiable |
+|------------------------|-----------|---------------|-----------------------|-----------------|
+| `SPOTIFY`              | yes       | yes           | yes                   | yes (captured)  |
+| `TUNEIN`               | ?         | ?             | ?                     | ?               |
+| `RADIO_BROWSER`        | ?         | ?             | ?                     | ?               |
+| `LOCAL_INTERNET_RADIO` | ?         | ?             | ?                     | ?               |
+| `STORED_MUSIC`         | ?         | ?             | ?                     | ?               |
+| `BLUETOOTH`            | ?         | ?             | ?                     | ?               |
+| `AUX` / `PRODUCT`      | ?         | ?             | ?                     | ?               |
+
+Two findings would change the player: a source reporting a `trackID` that does
+not change across a real skip (the readback would have to stop trusting it for
+that source), and a source whose `skipEnabled` is absent while skipping works
+anyway (which would rule out using the flag to hide the buttons).
+
 ## Ordering: revisions and epochs
 
 Status reaches the browser three ways — a full `devices` snapshot, a

--- a/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
+++ b/docs/content/docs/reference/PLAYER-SOURCE-BEHAVIOUR.md
@@ -167,25 +167,45 @@ across sources. The failure mode if a source reports a `trackID` that never
 changes across a skip is "unverified", not a false confirmation, which is the
 safe direction to be wrong in.
 
-Filling this in needs a speaker and one pass through its sources:
+Filling this in needs a speaker and two passes. The first collects what each
+source *reports*, by watching while you switch sources on the speaker or in the
+Bose app:
 
 ```bash
 soundtouch-cli --host <speaker> play capabilities --watch
 ```
 
 It prints one row per observation and a new row whenever the report changes, so
-switching sources on the speaker (or in the Bose app) collects the matrix in a
-single run. Record the results here:
+one run covers every source you visit. A radio stream rewriting its own title
+while the `trackID` stays put shows up here as a new row too, which is the
+behaviour that rules the title out as a confirmation signal.
 
-| Source                 | `trackID` | `skipEnabled` | `skipPreviousEnabled` | Skip verifiable |
-|------------------------|-----------|---------------|-----------------------|-----------------|
-| `SPOTIFY`              | yes       | yes           | yes                   | yes (captured)  |
-| `TUNEIN`               | ?         | ?             | ?                     | ?               |
-| `RADIO_BROWSER`        | ?         | ?             | ?                     | ?               |
-| `LOCAL_INTERNET_RADIO` | ?         | ?             | ?                     | ?               |
-| `STORED_MUSIC`         | ?         | ?             | ?                     | ?               |
-| `BLUETOOTH`            | ?         | ?             | ?                     | ?               |
-| `AUX` / `PRODUCT`      | ?         | ?             | ?                     | ?               |
+Reporting a `trackID` is not the same as that `trackID` moving when a skip
+happens, and only the second is what the player relies on. The second pass
+measures it, once per source, while that source is playing:
+
+```bash
+soundtouch-cli --host <speaker> play capabilities --probe-skip
+```
+
+That really does skip a track: it sends one `NEXT_TRACK`, watches for up to
+`--probe-wait` (6s by default), prints the before and after rows, and states
+whether the `trackID` moved, whether only the title moved, or whether nothing
+changed. Record both passes here:
+
+| Source                 | `trackID` | `skipEnabled` | `skipPreviousEnabled` | Skip moves `trackID` | Skip verifiable |
+|------------------------|-----------|---------------|-----------------------|----------------------|-----------------|
+| `SPOTIFY`              | yes       | yes           | yes                   | ?                    | expected        |
+| `TUNEIN`               | ?         | ?             | ?                     | ?                    | ?               |
+| `RADIO_BROWSER`        | ?         | ?             | ?                     | ?                    | ?               |
+| `LOCAL_INTERNET_RADIO` | ?         | ?             | ?                     | ?                    | ?               |
+| `STORED_MUSIC`         | ?         | ?             | ?                     | ?                    | ?               |
+| `BLUETOOTH`            | ?         | ?             | ?                     | ?                    | ?               |
+| `AUX` / `PRODUCT`      | ?         | ?             | ?                     | ?                    | ?               |
+
+The `SPOTIFY` row's first three columns come from the captured fixtures; its
+probe has not been run either, so "skip verifiable" is an expectation until it
+is.
 
 Two findings would change the player: a source reporting a `trackID` that does
 not change across a real skip (the readback would have to stop trusting it for

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -847,6 +847,61 @@ func TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms(t *testing.T) {
 	}
 }
 
+// TestDiscreteCommandConfirmsAcrossAReconnectEpoch: revisions restart at 0
+// when a device id is backed by a new DeviceConnection or the service is
+// restarted, so they only compare within one epoch. Comparing them raw made
+// every readback after a mid-command reconnect look older than the revision
+// the command started at, and the command could never confirm.
+func TestDiscreteCommandConfirmsAcrossAReconnectEpoch(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  epoch: 1,
+  revision: 50,
+  nowPlayingRevision: 50,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		// The connection was re-established mid-command: a new epoch, whose
+		// revisions start again from 0.
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"status":{"epoch":2,"revision":3,"nowPlayingRevision":3,` +
+				`"nowPlaying":{"Source":"PRODUCT","PlayStatus":"PAUSE_STATE"}}}}`))
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.play-btn`, chromedp.ByQuery),
+		chromedp.Click(`.play-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Playback paused'`, nil),
+	); err != nil {
+		t.Fatalf("exercise command confirmation across a reconnect: %v", err)
+	}
+}
+
 // TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail: a command the
 // event stream already confirmed must not be retracted by a later readback
 // that fails. Announcing "unverified" for a pause the speaker demonstrably

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -506,7 +506,7 @@ window.revisionChecks = {
 	}
 }
 
-func TestPowerAndPauseCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
+func TestDiscreteCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
 	const fixture = `
 import { h, render } from 'preact';
 import { useState } from 'preact/hooks';
@@ -514,7 +514,7 @@ import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
 const initialStatus = {
   revision: 1,
   nowPlayingRevision: 1,
-  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF' },
   volume: { ActualVolume: 20, MuteEnabled: false },
   presets: { Preset: [] },
   sources: { SourceItem: [] },
@@ -550,9 +550,12 @@ render(h(Fixture), document.getElementById('fixture'));
 			_, _ = w.Write([]byte(`{"success":true}`))
 		})
 		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, req *http.Request) {
+			key := chi.URLParam(req, "key")
 			mu.Lock()
-			mode = "pause"
-			keys = append(keys, chi.URLParam(req, "key"))
+			mode = map[string]string{
+				"PAUSE": "pause", "MUTE": "mute", "SHUFFLE_ON": "shuffle", "REPEAT_ALL": "repeat",
+			}[key]
+			keys = append(keys, key)
 			mu.Unlock()
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"success":true}`))
@@ -564,23 +567,48 @@ render(h(Fixture), document.getElementById('fixture'));
 			read := reads[currentMode]
 			mu.Unlock()
 
-			revision := read + 1
+			revisionBase := map[string]int{"power": 1, "pause": 100, "mute": 200, "shuffle": 300, "repeat": 400}[currentMode]
+			revision := read + revisionBase
+			nowPlayingRevision := revision
 			source := "PRODUCT"
 			playStatus := "PLAY_STATE"
+			shuffle := "SHUFFLE_OFF"
+			repeat := "REPEAT_OFF"
+			muted := false
 			if currentMode == "power" && read >= 2 {
 				source = "STANDBY"
 				playStatus = "STOP_STATE"
 			} else if currentMode == "pause" {
-				revision = read + 100
 				if read >= 2 {
 					playStatus = "PAUSE_STATE"
+				}
+			} else if currentMode == "mute" {
+				nowPlayingRevision = 200
+				playStatus = "PAUSE_STATE"
+				if read >= 2 {
+					muted = true
+				}
+			} else if currentMode == "shuffle" {
+				playStatus = "PAUSE_STATE"
+				if read >= 2 {
+					shuffle = "SHUFFLE_ON"
+				}
+			} else if currentMode == "repeat" {
+				playStatus = "PAUSE_STATE"
+				shuffle = "SHUFFLE_ON"
+				if read >= 2 {
+					repeat = "REPEAT_ALL"
 				}
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
 				"status": map[string]any{
-					"revision": revision, "nowPlayingRevision": revision,
-					"nowPlaying": map[string]string{"Source": source, "PlayStatus": playStatus},
+					"revision": revision, "nowPlayingRevision": nowPlayingRevision,
+					"nowPlaying": map[string]string{
+						"Source": source, "PlayStatus": playStatus,
+						"ShuffleSetting": shuffle, "RepeatSetting": repeat,
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": muted},
 				},
 			}})
 		})
@@ -596,23 +624,36 @@ render(h(Fixture), document.getElementById('fixture'));
 	})
 
 	ctx := newHeadlessChromeContext(t)
-	var powerPending, pausePending bool
+	var powerPending, pausePending, mutePending, shufflePending, repeatPending bool
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(server.URL+"/fixture"),
 		chromedp.WaitVisible(`.page-header .command-btn`, chromedp.ByQuery),
 		chromedp.Click(`.page-header .command-btn`, chromedp.ByQuery),
 		chromedp.Evaluate(`document.querySelector('.page-header .command-btn').getAttribute('aria-busy') === 'true'`, &powerPending),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Device powered off'`, nil),
-		chromedp.Evaluate(`window.publishStatus({revision: 100, nowPlayingRevision: 100, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PLAY_STATE'}})`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 100, nowPlayingRevision: 100, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PLAY_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF'}, volume: {ActualVolume: 20, MuteEnabled: false}})`, nil),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === ''`, nil),
 		chromedp.Click(`.play-btn`, chromedp.ByQuery),
 		chromedp.Evaluate(`document.querySelector('.play-btn').getAttribute('aria-busy') === 'true'`, &pausePending),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Playback paused'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 200, nowPlayingRevision: 200, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF'}, volume: {ActualVolume: 20, MuteEnabled: false}})`, nil),
+		chromedp.Click(`.mute-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.mute-btn').getAttribute('aria-busy') === 'true'`, &mutePending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Audio muted'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 300, nowPlayingRevision: 300, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
+		chromedp.Click(`.shuffle-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.shuffle-btn').getAttribute('aria-busy') === 'true'`, &shufflePending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Shuffle enabled'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 400, nowPlayingRevision: 400, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_ON', RepeatSetting: 'REPEAT_OFF'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
+		chromedp.Click(`.repeat-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.repeat-btn').getAttribute('aria-busy') === 'true'`, &repeatPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Repeat all enabled'`, nil),
 	); err != nil {
 		t.Fatalf("exercise bounded discrete commands: %v", err)
 	}
-	if !powerPending || !pausePending {
-		t.Errorf("pending state: power=%v pause=%v, want both true", powerPending, pausePending)
+	if !powerPending || !pausePending || !mutePending || !shufflePending || !repeatPending {
+		t.Errorf("pending state: power=%v pause=%v mute=%v shuffle=%v repeat=%v, want all true",
+			powerPending, pausePending, mutePending, shufflePending, repeatPending)
 	}
 
 	mu.Lock()
@@ -620,11 +661,13 @@ render(h(Fixture), document.getElementById('fixture'));
 	if powerWrites != 1 {
 		t.Errorf("power writes = %d, want 1", powerWrites)
 	}
-	if len(keys) != 1 || keys[0] != "PAUSE" {
-		t.Errorf("key writes = %v, want [PAUSE]", keys)
+	if got, want := fmt.Sprint(keys), "[PAUSE MUTE SHUFFLE_ON REPEAT_ALL]"; got != want {
+		t.Errorf("key writes = %s, want %s", got, want)
 	}
-	if reads["power"] != 3 || reads["pause"] != 3 {
-		t.Errorf("readbacks = power:%d pause:%d, want 3 each", reads["power"], reads["pause"])
+	for _, command := range []string{"power", "pause", "mute", "shuffle", "repeat"} {
+		if reads[command] != 3 {
+			t.Errorf("%s readbacks = %d, want 3", command, reads[command])
+		}
 	}
 }
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -747,12 +747,10 @@ window.pauseConfirmationChecks = {
 	}
 }
 
-// TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail: a command the
-// event stream already confirmed must not be retracted by a later readback
-// that fails. Announcing "unverified" for a pause the speaker demonstrably
-// performed is worse than saying nothing.
-func TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail(t *testing.T) {
-	const fixture = `
+// discreteCommandFixtureScript renders a device detail page whose readback
+// delays are compressed to [100, 250, 500]ms, and exposes window.publishStatus
+// so a test can play the part of the event stream.
+const discreteCommandFixtureScript = `
 import { h, render } from 'preact';
 import { useState } from 'preact/hooks';
 import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
@@ -777,7 +775,76 @@ window.publishStatus = status => publishStatus(status);
 render(h(Fixture), document.getElementById('fixture'));
 `
 
-	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+// registerDeviceDetailSideRoutes answers the requests the device detail page
+// makes besides the command under test, so they neither 404 nor interfere.
+func registerDeviceDetailSideRoutes(r chi.Router) {
+	r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+	})
+	r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
+	})
+	r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{}}})
+	})
+}
+
+// TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms: with a live
+// event stream the first matching readback settles the command, which frees
+// the transport again instead of holding every button disabled until the last
+// readback deadline (10s in production). The no-event-stream half is covered
+// by TestDiscreteCommandsUseOneWriteAndBoundedReadbacks, whose readbacks all
+// report webSocketConnected as absent and so run to the end of the window.
+func TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms(t *testing.T) {
+	var mu sync.Mutex
+	reads := 0
+	server := newPlayerFixtureServer(t, discreteCommandFixtureScript, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			reads++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true,"data":{"status":{"revision":9,"nowPlayingRevision":9,` +
+				`"webSocketConnected":true,"nowPlaying":{"Source":"PRODUCT","PlayStatus":"PAUSE_STATE"}}}}`))
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var transportEnabled bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.play-btn`, chromedp.ByQuery),
+		chromedp.Click(`.play-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Playback paused'`, nil),
+		chromedp.Evaluate(`document.querySelector('.play-btn').disabled === false`, &transportEnabled),
+		// Outlast the remaining readback deadlines (250ms and 500ms here).
+		chromedp.Sleep(900*time.Millisecond),
+	); err != nil {
+		t.Fatalf("exercise event-stream-confirmed command: %v", err)
+	}
+
+	if !transportEnabled {
+		t.Error("transport stayed disabled after the event stream confirmed the command")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads != 1 {
+		t.Errorf("readbacks with a live event stream = %d, want 1", reads)
+	}
+}
+
+// TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail: a command the
+// event stream already confirmed must not be retracted by a later readback
+// that fails. Announcing "unverified" for a pause the speaker demonstrably
+// performed is worse than saying nothing.
+func TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail(t *testing.T) {
+	server := newPlayerFixtureServer(t, discreteCommandFixtureScript, func(r chi.Router) {
 		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"success":true}`))
@@ -786,15 +853,7 @@ render(h(Fixture), document.getElementById('fixture'));
 		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "unavailable", http.StatusServiceUnavailable)
 		})
-		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
-		})
-		r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
-		})
-		r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
-			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{}}})
-		})
+		registerDeviceDetailSideRoutes(r)
 	})
 
 	ctx := newHeadlessChromeContext(t)

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -847,6 +847,77 @@ func TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms(t *testing.T) {
 	}
 }
 
+// TestControlsStayLiveOnAnUnpolledSpeaker: a speaker that is offline or has
+// not been polled yet reports no state, so nothing can be reconciled -- but
+// the power button and the transport must still work. That is exactly the
+// speaker you would want to power cycle from the UI.
+func TestControlsStayLiveOnAnUnpolledSpeaker(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail } from '/app/static/js/app.js';
+function Fixture() {
+  const [devices] = useState({ speaker: { info: { name: 'Speaker' } } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	powerWrites := 0
+	var keys []string
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/power", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			powerWrites++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			keys = append(keys, chi.URLParam(req, "key"))
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var powerEnabled, transportEnabled bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.page-header .command-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.page-header .command-btn').disabled === false`, &powerEnabled),
+		chromedp.Evaluate(`document.querySelector('.play-btn').disabled === false`, &transportEnabled),
+		chromedp.Click(`.page-header .command-btn`, chromedp.ByQuery),
+		chromedp.Click(`.play-btn`, chromedp.ByQuery),
+		// Both writes are fire-and-forget, so give them a moment to land.
+		chromedp.Sleep(300*time.Millisecond),
+	); err != nil {
+		t.Fatalf("exercise controls on an unpolled speaker: %v", err)
+	}
+
+	if !powerEnabled || !transportEnabled {
+		t.Errorf("enabled state: power=%v transport=%v, want both true", powerEnabled, transportEnabled)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if powerWrites != 1 {
+		t.Errorf("power writes = %d, want 1", powerWrites)
+	}
+	if got, want := fmt.Sprint(keys), "[PLAY]"; got != want {
+		t.Errorf("key writes = %s, want %s", got, want)
+	}
+}
+
 // TestDiscreteCommandConfirmsAcrossAReconnectEpoch: revisions restart at 0
 // when a device id is backed by a new DeviceConnection or the service is
 // restarted, so they only compare within one epoch. Comparing them raw made

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -747,6 +747,77 @@ window.pauseConfirmationChecks = {
 	}
 }
 
+// TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail: a command the
+// event stream already confirmed must not be retracted by a later readback
+// that fails. Announcing "unverified" for a pause the speaker demonstrably
+// performed is worse than saying nothing.
+func TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+let publishStatus;
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  publishStatus = status => setDevices(previous => mergeStatusUpdate(previous, 'speaker', status));
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+window.publishStatus = status => publishStatus(status);
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		// Every readback fails, so only the pushed status can confirm anything.
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		})
+		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
+		})
+		r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{}}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var statusText string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.play-btn`, chromedp.ByQuery),
+		chromedp.Click(`.play-btn`, chromedp.ByQuery),
+		// The speaker reports the pause before the first readback deadline.
+		chromedp.Evaluate(`window.publishStatus({revision: 100, nowPlayingRevision: 100, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE'}, volume: {ActualVolume: 20, MuteEnabled: false}})`, nil),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Playback paused, confirming'`, nil),
+		// Outlast the last readback deadline (500ms in this fixture).
+		chromedp.Sleep(900*time.Millisecond),
+		chromedp.Text(`.discrete-command-status`, &statusText, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("exercise push-confirmed command with failing readbacks: %v", err)
+	}
+
+	if statusText != "Playback paused" {
+		t.Errorf("status = %q, want the push confirmation to stand as %q", statusText, "Playback paused")
+	}
+}
+
 func TestPresetAndRecentCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
 	const fixture = `
 import { h, render } from 'preact';

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -506,6 +506,128 @@ window.revisionChecks = {
 	}
 }
 
+func TestPowerAndPauseCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+let publishStatus;
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  publishStatus = status => setDevices(previous => mergeStatusUpdate(previous, 'speaker', status));
+  return h(DeviceDetail, {
+    deviceId: 'speaker',
+    devices,
+    onBack: () => {},
+    commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+window.publishStatus = status => publishStatus(status);
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	mode := ""
+	reads := map[string]int{}
+	powerWrites := 0
+	var keys []string
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/power", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			mode = "power"
+			powerWrites++
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			mode = "pause"
+			keys = append(keys, chi.URLParam(req, "key"))
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			currentMode := mode
+			reads[currentMode]++
+			read := reads[currentMode]
+			mu.Unlock()
+
+			revision := read + 1
+			source := "PRODUCT"
+			playStatus := "PLAY_STATE"
+			if currentMode == "power" && read >= 2 {
+				source = "STANDBY"
+				playStatus = "STOP_STATE"
+			} else if currentMode == "pause" {
+				revision = read + 100
+				if read >= 2 {
+					playStatus = "PAUSE_STATE"
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": revision, "nowPlayingRevision": revision,
+					"nowPlaying": map[string]string{"Source": source, "PlayStatus": playStatus},
+				},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
+		})
+		r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{}}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var powerPending, pausePending bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.page-header .command-btn`, chromedp.ByQuery),
+		chromedp.Click(`.page-header .command-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.page-header .command-btn').getAttribute('aria-busy') === 'true'`, &powerPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Device powered off'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 100, nowPlayingRevision: 100, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PLAY_STATE'}})`, nil),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === ''`, nil),
+		chromedp.Click(`.play-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.play-btn').getAttribute('aria-busy') === 'true'`, &pausePending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Playback paused'`, nil),
+	); err != nil {
+		t.Fatalf("exercise bounded discrete commands: %v", err)
+	}
+	if !powerPending || !pausePending {
+		t.Errorf("pending state: power=%v pause=%v, want both true", powerPending, pausePending)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if powerWrites != 1 {
+		t.Errorf("power writes = %d, want 1", powerWrites)
+	}
+	if len(keys) != 1 || keys[0] != "PAUSE" {
+		t.Errorf("key writes = %v, want [PAUSE]", keys)
+	}
+	if reads["power"] != 3 || reads["pause"] != 3 {
+		t.Errorf("readbacks = power:%d pause:%d, want 3 each", reads["power"], reads["pause"])
+	}
+}
+
 // TestSourceExpiryDisablesCommandsOnNewerRevision: a stale marker pushed over
 // the socket must reach the buttons and make them unclickable, without the
 // projection ever showing the source as selected.

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -593,7 +593,7 @@ render(h(Fixture), document.getElementById('fixture'));
 					playStatus = "STOP_STATE"
 				} else if currentMode == "pause" {
 					if read >= 2 {
-						playStatus = "PAUSE_STATE"
+						playStatus = "STOP_STATE"
 					}
 				} else if currentMode == "mute" {
 					nowPlayingRevision = 200
@@ -714,6 +714,36 @@ render(h(Fixture), document.getElementById('fixture'));
 	}
 	if fullReads != 3 || nowPlayingReads != 18 {
 		t.Errorf("readback endpoints: full=%d now-playing=%d, want 3 and 18", fullReads, nowPlayingReads)
+	}
+}
+
+func TestPauseConfirmationAcceptsFirmwareStopWithoutConfirmingStandby(t *testing.T) {
+	const fixture = `
+import { matchesCommand } from '/app/static/js/discreteCommand.js';
+const pause = {action: 'pause'};
+window.pauseConfirmationChecks = {
+  paused: matchesCommand({nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE'}}, pause),
+  stoppedSource: matchesCommand({nowPlaying: {Source: 'LOCAL_INTERNET_RADIO', PlayStatus: 'STOP_STATE'}}, pause),
+  standby: !matchesCommand({nowPlaying: {Source: 'STANDBY', PlayStatus: 'STOP_STATE'}}, pause),
+  emptySource: !matchesCommand({nowPlaying: {Source: '', PlayStatus: 'STOP_STATE'}}, pause),
+};
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(chi.Router) {})
+	ctx := newHeadlessChromeContext(t)
+
+	var checks map[string]bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.Poll(`window.pauseConfirmationChecks !== undefined`, nil),
+		chromedp.Evaluate(`window.pauseConfirmationChecks`, &checks),
+	); err != nil {
+		t.Fatalf("exercise pause confirmation matrix: %v", err)
+	}
+	for name, passed := range checks {
+		if !passed {
+			t.Errorf("pause confirmation check %s failed", name)
+		}
 	}
 }
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -656,7 +656,7 @@ render(h(Fixture), document.getElementById('fixture'));
 
 	ctx := newHeadlessChromeContext(t)
 	var powerPending, pausePending, mutePending, shufflePending, repeatPending bool
-	var nextPending, previousPending bool
+	var nextFreedTransport bool
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(server.URL+"/fixture"),
 		chromedp.WaitVisible(`.page-header .command-btn`, chromedp.ByQuery),
@@ -682,21 +682,24 @@ render(h(Fixture), document.getElementById('fixture'));
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Repeat all enabled'`, nil),
 		chromedp.Evaluate(`window.publishStatus({revision: 500, nowPlayingRevision: 500, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_ON', RepeatSetting: 'REPEAT_ALL', Track: 'First track'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
 		chromedp.Poll(`document.querySelector('.track-title').textContent === 'First track'`, nil),
+		// Track skips settle on their write, so they confirm without a
+		// readback and free the transport again immediately.
 		chromedp.Click(`.next-btn`, chromedp.ByQuery),
-		chromedp.Evaluate(`document.querySelector('.next-btn').getAttribute('aria-busy') === 'true'`, &nextPending),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next track started'`, nil),
+		chromedp.Evaluate(`document.querySelector('.next-btn').disabled === false`, &nextFreedTransport),
 		chromedp.Evaluate(`window.publishStatus({revision: 600, nowPlayingRevision: 600, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_ON', RepeatSetting: 'REPEAT_ALL', Track: 'Second track'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
 		chromedp.Poll(`document.querySelector('.track-title').textContent === 'Second track'`, nil),
 		chromedp.Click(`.previous-btn`, chromedp.ByQuery),
-		chromedp.Evaluate(`document.querySelector('.previous-btn').getAttribute('aria-busy') === 'true'`, &previousPending),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Previous track started'`, nil),
 	); err != nil {
 		t.Fatalf("exercise bounded discrete commands: %v", err)
 	}
-	if !powerPending || !pausePending || !mutePending || !shufflePending || !repeatPending ||
-		!nextPending || !previousPending {
-		t.Errorf("pending state: power=%v pause=%v mute=%v shuffle=%v repeat=%v next=%v previous=%v, want all true",
-			powerPending, pausePending, mutePending, shufflePending, repeatPending, nextPending, previousPending)
+	if !powerPending || !pausePending || !mutePending || !shufflePending || !repeatPending {
+		t.Errorf("pending state: power=%v pause=%v mute=%v shuffle=%v repeat=%v, want all true",
+			powerPending, pausePending, mutePending, shufflePending, repeatPending)
+	}
+	if !nextFreedTransport {
+		t.Error("the transport stayed disabled after a track skip settled on its write")
 	}
 
 	mu.Lock()
@@ -707,13 +710,18 @@ render(h(Fixture), document.getElementById('fixture'));
 	if got, want := fmt.Sprint(keys), "[PAUSE MUTE SHUFFLE_ON REPEAT_ALL NEXT_TRACK PREV_TRACK]"; got != want {
 		t.Errorf("key writes = %s, want %s", got, want)
 	}
-	for _, command := range []string{"power", "pause", "mute", "shuffle", "repeat", "next", "previous"} {
+	for _, command := range []string{"power", "pause", "mute", "shuffle", "repeat"} {
 		if reads[command] != 3 {
 			t.Errorf("%s readbacks = %d, want 3", command, reads[command])
 		}
 	}
-	if fullReads != 3 || nowPlayingReads != 18 {
-		t.Errorf("readback endpoints: full=%d now-playing=%d, want 3 and 18", fullReads, nowPlayingReads)
+	for _, command := range []string{"next", "previous"} {
+		if reads[command] != 0 {
+			t.Errorf("%s readbacks = %d, want 0 for a command that settles on its write", command, reads[command])
+		}
+	}
+	if fullReads != 3 || nowPlayingReads != 12 {
+		t.Errorf("readback endpoints: full=%d now-playing=%d, want 3 and 12", fullReads, nowPlayingReads)
 	}
 }
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -539,6 +539,8 @@ render(h(Fixture), document.getElementById('fixture'));
 	mode := ""
 	reads := map[string]int{}
 	powerWrites := 0
+	fullReads := 0
+	nowPlayingReads := 0
 	var keys []string
 	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
 		r.Post("/api/control/devices/speaker/power", func(w http.ResponseWriter, _ *http.Request) {
@@ -561,77 +563,86 @@ render(h(Fixture), document.getElementById('fixture'));
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"success":true}`))
 		})
-		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
-			mu.Lock()
-			currentMode := mode
-			reads[currentMode]++
-			read := reads[currentMode]
-			mu.Unlock()
+		readback := func(kind string) http.HandlerFunc {
+			return func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				currentMode := mode
+				reads[currentMode]++
+				if kind == "full" {
+					fullReads++
+				} else {
+					nowPlayingReads++
+				}
+				read := reads[currentMode]
+				mu.Unlock()
 
-			revisionBase := map[string]int{
-				"power": 1, "pause": 100, "mute": 200, "shuffle": 300, "repeat": 400,
-				"next": 500, "previous": 600,
-			}[currentMode]
-			revision := read + revisionBase
-			nowPlayingRevision := revision
-			source := "PRODUCT"
-			playStatus := "PLAY_STATE"
-			shuffle := "SHUFFLE_OFF"
-			repeat := "REPEAT_OFF"
-			muted := false
-			track := "First track"
-			if currentMode == "power" && read >= 2 {
-				source = "STANDBY"
-				playStatus = "STOP_STATE"
-			} else if currentMode == "pause" {
-				if read >= 2 {
+				revisionBase := map[string]int{
+					"power": 1, "pause": 100, "mute": 200, "shuffle": 300, "repeat": 400,
+					"next": 500, "previous": 600,
+				}[currentMode]
+				revision := read + revisionBase
+				nowPlayingRevision := revision
+				source := "PRODUCT"
+				playStatus := "PLAY_STATE"
+				shuffle := "SHUFFLE_OFF"
+				repeat := "REPEAT_OFF"
+				muted := false
+				track := "First track"
+				if currentMode == "power" && read >= 2 {
+					source = "STANDBY"
+					playStatus = "STOP_STATE"
+				} else if currentMode == "pause" {
+					if read >= 2 {
+						playStatus = "PAUSE_STATE"
+					}
+				} else if currentMode == "mute" {
+					nowPlayingRevision = 200
 					playStatus = "PAUSE_STATE"
-				}
-			} else if currentMode == "mute" {
-				nowPlayingRevision = 200
-				playStatus = "PAUSE_STATE"
-				if read >= 2 {
-					muted = true
-				}
-			} else if currentMode == "shuffle" {
-				playStatus = "PAUSE_STATE"
-				if read >= 2 {
+					if read >= 2 {
+						muted = true
+					}
+				} else if currentMode == "shuffle" {
+					playStatus = "PAUSE_STATE"
+					if read >= 2 {
+						shuffle = "SHUFFLE_ON"
+					}
+				} else if currentMode == "repeat" {
+					playStatus = "PAUSE_STATE"
 					shuffle = "SHUFFLE_ON"
-				}
-			} else if currentMode == "repeat" {
-				playStatus = "PAUSE_STATE"
-				shuffle = "SHUFFLE_ON"
-				if read >= 2 {
+					if read >= 2 {
+						repeat = "REPEAT_ALL"
+					}
+				} else if currentMode == "next" {
+					playStatus = "PAUSE_STATE"
+					shuffle = "SHUFFLE_ON"
 					repeat = "REPEAT_ALL"
-				}
-			} else if currentMode == "next" {
-				playStatus = "PAUSE_STATE"
-				shuffle = "SHUFFLE_ON"
-				repeat = "REPEAT_ALL"
-				if read >= 2 {
+					if read >= 2 {
+						track = "Second track"
+					}
+				} else if currentMode == "previous" {
+					playStatus = "PAUSE_STATE"
+					shuffle = "SHUFFLE_ON"
+					repeat = "REPEAT_ALL"
 					track = "Second track"
+					if read >= 2 {
+						track = "First track"
+					}
 				}
-			} else if currentMode == "previous" {
-				playStatus = "PAUSE_STATE"
-				shuffle = "SHUFFLE_ON"
-				repeat = "REPEAT_ALL"
-				track = "Second track"
-				if read >= 2 {
-					track = "First track"
-				}
-			}
-			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
-				"status": map[string]any{
-					"revision": revision, "nowPlayingRevision": nowPlayingRevision,
-					"nowPlaying": map[string]string{
-						"Source": source, "PlayStatus": playStatus,
-						"ShuffleSetting": shuffle, "RepeatSetting": repeat, "Track": track,
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+					"status": map[string]any{
+						"revision": revision, "nowPlayingRevision": nowPlayingRevision,
+						"nowPlaying": map[string]string{
+							"Source": source, "PlayStatus": playStatus,
+							"ShuffleSetting": shuffle, "RepeatSetting": repeat, "Track": track,
+						},
+						"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": muted},
 					},
-					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": muted},
-				},
-			}})
-		})
+				}})
+			}
+		}
+		r.Get("/api/control/devices/speaker", readback("full"))
+		r.Get("/api/control/devices/speaker/now-playing", readback("now-playing"))
 		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
 			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
 		})
@@ -700,6 +711,9 @@ render(h(Fixture), document.getElementById('fixture'));
 		if reads[command] != 3 {
 			t.Errorf("%s readbacks = %d, want 3", command, reads[command])
 		}
+	}
+	if fullReads != 3 || nowPlayingReads != 18 {
+		t.Errorf("readback endpoints: full=%d now-playing=%d, want 3 and 18", fullReads, nowPlayingReads)
 	}
 }
 
@@ -819,6 +833,390 @@ render(h(Fixture), document.getElementById('fixture'));
 	}
 	if reads["preset"] != 3 || reads["recent"] != 3 {
 		t.Errorf("readbacks: preset=%d recent=%d, want 3 each", reads["preset"], reads["recent"])
+	}
+}
+
+func TestProviderAndLibraryPlaybackUseOneWriteAndBoundedReadbacks(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState, useRef } from 'preact/hooks';
+import { mergeStatusUpdate } from '/app/static/js/app.js';
+import { ContentPlaybackCommand } from '/app/static/js/components/ContentPlaybackCommand.js';
+import { TuneInBrowser } from '/app/static/js/components/TuneInBrowser.js';
+import { RadioBrowser } from '/app/static/js/components/RadioBrowser.js';
+import { PlayURL } from '/app/static/js/components/PlayURL.js';
+import { Library } from '/app/static/js/components/Library.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { device_id: 'DEVICE1', name: 'Speaker', ip_address: '192.0.2.1' }, status: initialStatus } });
+  const [request, setRequest] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [showTuneIn, setShowTuneIn] = useState(true);
+  const owner = useRef({ generation: 0, busy: false });
+  const onStatusReadback = (deviceId, status, info) => setDevices(previous => {
+    if (info?.device_id && previous[deviceId]?.info?.device_id !== info.device_id) return previous;
+    return mergeStatusUpdate(previous, deviceId, status);
+  });
+  const onPlaybackRequest = next => {
+    if (owner.current.busy) return false;
+    owner.current.busy = true;
+    owner.current.generation += 1;
+    setBusy(true);
+    setRequest({ ...next, key: 'command-' + owner.current.generation, targetIdentity: devices[next.deviceId]?.info?.device_id });
+    return true;
+  };
+  const onStateChange = state => {
+    owner.current.busy = state.busy;
+    setBusy(state.busy);
+  };
+  const onClear = () => {
+    if (!owner.current.busy) setRequest(null);
+  };
+  window.hideTuneIn = () => setShowTuneIn(false);
+  const props = { devices, onPlaybackRequest, playbackBusy: busy, commandReadbackDelays: [100, 250, 500] };
+  return h('div', {}, [
+    request ? h(ContentPlaybackCommand, { key: request.key, request, devices, onStatusReadback, onStateChange, onClear }) : null,
+    showTuneIn ? h('section', { id: 'tunein' }, h(TuneInBrowser, props)) : null,
+    h('section', { id: 'radio' }, h(RadioBrowser, props)),
+    h('section', { id: 'url' }, h(PlayURL, { ...props, serverServiceUrl: 'http://aftertouch.test' })),
+    h('section', { id: 'library' }, h(Library, props)),
+  ]);
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	mode := ""
+	reads := map[string]int{}
+	writes := map[string]int{}
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/providers/tunein/navigate", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"bmx_sections": []any{
+					map[string]any{
+						"name": "Stations",
+						"items": []any{
+							map[string]any{
+								"name": "TuneIn station",
+								"_links": map[string]any{"bmx_playback": map[string]string{
+									"href": "/tunein/station", "type": "stationurl",
+								}},
+							},
+						},
+					},
+				},
+			}})
+		})
+		r.Get("/api/control/providers/radiobrowser/search", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"bmx_sections": []any{
+					map[string]any{
+						"name": "Stations",
+						"items": []any{
+							map[string]any{
+								"name": "RadioBrowser station",
+								"_links": map[string]any{"bmx_playback": map[string]string{
+									"href": "/radiobrowser/station", "type": "stationurl",
+								}},
+							},
+						},
+					},
+				},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/library/servers", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: []any{
+				map[string]any{"udn": "uuid:library", "name": "Media server", "ready": true},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/library/browse", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"entries": []any{map[string]any{
+					"name": "Library track", "location": "/library/track", "type": "track", "playable": true,
+				}},
+			}})
+		})
+
+		registerWrite := func(command string) http.HandlerFunc {
+			return func(w http.ResponseWriter, _ *http.Request) {
+				mu.Lock()
+				mode = command
+				writes[command]++
+				mu.Unlock()
+				_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+			}
+		}
+		r.Post("/api/control/devices/speaker/providers/tunein/play", registerWrite("tunein"))
+		r.Post("/api/control/devices/speaker/providers/radiobrowser/play", registerWrite("radiobrowser"))
+		r.Post("/api/control/devices/speaker/providers/url/play", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			mode = "url"
+			writes["url"]++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]string{
+				"source": "LOCAL_INTERNET_RADIO", "location": "/orion/fixture", "itemName": "Fixture stream",
+			}})
+		})
+		r.Post("/api/control/devices/speaker/library/play", registerWrite("library"))
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			currentMode := mode
+			reads[currentMode]++
+			read := reads[currentMode]
+			mu.Unlock()
+
+			type expectedContent struct {
+				source   string
+				account  string
+				location string
+				name     string
+			}
+			expected := map[string]expectedContent{
+				"tunein":       {source: "TUNEIN", location: "/tunein/station", name: "TuneIn station"},
+				"radiobrowser": {source: "RADIO_BROWSER", location: "/radiobrowser/station", name: "RadioBrowser station"},
+				"url":          {source: "LOCAL_INTERNET_RADIO", location: "/orion/fixture", name: "Fixture stream"},
+				"library":      {source: "STORED_MUSIC", account: "uuid:library/0", location: "/library/track", name: "Library track"},
+			}[currentMode]
+			base := map[string]int{"tunein": 10, "radiobrowser": 20, "url": 30, "library": 40}[currentMode]
+			revision := base + read
+			source, account, location, name := "PRODUCT", "", "", "Original"
+			if read >= 2 {
+				source, account, location, name = expected.source, expected.account, expected.location, expected.name
+			}
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"info": map[string]string{"device_id": "DEVICE1"},
+				"status": map[string]any{
+					"revision": revision, "nowPlayingRevision": revision,
+					"nowPlaying": map[string]any{
+						"Source": source, "SourceAccount": account, "PlayStatus": "PLAY_STATE",
+						"ContentItem": map[string]string{
+							"Source": source, "SourceAccount": account, "Location": location, "ItemName": name,
+						},
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var radioDisabledWhilePending bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`#tunein .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.SetValue(`#radio .tunein-search-input`, "station", chromedp.ByQuery),
+		chromedp.Click(`#radio .btn-primary`, chromedp.ByQuery),
+		chromedp.WaitVisible(`#radio .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.Click(`#tunein .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.Click(`#tunein .picker-device-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('#radio .tunein-play-btn')?.disabled === true`, nil),
+		chromedp.Evaluate(`document.querySelector('#radio .tunein-play-btn').disabled`, &radioDisabledWhilePending),
+		chromedp.Evaluate(`window.hideTuneIn()`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('final-confirmed')`, nil),
+
+		chromedp.Click(`#radio .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.Click(`#radio .picker-device-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('final-confirmed')`, nil),
+
+		chromedp.SetValue(`#url input[type="url"]`, "http://stream.test/audio", chromedp.ByQuery),
+		chromedp.SetValue(`#url input[type="text"]`, "Fixture stream", chromedp.ByQuery),
+		chromedp.Click(`#url .tunein-toolbar .btn-primary`, chromedp.ByQuery),
+		chromedp.Click(`#url .picker-device-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('final-confirmed')`, nil),
+
+		chromedp.WaitVisible(`#library .tunein-item`, chromedp.ByQuery),
+		chromedp.Click(`#library .tunein-item`, chromedp.ByQuery),
+		chromedp.WaitVisible(`#library .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.Click(`#library .tunein-play-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('final-confirmed')`, nil),
+	); err != nil {
+		t.Fatalf("exercise provider and library playback command state: %v", err)
+	}
+	if !radioDisabledWhilePending {
+		t.Error("a second provider command remained enabled while the first command was pending")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, command := range []string{"tunein", "radiobrowser", "url", "library"} {
+		if writes[command] != 1 {
+			t.Errorf("%s writes = %d, want 1", command, writes[command])
+		}
+		if reads[command] != 3 {
+			t.Errorf("%s readbacks = %d, want 3", command, reads[command])
+		}
+	}
+}
+
+func TestContentPlaybackCommandFencesTargetsAndClassifiesOutcomes(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { api } from '/app/static/js/api.js';
+import { mergeStatusUpdate } from '/app/static/js/app.js';
+import { ContentPlaybackCommand } from '/app/static/js/components/ContentPlaybackCommand.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { device_id: 'DEVICE1', name: 'Speaker' }, status: initialStatus } });
+  const [request, setRequest] = useState(null);
+  const commandRequest = (scenario, targetIdentity = devices.speaker.info.device_id) => ({
+    key: scenario + '-' + Date.now(),
+    deviceId: 'speaker',
+    targetIdentity,
+    action: 'tunein',
+    readbackDelays: [100, 250, 500],
+    invoke: () => api.tuneInPlay('speaker', { location: '/' + scenario, type: 'stationurl', name: scenario }),
+    expected: { source: 'TUNEIN', location: '/' + scenario, itemName: scenario },
+  });
+  const start = scenario => setRequest(commandRequest(scenario));
+  const startWithReplacement = () => {
+    const targetIdentity = devices.speaker.info.device_id;
+    setRequest(commandRequest('pretarget', targetIdentity));
+    setDevices(previous => ({
+      ...previous,
+      speaker: { ...previous.speaker, info: { ...previous.speaker.info, device_id: 'DEVICE2' } },
+    }));
+  };
+  const onStatusReadback = (deviceId, status, info) => setDevices(previous => {
+    if (info?.device_id && previous[deviceId]?.info?.device_id !== info.device_id) return previous;
+    return mergeStatusUpdate(previous, deviceId, status);
+  });
+  window.replaceTarget = () => setDevices(previous => ({
+    ...previous,
+    speaker: { ...previous.speaker, info: { ...previous.speaker.info, device_id: 'DEVICE2' } },
+  }));
+  window.restoreTarget = () => setDevices(previous => ({
+    ...previous,
+    speaker: { ...previous.speaker, info: { ...previous.speaker.info, device_id: 'DEVICE1' }, status: initialStatus },
+  }));
+  window.publishNewer = () => setDevices(previous => mergeStatusUpdate(previous, 'speaker', {
+    revision: 100,
+    nowPlayingRevision: 100,
+    nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE', Track: 'Newer external state' },
+    volume: { ActualVolume: 20, MuteEnabled: false },
+  }));
+  return h('div', {}, [
+    h('button', { id: 'reject', onClick: () => start('reject') }, 'Reject'),
+    h('button', { id: 'target', onClick: () => start('target') }, 'Target'),
+    h('button', { id: 'pretarget', onClick: startWithReplacement }, 'Pre-write target'),
+    h('button', { id: 'stale', onClick: () => start('stale') }, 'Stale'),
+    request ? h(ContentPlaybackCommand, {
+      key: request.key,
+      request,
+      devices,
+      onStatusReadback,
+      onClear: () => setRequest(null),
+    }) : null,
+  ]);
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	mode := ""
+	reads := map[string]int{}
+	writes := map[string]int{}
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/providers/tunein/play", func(w http.ResponseWriter, req *http.Request) {
+			var body struct {
+				Location string `json:"location"`
+			}
+			if err := json.NewDecoder(req.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			currentMode := strings.TrimPrefix(body.Location, "/")
+			mu.Lock()
+			mode = currentMode
+			writes[currentMode]++
+			mu.Unlock()
+			if currentMode == "reject" {
+				_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: false, Error: "catalog rejected"})
+				return
+			}
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			currentMode := mode
+			reads[currentMode]++
+			read := reads[currentMode]
+			mu.Unlock()
+			revision := read + 1
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"info": map[string]string{"device_id": "DEVICE1"},
+				"status": map[string]any{
+					"revision": revision, "nowPlayingRevision": revision,
+					"nowPlaying": map[string]any{
+						"Source": "TUNEIN", "PlayStatus": "PLAY_STATE",
+						"ContentItem": map[string]string{
+							"Source": "TUNEIN", "Location": "/" + currentMode, "ItemName": currentMode,
+						},
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.Click(`#reject`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('failed')`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-error')?.textContent === 'catalog rejected'`, nil),
+		chromedp.Click(`.content-command-status button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status') === null`, nil),
+
+		chromedp.Click(`#target`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.content-command-status.pending`, chromedp.ByQuery),
+		chromedp.Evaluate(`window.replaceTarget()`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('failed')`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-error')?.textContent === 'Playback target changed'`, nil),
+		chromedp.Click(`.content-command-status button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status') === null`, nil),
+		chromedp.Evaluate(`window.restoreTarget()`, nil),
+
+		chromedp.Click(`#pretarget`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('failed')`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-error')?.textContent === 'Playback target changed'`, nil),
+		chromedp.Click(`.content-command-status button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status') === null`, nil),
+		chromedp.Evaluate(`window.restoreTarget()`, nil),
+
+		chromedp.Click(`#stale`, chromedp.ByQuery),
+		chromedp.WaitVisible(`.content-command-status.pending`, chromedp.ByQuery),
+		chromedp.Evaluate(`window.publishNewer()`, nil),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('unverified')`, nil),
+	); err != nil {
+		t.Fatalf("exercise negative content playback outcomes: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, command := range []string{"reject", "target", "stale"} {
+		if writes[command] != 1 {
+			t.Errorf("%s writes = %d, want 1", command, writes[command])
+		}
+	}
+	if reads["reject"] != 0 {
+		t.Errorf("rejected command readbacks = %d, want 0 after definite rejection", reads["reject"])
+	}
+	if reads["stale"] != 3 {
+		t.Errorf("stale command readbacks = %d, want 3", reads["stale"])
+	}
+	if writes["pretarget"] != 0 {
+		t.Errorf("pre-write target replacement writes = %d, want 0", writes["pretarget"])
 	}
 }
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -1235,7 +1235,7 @@ function Fixture() {
     targetIdentity,
     action: 'tunein',
     readbackDelays: [100, 250, 500],
-    invoke: () => api.tuneInPlay('speaker', { location: '/' + scenario, type: 'stationurl', name: scenario }),
+    invoke: () => api.tuneInPlayChecked('speaker', { location: '/' + scenario, type: 'stationurl', name: scenario }),
     expected: { source: 'TUNEIN', location: '/' + scenario, itemName: scenario },
   });
   const start = scenario => setRequest(commandRequest(scenario));
@@ -1269,6 +1269,7 @@ function Fixture() {
     h('button', { id: 'reject', onClick: () => start('reject') }, 'Reject'),
     h('button', { id: 'target', onClick: () => start('target') }, 'Target'),
     h('button', { id: 'pretarget', onClick: startWithReplacement }, 'Pre-write target'),
+    h('button', { id: 'indefinite', onClick: () => start('indefinite') }, 'Indefinite'),
     h('button', { id: 'stale', onClick: () => start('stale') }, 'Stale'),
     request ? h(ContentPlaybackCommand, {
       key: request.key,
@@ -1300,8 +1301,17 @@ render(h(Fixture), document.getElementById('fixture'));
 			mode = currentMode
 			writes[currentMode]++
 			mu.Unlock()
+			// 4xx is the only definitive refusal: the service produces it
+			// before any speaker call, so nothing was sent onward. 5xx is not
+			// proof of anything, since a request that timed out after the
+			// speaker already acted looks exactly like one it never received.
 			if currentMode == "reject" {
+				w.WriteHeader(http.StatusBadRequest)
 				_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: false, Error: "catalog rejected"})
+				return
+			}
+			if currentMode == "indefinite" {
+				http.Error(w, "speaker call failed", http.StatusInternalServerError)
 				return
 			}
 			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
@@ -1354,6 +1364,13 @@ render(h(Fixture), document.getElementById('fixture'));
 		chromedp.Poll(`document.querySelector('.content-command-status') === null`, nil),
 		chromedp.Evaluate(`window.restoreTarget()`, nil),
 
+		// A 5xx says nothing about whether the speaker acted, so the readbacks
+		// must keep verifying and can still confirm the command.
+		chromedp.Click(`#indefinite`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status')?.classList.contains('final-confirmed')`, nil),
+		chromedp.Click(`.content-command-status button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.content-command-status') === null`, nil),
+
 		chromedp.Click(`#stale`, chromedp.ByQuery),
 		chromedp.WaitVisible(`.content-command-status.pending`, chromedp.ByQuery),
 		chromedp.Evaluate(`window.publishNewer()`, nil),
@@ -1364,7 +1381,7 @@ render(h(Fixture), document.getElementById('fixture'));
 
 	mu.Lock()
 	defer mu.Unlock()
-	for _, command := range []string{"reject", "target", "stale"} {
+	for _, command := range []string{"reject", "target", "indefinite", "stale"} {
 		if writes[command] != 1 {
 			t.Errorf("%s writes = %d, want 1", command, writes[command])
 		}

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -877,6 +877,41 @@ func TestDiscreteCommandKeepsPushConfirmationWhenReadbacksFail(t *testing.T) {
 	}
 }
 
+// TestPlayConfirmationAcceptsBuffering: BUFFERING_STATE is a real firmware
+// play status (models.PlayStatusBuffering), and internet radio sits in it for
+// seconds at a time. Requiring PLAY_STATE reported a working play command as
+// unverified and held the transport disabled for the whole readback window.
+func TestPlayConfirmationAcceptsBuffering(t *testing.T) {
+	const fixture = `
+import { matchesCommand } from '/app/static/js/discreteCommand.js';
+const play = {action: 'play'};
+window.playConfirmationChecks = {
+  playing: matchesCommand({nowPlaying: {Source: 'TUNEIN', PlayStatus: 'PLAY_STATE'}}, play),
+  buffering: matchesCommand({nowPlaying: {Source: 'TUNEIN', PlayStatus: 'BUFFERING_STATE'}}, play),
+  paused: !matchesCommand({nowPlaying: {Source: 'TUNEIN', PlayStatus: 'PAUSE_STATE'}}, play),
+  standby: !matchesCommand({nowPlaying: {Source: 'STANDBY', PlayStatus: 'BUFFERING_STATE'}}, play),
+  emptySource: !matchesCommand({nowPlaying: {Source: '', PlayStatus: 'BUFFERING_STATE'}}, play),
+};
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(chi.Router) {})
+	ctx := newHeadlessChromeContext(t)
+
+	var checks map[string]bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.Poll(`window.playConfirmationChecks !== undefined`, nil),
+		chromedp.Evaluate(`window.playConfirmationChecks`, &checks),
+	); err != nil {
+		t.Fatalf("exercise play confirmation matrix: %v", err)
+	}
+	for name, passed := range checks {
+		if !passed {
+			t.Errorf("play confirmation check %s failed", name)
+		}
+	}
+}
+
 func TestPresetAndRecentCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
 	const fixture = `
 import { h, render } from 'preact';

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -1109,6 +1109,72 @@ render(h(Fixture), document.getElementById('fixture'));
 	}
 }
 
+// TestPreviousTrackConfirmsARestart: measured on a SoundTouch 10, the first
+// PREV_TRACK restarts the current track and only a second press steps back.
+// The restart changes no identity, so without reading the play position a
+// working Previous would report "unverified" every time.
+func TestPreviousTrackConfirmsARestart(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: {
+    Source: 'STORED_MUSIC', PlayStatus: 'PLAY_STATE',
+    Track: 'Something To Believe', Artist: 'An artist', Album: 'An album',
+    Time: { Total: 0, Position: 97 },
+    SkipEnabled: {}, SkipPreviousEnabled: {},
+  },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		// The same track, back at the beginning: a restart, not a step back.
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": 5, "nowPlayingRevision": 5,
+					"nowPlaying": map[string]any{
+						"Source": "STORED_MUSIC", "PlayStatus": "PLAY_STATE",
+						"Track": "Something To Believe", "Artist": "An artist", "Album": "An album",
+						"Time":        map[string]any{"Total": 0, "Position": 2},
+						"SkipEnabled": map[string]any{}, "SkipPreviousEnabled": map[string]any{},
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.previous-btn`, chromedp.ByQuery),
+		chromedp.Click(`.previous-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Previous track started'`, nil),
+	); err != nil {
+		t.Fatalf("exercise a previous-track restart: %v", err)
+	}
+}
+
 // TestEmptyPresetSlotStaysSavableWhileACommandIsPending: an empty slot's
 // tile is a save gesture, not a playback command, so an in-flight command
 // has no reason to disable it -- and the sibling star button, which saves the

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -955,6 +955,160 @@ func TestTrackSkipIsNotConfirmedByRollingStreamMetadata(t *testing.T) {
 	}
 }
 
+// libraryFixtureScript renders the device detail page for a source shaped like
+// STORED_MUSIC as measured on hardware: it claims skipEnabled but reports no
+// trackID, so only its track metadata can confirm a skip.
+const libraryFixtureScript = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: {
+    Source: 'STORED_MUSIC', PlayStatus: 'PLAY_STATE',
+    Track: 'First track', Artist: 'An artist', Album: 'An album',
+    SkipEnabled: {}, SkipPreviousEnabled: {},
+  },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+// TestTrackSkipConfirmsByMetadataWhereTheSourceClaimsSkip: a media library
+// changes its track title only when the track really changes, and says so by
+// claiming skipEnabled. Measured on hardware: STORED_MUSIC reports
+// skipEnabled and skipPreviousEnabled with no trackID at all, so refusing to
+// verify without a trackID would leave a whole source unverifiable.
+func TestTrackSkipConfirmsByMetadataWhereTheSourceClaimsSkip(t *testing.T) {
+	var mu sync.Mutex
+	reads := 0
+	server := newPlayerFixtureServer(t, libraryFixtureScript, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			reads++
+			read := reads
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": read + 1, "nowPlayingRevision": read + 1,
+					"nowPlaying": map[string]any{
+						"Source": "STORED_MUSIC", "PlayStatus": "PLAY_STATE",
+						"Track": "Second track", "Artist": "An artist", "Album": "An album",
+						"SkipEnabled": map[string]any{}, "SkipPreviousEnabled": map[string]any{},
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.next-btn`, chromedp.ByQuery),
+		chromedp.Click(`.next-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next track started'`, nil),
+	); err != nil {
+		t.Fatalf("exercise a library skip confirmed by metadata: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads == 0 {
+		t.Error("a skip against a source claiming skipEnabled was not verified by readback")
+	}
+}
+
+// TestTrackSkipSettlesOnWriteWhereTheSourceClaimsNoSkip: live radio rewrites
+// its own title while the same stream plays on, and claims no skip support.
+// Measured on hardware: TUNEIN and RADIO_BROWSER report neither a trackID nor
+// skipEnabled. Trusting the title there would confirm skips that never
+// happened, so nothing is read back at all.
+func TestTrackSkipSettlesOnWriteWhereTheSourceClaimsNoSkip(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: {
+    Source: 'TUNEIN', PlayStatus: 'PLAY_STATE',
+    Track: 'Rolling stream title', StationName: 'A station',
+  },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	reads := 0
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			reads++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": 9, "nowPlayingRevision": 9,
+					"nowPlaying": map[string]any{
+						"Source": "TUNEIN", "PlayStatus": "PLAY_STATE",
+						"Track": "A different rolling title", "StationName": "A station",
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.next-btn`, chromedp.ByQuery),
+		chromedp.Click(`.next-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next track started'`, nil),
+		// Outlast every readback deadline in the fixture.
+		chromedp.Sleep(900*time.Millisecond),
+	); err != nil {
+		t.Fatalf("exercise a skip against a source claiming no skip support: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads != 0 {
+		t.Errorf("readbacks = %d, want 0 where a rolling title is the only thing that changes", reads)
+	}
+}
+
 // TestEmptyPresetSlotStaysSavableWhileACommandIsPending: an empty slot's
 // tile is a save gesture, not a playback command, so an in-flight command
 // has no reason to disable it -- and the sibling star button, which saves the

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -847,6 +847,84 @@ func TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms(t *testing.T) {
 	}
 }
 
+// TestEmptyPresetSlotStaysSavableWhileACommandIsPending: an empty slot's
+// tile is a save gesture, not a playback command, so an in-flight command
+// has no reason to disable it -- and the sibling star button, which saves the
+// same thing, stays enabled throughout anyway.
+func TestEmptyPresetSlotStaysSavableWhileACommandIsPending(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [{ ID: 1, ContentItem: { Source: 'TUNEIN', Location: '/station/preset', ItemName: 'Preset station' } }] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	storedSlots := []string{}
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/action/preset", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/action/storepreset", func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			storedSlots = append(storedSlots, req.URL.Query().Get("id"))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		// Never matches the preset, so the command stays pending for the whole
+		// readback window while the empty slot is clicked.
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": 1, "nowPlayingRevision": 1,
+					"nowPlaying": map[string]any{"Source": "PRODUCT", "PlayStatus": "PLAY_STATE"},
+					"volume":     map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var savableEnabled bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.preset-slot.savable`, chromedp.ByQuery),
+		chromedp.Click(`.preset-slot:not(.empty)`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Starting preset'`, nil),
+		chromedp.Evaluate(`document.querySelector('.preset-slot.savable').disabled === false`, &savableEnabled),
+		chromedp.Click(`.preset-slot.savable`, chromedp.ByQuery),
+		chromedp.Sleep(300*time.Millisecond),
+	); err != nil {
+		t.Fatalf("exercise empty preset slot during a pending command: %v", err)
+	}
+
+	if !savableEnabled {
+		t.Error("the empty slot's save gesture was disabled while a command was pending")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := fmt.Sprint(storedSlots), "[2]"; got != want {
+		t.Errorf("stored preset slots = %s, want %s", got, want)
+	}
+}
+
 // TestControlsStayLiveOnAnUnpolledSpeaker: a speaker that is offline or has
 // not been polled yet reports no state, so nothing can be reconciled -- but
 // the power button and the transport must still work. That is exactly the

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -847,6 +847,114 @@ func TestDiscreteCommandStopsReadbacksOnceTheEventStreamConfirms(t *testing.T) {
 	}
 }
 
+// trackSkipFixtureScript renders the device detail page for a source that
+// reports a trackID, which is what makes a skip verifiable at all.
+const trackSkipFixtureScript = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'SPOTIFY', PlayStatus: 'PLAY_STATE', Track: 'First track', TrackID: 'track-1' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+// trackSkipServer answers a NEXT_TRACK write and then reports the given
+// trackID and track title back, with a revision that always advances.
+func trackSkipServer(t *testing.T, reads *int, mu *sync.Mutex, trackID string, rollingTitle bool) *httptest.Server {
+	t.Helper()
+
+	return newPlayerFixtureServer(t, trackSkipFixtureScript, func(r chi.Router) {
+		r.Post("/api/control/devices/speaker/key/{key}", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"success":true}`))
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			*reads++
+			read := *reads
+			mu.Unlock()
+			track := "First track"
+			if rollingTitle {
+				track = fmt.Sprintf("Rolling stream title %d", read)
+			}
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": read + 1, "nowPlayingRevision": read + 1,
+					"nowPlaying": map[string]any{
+						"Source": "SPOTIFY", "PlayStatus": "PLAY_STATE",
+						"Track": track, "TrackID": trackID,
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		registerDeviceDetailSideRoutes(r)
+	})
+}
+
+// TestTrackSkipConfirmsByTrackID: where the speaker reports a trackID, a skip
+// is genuinely verifiable, and the readbacks confirm it.
+func TestTrackSkipConfirmsByTrackID(t *testing.T) {
+	var mu sync.Mutex
+	reads := 0
+	server := trackSkipServer(t, &reads, &mu, "track-2", false)
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.next-btn`, chromedp.ByQuery),
+		chromedp.Click(`.next-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next track started'`, nil),
+	); err != nil {
+		t.Fatalf("exercise a verifiable track skip: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads == 0 {
+		t.Error("a skip against a source with a trackID was not verified by readback")
+	}
+}
+
+// TestTrackSkipIsNotConfirmedByRollingStreamMetadata: a live stream rewrites
+// its own track title while the same track keeps playing. That is not a skip,
+// and confirming on it would report a skip that never happened as done. The
+// trackID is what stays put.
+func TestTrackSkipIsNotConfirmedByRollingStreamMetadata(t *testing.T) {
+	var mu sync.Mutex
+	reads := 0
+	server := trackSkipServer(t, &reads, &mu, "track-1", true)
+
+	ctx := newHeadlessChromeContext(t)
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.next-btn`, chromedp.ByQuery),
+		chromedp.Click(`.next-btn`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next-track command unverified'`, nil),
+	); err != nil {
+		t.Fatalf("exercise a skip against rolling stream metadata: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads != 3 {
+		t.Errorf("readbacks = %d, want all 3 while the trackID never changed", reads)
+	}
+}
+
 // TestEmptyPresetSlotStaysSavableWhileACommandIsPending: an empty slot's
 // tile is a save gesture, not a playback command, so an in-flight command
 // has no reason to disable it -- and the sibling star button, which saves the

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -514,7 +514,7 @@ import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
 const initialStatus = {
   revision: 1,
   nowPlayingRevision: 1,
-  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF' },
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE', ShuffleSetting: 'SHUFFLE_OFF', RepeatSetting: 'REPEAT_OFF', Track: 'First track' },
   volume: { ActualVolume: 20, MuteEnabled: false },
   presets: { Preset: [] },
   sources: { SourceItem: [] },
@@ -554,6 +554,7 @@ render(h(Fixture), document.getElementById('fixture'));
 			mu.Lock()
 			mode = map[string]string{
 				"PAUSE": "pause", "MUTE": "mute", "SHUFFLE_ON": "shuffle", "REPEAT_ALL": "repeat",
+				"NEXT_TRACK": "next", "PREV_TRACK": "previous",
 			}[key]
 			keys = append(keys, key)
 			mu.Unlock()
@@ -567,7 +568,10 @@ render(h(Fixture), document.getElementById('fixture'));
 			read := reads[currentMode]
 			mu.Unlock()
 
-			revisionBase := map[string]int{"power": 1, "pause": 100, "mute": 200, "shuffle": 300, "repeat": 400}[currentMode]
+			revisionBase := map[string]int{
+				"power": 1, "pause": 100, "mute": 200, "shuffle": 300, "repeat": 400,
+				"next": 500, "previous": 600,
+			}[currentMode]
 			revision := read + revisionBase
 			nowPlayingRevision := revision
 			source := "PRODUCT"
@@ -575,6 +579,7 @@ render(h(Fixture), document.getElementById('fixture'));
 			shuffle := "SHUFFLE_OFF"
 			repeat := "REPEAT_OFF"
 			muted := false
+			track := "First track"
 			if currentMode == "power" && read >= 2 {
 				source = "STANDBY"
 				playStatus = "STOP_STATE"
@@ -599,6 +604,21 @@ render(h(Fixture), document.getElementById('fixture'));
 				if read >= 2 {
 					repeat = "REPEAT_ALL"
 				}
+			} else if currentMode == "next" {
+				playStatus = "PAUSE_STATE"
+				shuffle = "SHUFFLE_ON"
+				repeat = "REPEAT_ALL"
+				if read >= 2 {
+					track = "Second track"
+				}
+			} else if currentMode == "previous" {
+				playStatus = "PAUSE_STATE"
+				shuffle = "SHUFFLE_ON"
+				repeat = "REPEAT_ALL"
+				track = "Second track"
+				if read >= 2 {
+					track = "First track"
+				}
 			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
@@ -606,7 +626,7 @@ render(h(Fixture), document.getElementById('fixture'));
 					"revision": revision, "nowPlayingRevision": nowPlayingRevision,
 					"nowPlaying": map[string]string{
 						"Source": source, "PlayStatus": playStatus,
-						"ShuffleSetting": shuffle, "RepeatSetting": repeat,
+						"ShuffleSetting": shuffle, "RepeatSetting": repeat, "Track": track,
 					},
 					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": muted},
 				},
@@ -625,6 +645,7 @@ render(h(Fixture), document.getElementById('fixture'));
 
 	ctx := newHeadlessChromeContext(t)
 	var powerPending, pausePending, mutePending, shufflePending, repeatPending bool
+	var nextPending, previousPending bool
 	if err := chromedp.Run(ctx,
 		chromedp.Navigate(server.URL+"/fixture"),
 		chromedp.WaitVisible(`.page-header .command-btn`, chromedp.ByQuery),
@@ -648,12 +669,23 @@ render(h(Fixture), document.getElementById('fixture'));
 		chromedp.Click(`.repeat-btn`, chromedp.ByQuery),
 		chromedp.Evaluate(`document.querySelector('.repeat-btn').getAttribute('aria-busy') === 'true'`, &repeatPending),
 		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Repeat all enabled'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 500, nowPlayingRevision: 500, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_ON', RepeatSetting: 'REPEAT_ALL', Track: 'First track'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
+		chromedp.Poll(`document.querySelector('.track-title').textContent === 'First track'`, nil),
+		chromedp.Click(`.next-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.next-btn').getAttribute('aria-busy') === 'true'`, &nextPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Next track started'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 600, nowPlayingRevision: 600, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PAUSE_STATE', ShuffleSetting: 'SHUFFLE_ON', RepeatSetting: 'REPEAT_ALL', Track: 'Second track'}, volume: {ActualVolume: 20, MuteEnabled: true}})`, nil),
+		chromedp.Poll(`document.querySelector('.track-title').textContent === 'Second track'`, nil),
+		chromedp.Click(`.previous-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.previous-btn').getAttribute('aria-busy') === 'true'`, &previousPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Previous track started'`, nil),
 	); err != nil {
 		t.Fatalf("exercise bounded discrete commands: %v", err)
 	}
-	if !powerPending || !pausePending || !mutePending || !shufflePending || !repeatPending {
-		t.Errorf("pending state: power=%v pause=%v mute=%v shuffle=%v repeat=%v, want all true",
-			powerPending, pausePending, mutePending, shufflePending, repeatPending)
+	if !powerPending || !pausePending || !mutePending || !shufflePending || !repeatPending ||
+		!nextPending || !previousPending {
+		t.Errorf("pending state: power=%v pause=%v mute=%v shuffle=%v repeat=%v next=%v previous=%v, want all true",
+			powerPending, pausePending, mutePending, shufflePending, repeatPending, nextPending, previousPending)
 	}
 
 	mu.Lock()
@@ -661,13 +693,132 @@ render(h(Fixture), document.getElementById('fixture'));
 	if powerWrites != 1 {
 		t.Errorf("power writes = %d, want 1", powerWrites)
 	}
-	if got, want := fmt.Sprint(keys), "[PAUSE MUTE SHUFFLE_ON REPEAT_ALL]"; got != want {
+	if got, want := fmt.Sprint(keys), "[PAUSE MUTE SHUFFLE_ON REPEAT_ALL NEXT_TRACK PREV_TRACK]"; got != want {
 		t.Errorf("key writes = %s, want %s", got, want)
 	}
-	for _, command := range []string{"power", "pause", "mute", "shuffle", "repeat"} {
+	for _, command := range []string{"power", "pause", "mute", "shuffle", "repeat", "next", "previous"} {
 		if reads[command] != 3 {
 			t.Errorf("%s readbacks = %d, want 3", command, reads[command])
 		}
+	}
+}
+
+func TestPresetAndRecentCommandsUseOneWriteAndBoundedReadbacks(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail, mergeStatusUpdate } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'PRODUCT', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [{ ID: 1, ContentItem: { Source: 'TUNEIN', Location: '/station/preset', ItemName: 'Preset station' } }] },
+  sources: { SourceItem: [] },
+};
+let publishStatus;
+function Fixture() {
+  const [devices, setDevices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  publishStatus = status => setDevices(previous => mergeStatusUpdate(previous, 'speaker', status));
+  return h(DeviceDetail, {
+    deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500],
+    onStatusReadback: (deviceId, status) => setDevices(previous => mergeStatusUpdate(previous, deviceId, status)),
+  });
+}
+window.publishStatus = status => publishStatus(status);
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	mode := ""
+	reads := map[string]int{}
+	presetWrites := 0
+	recentWrites := 0
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/action/preset", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			mode = "preset"
+			presetWrites++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Post("/api/control/devices/speaker/play", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			mode = "recent"
+			recentWrites++
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/now-playing", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			currentMode := mode
+			reads[currentMode]++
+			read := reads[currentMode]
+			mu.Unlock()
+
+			revisionBase := map[string]int{"preset": 1, "recent": 100}[currentMode]
+			source := "PRODUCT"
+			location := ""
+			name := "Original"
+			if currentMode == "preset" && read >= 2 {
+				source, location, name = "TUNEIN", "/station/preset", "Preset station"
+			} else if currentMode == "recent" && read >= 2 {
+				source, location, name = "LOCAL_INTERNET_RADIO", "/station/recent", "Recent station"
+			}
+			revision := revisionBase + read
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"status": map[string]any{
+					"revision": revision, "nowPlayingRevision": revision,
+					"nowPlaying": map[string]any{
+						"Source": source, "PlayStatus": "PLAY_STATE",
+						"ContentItem": map[string]string{"Source": source, "Location": location, "ItemName": name},
+					},
+					"volume": map[string]any{"ActualVolume": 20, "MuteEnabled": false},
+				},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
+		})
+		r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{
+				map[string]any{"ID": "recent-1", "ContentItem": map[string]any{
+					"Source": "LOCAL_INTERNET_RADIO", "Location": "/station/recent", "ItemName": "Recent station",
+				}},
+			}}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var presetPending, recentPending bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.preset-slot:not(.empty)`, chromedp.ByQuery),
+		chromedp.Click(`.preset-slot:not(.empty)`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.preset-slot:not(.empty)').getAttribute('aria-busy') === 'true'`, &presetPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Preset started'`, nil),
+		chromedp.Evaluate(`window.publishStatus({revision: 100, nowPlayingRevision: 100, nowPlaying: {Source: 'PRODUCT', PlayStatus: 'PLAY_STATE'}, volume: {ActualVolume: 20, MuteEnabled: false}, presets: {Preset: [{ID: 1, ContentItem: {Source: 'TUNEIN', Location: '/station/preset', ItemName: 'Preset station'}}]}})`, nil),
+		chromedp.WaitVisible(`.recent-item`, chromedp.ByQuery),
+		chromedp.Click(`.recent-item`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.recent-item').getAttribute('aria-busy') === 'true'`, &recentPending),
+		chromedp.Poll(`document.querySelector('.discrete-command-status').textContent === 'Recent item started'`, nil),
+	); err != nil {
+		t.Fatalf("exercise preset and recent command state: %v", err)
+	}
+	if !presetPending || !recentPending {
+		t.Errorf("pending state: preset=%v recent=%v, want both true", presetPending, recentPending)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if presetWrites != 1 || recentWrites != 1 {
+		t.Errorf("writes: preset=%d recent=%d, want 1 each", presetWrites, recentWrites)
+	}
+	if reads["preset"] != 3 || reads["recent"] != 3 {
+		t.Errorf("readbacks: preset=%d recent=%d, want 3 each", reads["preset"], reads["recent"])
 	}
 }
 

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -1753,7 +1753,12 @@ func (app *WebApp) HandlePlayURL(w http.ResponseWriter, r *http.Request) {
 
 	if encErr := json.NewEncoder(w).Encode(webtypes.APIResponse{
 		Success: true,
-		Data:    map[string]string{"message": "Playing " + req.Name},
+		Data: map[string]string{
+			"message":  "Playing " + req.Name,
+			"source":   contentItem.Source,
+			"location": contentItem.Location,
+			"itemName": contentItem.ItemName,
+		},
 	}); encErr != nil {
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
 	}

--- a/pkg/service/soundtouchweb/handler_test.go
+++ b/pkg/service/soundtouchweb/handler_test.go
@@ -4,6 +4,7 @@ package soundtouchweb
 import (
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/gesellix/bose-soundtouch/pkg/client"
 	"github.com/gesellix/bose-soundtouch/pkg/models"
+	bmxpkg "github.com/gesellix/bose-soundtouch/pkg/service/bmx"
 	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
 	"github.com/go-chi/chi/v5"
 )
@@ -847,6 +849,61 @@ func TestHandleDevicePlay_SourceAccountFiltering(t *testing.T) {
 				t.Errorf("XML should contain %q, got: %s", want, capturedBody)
 			}
 		})
+	}
+}
+
+func TestHandlePlayURLReturnsSelectedContentIdentity(t *testing.T) {
+	var selected models.ContentItem
+	speaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/select" {
+			http.NotFound(w, r)
+			return
+		}
+		if err := xml.NewDecoder(r.Body).Decode(&selected); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer speaker.Close()
+
+	app := NewWebApp()
+	app.ServiceURL = "http://aftertouch.test"
+	conn := webtypes.NewDeviceConnection(
+		client.NewClient(&client.Config{Host: speaker.URL}),
+		&models.DeviceInfo{DeviceID: "DEVICE1", Name: "Speaker"},
+	)
+	app.AddDevice("speaker", conn)
+
+	body := strings.NewReader(`{"url":"http://stream.test/audio","name":"Fixture stream","imageUrl":"http://stream.test/art.png"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/control/devices/speaker/providers/url/play", body)
+	req = withChiParams(req, map[string]string{"id": "speaker"})
+	w := httptest.NewRecorder()
+	app.HandlePlayURL(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("play URL status = %d: %s", w.Code, w.Body.String())
+	}
+	expectedLocation := bmxpkg.BuildOrionLocation(
+		app.ServiceURL,
+		"Fixture stream",
+		"http://stream.test/art.png",
+		"http://stream.test/audio",
+	)
+	var response struct {
+		Success bool              `json:"success"`
+		Data    map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("decode play URL response: %v", err)
+	}
+	if !response.Success || response.Data["source"] != "LOCAL_INTERNET_RADIO" ||
+		response.Data["location"] != expectedLocation || response.Data["itemName"] != "Fixture stream" {
+		t.Fatalf("play URL identity = %+v, want exact selected content", response)
+	}
+	if selected.Source != response.Data["source"] || selected.Location != response.Data["location"] ||
+		selected.ItemName != response.Data["itemName"] {
+		t.Fatalf("speaker selection = %+v, response = %+v", selected, response.Data)
 	}
 }
 

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -1010,6 +1010,23 @@ img.recent-source-icon { width: 20px; height: 20px; object-fit: contain; filter:
 .tunein-section-name { font-size: .85rem; font-weight: 600; color: var(--text-dim); padding: 8px 0 2px; margin: 0; }
 .tunein-load-more { margin: 4px 0 12px; }
 
+.content-command-status {
+    min-height: 1.5rem;
+    margin-bottom: .75rem;
+    color: var(--text-dim);
+    font-size: .8rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: .75rem;
+}
+.content-command-status.provisional-confirmed { font-style: italic; }
+.content-command-status.unverified { color: #8a5a00; }
+.content-command-status.failed { color: var(--offline); }
+.content-command-status span { min-width: 0; overflow-wrap: anywhere; }
+.content-command-error { display: block; margin-top: .15rem; }
+.content-command-status .btn-secondary { flex-shrink: 0; }
+
 /* ── Device picker overlay ───────────────────────────────────────────────── */
 .overlay {
     position: fixed; inset: 0;

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -596,6 +596,18 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 /* The primary action is deliberately larger; everything else is uniform. */
 .ctrl-btn.play-btn { width: 3rem; height: 3rem; }
 .ctrl-btn.active { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
+.command-btn:disabled { cursor: not-allowed; opacity: .55; }
+.command-btn.pending { cursor: wait; }
+.command-btn.provisional-confirmed { border-style: dashed; cursor: progress; }
+.command-btn.unverified { border-color: #a76b00; }
+.command-btn.failed { border-color: var(--offline); }
+
+.discrete-command-status {
+    min-height: 1.2em;
+    margin: -.35rem 0 .4rem;
+    color: var(--text-dim);
+    font-size: .75rem;
+}
 
 .volume-row { display: flex; align-items: center; gap: .75rem; }
 .volume-icon { display: flex; align-items: center; }

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -45,6 +45,12 @@ export const api = {
     removeDevice: (id) => req(`/api/control/devices/${id}`, { method: 'DELETE' }),
     discover: () => req('/api/control/discover', { method: 'POST' }),
     key: (id, key) => req(`/api/control/devices/${id}/key/${key}`, { method: 'POST' }),
+    // Checked variants of the mutations the discrete-command hook issues. They
+    // send the same request, but surface the failure and whether it is
+    // definitive, which is what tells the hook to stop verifying (see
+    // checkedReq). The plain forms keep their response-level behaviour for the
+    // callers that already rely on it.
+    keyChecked: (id, key) => checkedReq(`/api/control/devices/${id}/key/${key}`, { method: 'POST' }),
     volume: (id, level) => req(`/api/control/devices/${id}/volume/${level}`, { method: 'POST' }),
     bass: (id, level) => req(`/api/control/devices/${id}/action/bass`, {
         method: 'POST',
@@ -57,6 +63,7 @@ export const api = {
         body: JSON.stringify({ level }),
     }),
     power: (id) => req(`/api/control/devices/${id}/power`, { method: 'POST' }),
+    powerChecked: (id) => checkedReq(`/api/control/devices/${id}/power`, { method: 'POST' }),
     recents: (id) => req(`/api/control/devices/${id}/recents`),
     zone: (id) => req(`/api/control/devices/${id}/zone`),
     zoneCandidates: (id) => req(`/api/control/devices/${id}/zone/candidates`),
@@ -98,6 +105,7 @@ export const api = {
     tuneInSearch: (q) => req(`/api/control/providers/tunein/search?q=${encodeURIComponent(q)}`),
     tuneInSearchNext: (cursor) => req(`/api/control/providers/tunein/search/next?cursor=${encodeURIComponent(cursor)}`),
     control: (id, action, presetId) => req(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
+    controlChecked: (id, action, presetId) => checkedReq(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
     storePreset: (id, slotId) => req(`/api/control/devices/${id}/action/storepreset?id=${slotId}`),
     selectSource: (id, source, account) => checkedReq(`/api/control/devices/${id}/action/source`, {
         method: 'POST',
@@ -109,13 +117,28 @@ export const api = {
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
+    tuneInPlayChecked: (deviceId, item) => checkedReq(`/api/control/devices/${deviceId}/providers/tunein/play`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(item),
+    }),
     radioBrowserSearch: (q) => req(`/api/control/providers/radiobrowser/search?q=${encodeURIComponent(q)}`),
     radioBrowserPlay: (deviceId, item) => req(`/api/control/devices/${deviceId}/providers/radiobrowser/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(item),
     }),
+    radioBrowserPlayChecked: (deviceId, item) => checkedReq(`/api/control/devices/${deviceId}/providers/radiobrowser/play`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(item),
+    }),
     playURL: (deviceId, url, name, imageUrl, serviceUrl) => req(`/api/control/devices/${deviceId}/providers/url/play`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ url, name, imageUrl, serviceUrl }),
+    }),
+    playURLChecked: (deviceId, url, name, imageUrl, serviceUrl) => checkedReq(`/api/control/devices/${deviceId}/providers/url/play`, {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify({ url, name, imageUrl, serviceUrl }),
@@ -140,4 +163,5 @@ export const api = {
         return req(`/api/control/devices/${id}/library/browse?${qs}`);
     },
     libraryPlay: (id, body) => req(`/api/control/devices/${id}/library/play`, { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(body) }),
+    libraryPlayChecked: (id, body) => checkedReq(`/api/control/devices/${id}/library/play`, { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(body) }),
 };

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -191,12 +191,14 @@ export function DeviceDetail({
 
     function previousTrack() {
         runDiscreteCommand('previous-track',
-            () => api.keyChecked(deviceId, 'PREV_TRACK'));
+            () => api.keyChecked(deviceId, 'PREV_TRACK'),
+            { previousTrackID: status?.nowPlaying?.TrackID || '' });
     }
 
     function nextTrack() {
         runDiscreteCommand('next-track',
-            () => api.keyChecked(deviceId, 'NEXT_TRACK'));
+            () => api.keyChecked(deviceId, 'NEXT_TRACK'),
+            { previousTrackID: status?.nowPlaying?.TrackID || '' });
     }
 
     function selectPreset(preset) {

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -1,5 +1,5 @@
 import { h, render } from 'preact';
-import { useState, useEffect, useCallback } from 'preact/hooks';
+import { useState, useEffect, useCallback, useRef } from 'preact/hooks';
 import htm from 'htm';
 import { DeviceList } from './components/DeviceList.js';
 import { NowPlaying } from './components/NowPlaying.js';
@@ -83,6 +83,65 @@ function replaceDevice(previous, deviceId, device) {
     ]);
 }
 
+const DISCRETE_COMMAND_READBACK_DELAYS_MS = [2000, 5000, 10000];
+
+function nowPlayingRevision(status) {
+    const revision = status?.nowPlayingRevision;
+    return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
+}
+
+function matchesDiscreteCommand(status, action) {
+    const nowPlaying = status?.nowPlaying;
+    if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
+    if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
+    if (action === 'pause') return nowPlaying?.PlayStatus === 'PAUSE_STATE';
+    if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
+    return false;
+}
+
+function discreteCommandFailed(status, action) {
+    if (action !== 'play' && action !== 'pause') return false;
+    const nowPlaying = status?.nowPlaying;
+    return nowPlaying?.Source === 'INVALID_SOURCE' ||
+        nowPlaying?.Source?.endsWith('_ERROR') ||
+        nowPlaying?.PlayStatus === 'INVALID_PLAY_STATE';
+}
+
+function discreteCommandText(command) {
+    if (!command) return '';
+    const labels = {
+        'power-off': {
+            pending: 'Turning device off',
+            'provisional-confirmed': 'Device powered off, confirming',
+            'final-confirmed': 'Device powered off',
+            unverified: 'Power command unverified',
+            failed: 'Power command failed',
+        },
+        'power-on': {
+            pending: 'Waking device',
+            'provisional-confirmed': 'Device awake, confirming',
+            'final-confirmed': 'Device awake',
+            unverified: 'Power command unverified',
+            failed: 'Power command failed',
+        },
+        pause: {
+            pending: 'Pausing playback',
+            'provisional-confirmed': 'Playback paused, confirming',
+            'final-confirmed': 'Playback paused',
+            unverified: 'Pause command unverified',
+            failed: 'Pause command failed',
+        },
+        play: {
+            pending: 'Starting playback',
+            'provisional-confirmed': 'Playback started, confirming',
+            'final-confirmed': 'Playback started',
+            unverified: 'Play command unverified',
+            failed: 'Play command failed',
+        },
+    };
+    return labels[command.action]?.[command.outcome] || '';
+}
+
 export function mergeStatusUpdate(previous, deviceId, status) {
     // Object.prototype.hasOwnProperty, not a plain previous[deviceId] truthy
     // check: a deviceId of "__proto__" or "constructor" would otherwise
@@ -98,8 +157,173 @@ export function mergeStatusUpdate(previous, deviceId, status) {
     });
 }
 
-function DeviceDetail({ deviceId, devices, onBack, onDevicesChanged, notify, onRemove, onStatusReadback, onNavigate }) {
+export function DeviceDetail({
+    deviceId,
+    devices,
+    onBack,
+    onDevicesChanged,
+    notify,
+    onRemove,
+    onStatusReadback,
+    onNavigate,
+    commandReadbackDelays = DISCRETE_COMMAND_READBACK_DELAYS_MS,
+}) {
     const device = devices[deviceId];
+    const status = device?.status;
+    const [command, setCommand] = useState(null);
+    const commandRef = useRef({ generation: 0, active: null, timers: [] });
+
+    function clearCommandReadbacks() {
+        commandRef.current.timers.forEach(clearTimeout);
+        commandRef.current.timers = [];
+    }
+
+    useEffect(() => {
+        commandRef.current.generation += 1;
+        commandRef.current.active = null;
+        clearCommandReadbacks();
+        setCommand(null);
+
+        return () => {
+            commandRef.current.generation += 1;
+            commandRef.current.active = null;
+            clearCommandReadbacks();
+        };
+    }, [deviceId]);
+
+    useEffect(() => {
+        const revision = nowPlayingRevision(status);
+        if (!command || revision === null || command.startRevision === null ||
+            revision <= command.startRevision || command.outcome === 'failed' ||
+            command.outcome === 'unverified') return;
+
+        const matches = matchesDiscreteCommand(status, command.action);
+        if (command.outcome === 'final-confirmed') {
+            if (revision > command.confirmedRevision && !matches) {
+                setCommand(previous => previous?.generation === command.generation
+                    ? null : previous);
+            }
+            return;
+        }
+        if (discreteCommandFailed(status, command.action)) {
+            clearCommandReadbacks();
+            commandRef.current.active = null;
+            setCommand(previous => previous?.generation === command.generation
+                ? { ...previous, outcome: 'failed' }
+                : previous);
+        } else if (matches && command.outcome === 'pending') {
+            setCommand(previous => previous?.generation === command.generation
+                ? { ...previous, outcome: 'provisional-confirmed' }
+                : previous);
+        }
+    }, [command, status]);
+
+    function runDiscreteCommand(action, invoke) {
+        if (commandRef.current.active) return;
+
+        clearCommandReadbacks();
+        const generation = commandRef.current.generation + 1;
+        const startRevision = nowPlayingRevision(status);
+        const active = { generation, latestReadback: -1, writeError: null };
+        commandRef.current.generation = generation;
+        commandRef.current.active = active;
+        setCommand({ action, generation, outcome: 'pending', startRevision });
+        const startedAt = Date.now();
+
+        commandReadbackDelays.forEach((delay, index) => {
+            const timer = setTimeout(async () => {
+                if (commandRef.current.active !== active) return;
+                active.latestReadback = index;
+
+                try {
+                    const response = await api.deviceNowPlaying(deviceId);
+                    if (commandRef.current.active !== active || active.latestReadback !== index) return;
+                    if (response?.success === false || !response?.data?.status) {
+                        throw new Error(response?.error || 'Device status unavailable');
+                    }
+
+                    const readbackStatus = response.data.status;
+                    const readbackRevision = nowPlayingRevision(readbackStatus);
+                    const revisionIsNewer = startRevision !== null && readbackRevision !== null &&
+                        readbackRevision > startRevision;
+                    onStatusReadback?.(deviceId, readbackStatus);
+
+                    if (revisionIsNewer && discreteCommandFailed(readbackStatus, action)) {
+                        clearCommandReadbacks();
+                        commandRef.current.active = null;
+                        setCommand({ action, generation, outcome: 'failed', startRevision });
+                    } else if (revisionIsNewer && matchesDiscreteCommand(readbackStatus, action)) {
+                        const isFinalReadback = index === commandReadbackDelays.length - 1;
+                        setCommand({
+                            action,
+                            generation,
+                            outcome: isFinalReadback ? 'final-confirmed' : 'provisional-confirmed',
+                            startRevision,
+                            confirmedRevision: readbackRevision,
+                        });
+                        if (isFinalReadback) {
+                            clearCommandReadbacks();
+                            commandRef.current.active = null;
+                        }
+                    } else if (index === commandReadbackDelays.length - 1) {
+                        commandRef.current.active = null;
+                        setCommand({
+                            action,
+                            generation,
+                            outcome: 'unverified',
+                            startRevision,
+                            error: active.writeError?.message,
+                        });
+                    }
+                } catch (_) {
+                    if (commandRef.current.active === active && active.latestReadback === index &&
+                        index === commandReadbackDelays.length - 1) {
+                        commandRef.current.active = null;
+                        setCommand({
+                            action,
+                            generation,
+                            outcome: 'unverified',
+                            startRevision,
+                            error: active.writeError?.message,
+                        });
+                    }
+                }
+            }, Math.max(0, delay - (Date.now() - startedAt)));
+            commandRef.current.timers.push(timer);
+        });
+
+        let write;
+        try {
+            write = invoke();
+        } catch (error) {
+            active.writeError = error;
+            return;
+        }
+        Promise.resolve(write).then(response => {
+            if (response?.success === false) throw new Error(response.error || 'Command rejected');
+        }).catch(error => {
+            if (commandRef.current.active === active) active.writeError = error;
+        });
+    }
+
+    const commandBusy = command?.outcome === 'pending' ||
+        command?.outcome === 'provisional-confirmed';
+    const commandStatus = discreteCommandText(command);
+    const source = status?.nowPlaying?.Source;
+    const playStatus = status?.nowPlaying?.PlayStatus;
+
+    function togglePower() {
+        if (!source) return;
+        runDiscreteCommand(source === 'STANDBY' ? 'power-on' : 'power-off',
+            () => api.power(deviceId));
+    }
+
+    function togglePlayback() {
+        if (!playStatus) return;
+        const isPlaying = playStatus === 'PLAY_STATE';
+        runDiscreteCommand(isPlaying ? 'pause' : 'play',
+            () => api.key(deviceId, isPlaying ? 'PAUSE' : 'PLAY'));
+    }
 
     if (!device) {
         return html`
@@ -114,7 +338,13 @@ function DeviceDetail({ deviceId, devices, onBack, onDevicesChanged, notify, onR
         <div class="device-detail">
             <div class="page-header">
                 <button class="back-btn" onClick=${onBack}>← Back</button>
-                <button class="btn-icon" onClick=${() => api.power(deviceId)} title="Power">
+                <button
+                    class="btn-icon command-btn ${command?.action?.startsWith('power-') ? command.outcome : ''}"
+                    onClick=${togglePower}
+                    title="Power"
+                    disabled=${commandBusy || !source}
+                    aria-busy=${command?.action?.startsWith('power-') && commandBusy ? 'true' : null}
+                >
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
                         <path d="M12 2v8" />
                         <path d="M18.36 6.64a9 9 0 1 1-12.73 0" />
@@ -122,7 +352,14 @@ function DeviceDetail({ deviceId, devices, onBack, onDevicesChanged, notify, onR
                 </button>
             </div>
             <${NowPlaying} nowPlaying=${device.status?.nowPlaying} deviceId=${deviceId} presets=${device.status?.presets} />
-            <${Controls} deviceId=${deviceId} status=${device.status} />
+            <${Controls}
+                deviceId=${deviceId}
+                status=${device.status}
+                command=${command}
+                commandBusy=${commandBusy}
+                commandStatus=${commandStatus}
+                onTogglePlayback=${togglePlayback}
+            />
             <${Presets} deviceId=${deviceId} status=${device.status} />
             <${Sources}
                 deviceId=${deviceId}

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -15,9 +15,16 @@ import { Library } from './components/Library.js';
 import { PlayURL } from './components/PlayURL.js';
 import { TTS } from './components/TTS.js';
 import { Announcements } from './components/Announcements.js';
+import { ContentPlaybackCommand } from './components/ContentPlaybackCommand.js';
 import { api } from './api.js';
 import { isSoundTouch10StereoPair } from './stereoPresentation.mjs';
 import { removeDeviceAndRefresh } from './deviceRemoval.js';
+import {
+    DISCRETE_COMMAND_READBACK_DELAYS_MS,
+    contentExpectation,
+    playbackIdentity,
+    useDiscreteCommand,
+} from './discreteCommand.js';
 
 const html = htm.bind(h);
 
@@ -83,217 +90,6 @@ function replaceDevice(previous, deviceId, device) {
     ]);
 }
 
-const DISCRETE_COMMAND_READBACK_DELAYS_MS = [2000, 5000, 10000];
-
-function nowPlayingRevision(status) {
-    const revision = status?.nowPlayingRevision;
-    return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
-}
-
-function commandAction(command) {
-    return typeof command === 'string' ? command : command?.action;
-}
-
-function discreteCommandRevision(status, command) {
-    return commandAction(command)?.startsWith('mute-')
-        ? statusRevision(status)
-        : nowPlayingRevision(status);
-}
-
-function playbackIdentity(nowPlaying) {
-    if (!nowPlaying) return '';
-    const item = nowPlaying.ContentItem || {};
-    return [
-        nowPlaying.Source,
-        nowPlaying.SourceAccount,
-        item.Source,
-        item.SourceAccount,
-        item.Location,
-        nowPlaying.TrackID,
-        nowPlaying.Track,
-        nowPlaying.StationName,
-    ].map(value => value || '').join('\u0000');
-}
-
-function contentExpectation(item) {
-    const source = item?.Source || '';
-    const sourceAccount = item?.SourceAccount && item.SourceAccount !== source
-        ? item.SourceAccount
-        : '';
-    return {
-        source,
-        sourceAccount,
-        location: item?.Location || '',
-        itemName: item?.ItemName || '',
-    };
-}
-
-function matchesContentExpectation(nowPlaying, expected) {
-    if (!nowPlaying || !expected) return false;
-    const item = nowPlaying.ContentItem || {};
-    const source = item.Source || nowPlaying.Source || '';
-    const account = item.SourceAccount || nowPlaying.SourceAccount || '';
-    if (expected.source && source !== expected.source) return false;
-    if (expected.sourceAccount && account !== expected.sourceAccount) return false;
-    if (expected.location) {
-        return item.Location === expected.location ||
-            nowPlaying.StationLocation === expected.location;
-    }
-    if (expected.itemName) return [
-        item.ItemName,
-        nowPlaying.Track,
-        nowPlaying.StationName,
-    ].includes(expected.itemName);
-    return Boolean(expected.source);
-}
-
-function matchesDiscreteCommand(status, command) {
-    const action = commandAction(command);
-    const nowPlaying = status?.nowPlaying;
-    if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
-    if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
-    if (action === 'pause') return nowPlaying?.PlayStatus === 'PAUSE_STATE';
-    if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
-    if (action === 'mute-on') return status?.volume?.MuteEnabled === true;
-    if (action === 'mute-off') return status?.volume?.MuteEnabled === false;
-    if (action === 'shuffle-on') return nowPlaying?.ShuffleSetting === 'SHUFFLE_ON';
-    if (action === 'shuffle-off') return nowPlaying?.ShuffleSetting === 'SHUFFLE_OFF';
-    if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
-    if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
-    if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
-    if (action === 'next-track' || action === 'previous-track') {
-        const identity = playbackIdentity(nowPlaying);
-        return Boolean(identity) && identity !== command?.expected?.previousIdentity;
-    }
-    if (action === 'preset' || action === 'recent') {
-        return matchesContentExpectation(nowPlaying, command?.expected);
-    }
-    return false;
-}
-
-function discreteCommandFailed(status, command) {
-    const action = commandAction(command);
-    if (!['play', 'pause', 'next-track', 'previous-track', 'preset', 'recent'].includes(action)) {
-        return false;
-    }
-    const nowPlaying = status?.nowPlaying;
-    return nowPlaying?.Source === 'INVALID_SOURCE' ||
-        nowPlaying?.Source?.endsWith('_ERROR') ||
-        nowPlaying?.PlayStatus === 'INVALID_PLAY_STATE';
-}
-
-function discreteCommandText(command) {
-    if (!command) return '';
-    const labels = {
-        'power-off': {
-            pending: 'Turning device off',
-            'provisional-confirmed': 'Device powered off, confirming',
-            'final-confirmed': 'Device powered off',
-            unverified: 'Power command unverified',
-            failed: 'Power command failed',
-        },
-        'power-on': {
-            pending: 'Waking device',
-            'provisional-confirmed': 'Device awake, confirming',
-            'final-confirmed': 'Device awake',
-            unverified: 'Power command unverified',
-            failed: 'Power command failed',
-        },
-        pause: {
-            pending: 'Pausing playback',
-            'provisional-confirmed': 'Playback paused, confirming',
-            'final-confirmed': 'Playback paused',
-            unverified: 'Pause command unverified',
-            failed: 'Pause command failed',
-        },
-        play: {
-            pending: 'Starting playback',
-            'provisional-confirmed': 'Playback started, confirming',
-            'final-confirmed': 'Playback started',
-            unverified: 'Play command unverified',
-            failed: 'Play command failed',
-        },
-        'mute-on': {
-            pending: 'Muting audio',
-            'provisional-confirmed': 'Audio muted, confirming',
-            'final-confirmed': 'Audio muted',
-            unverified: 'Mute command unverified',
-            failed: 'Mute command failed',
-        },
-        'mute-off': {
-            pending: 'Unmuting audio',
-            'provisional-confirmed': 'Audio unmuted, confirming',
-            'final-confirmed': 'Audio unmuted',
-            unverified: 'Unmute command unverified',
-            failed: 'Unmute command failed',
-        },
-        'shuffle-on': {
-            pending: 'Enabling shuffle',
-            'provisional-confirmed': 'Shuffle enabled, confirming',
-            'final-confirmed': 'Shuffle enabled',
-            unverified: 'Shuffle command unverified',
-            failed: 'Shuffle command failed',
-        },
-        'shuffle-off': {
-            pending: 'Disabling shuffle',
-            'provisional-confirmed': 'Shuffle disabled, confirming',
-            'final-confirmed': 'Shuffle disabled',
-            unverified: 'Shuffle command unverified',
-            failed: 'Shuffle command failed',
-        },
-        'repeat-all': {
-            pending: 'Enabling repeat all',
-            'provisional-confirmed': 'Repeat all enabled, confirming',
-            'final-confirmed': 'Repeat all enabled',
-            unverified: 'Repeat command unverified',
-            failed: 'Repeat command failed',
-        },
-        'repeat-one': {
-            pending: 'Enabling repeat one',
-            'provisional-confirmed': 'Repeat one enabled, confirming',
-            'final-confirmed': 'Repeat one enabled',
-            unverified: 'Repeat command unverified',
-            failed: 'Repeat command failed',
-        },
-        'repeat-off': {
-            pending: 'Disabling repeat',
-            'provisional-confirmed': 'Repeat disabled, confirming',
-            'final-confirmed': 'Repeat disabled',
-            unverified: 'Repeat command unverified',
-            failed: 'Repeat command failed',
-        },
-        'next-track': {
-            pending: 'Skipping to next track',
-            'provisional-confirmed': 'Next track started, confirming',
-            'final-confirmed': 'Next track started',
-            unverified: 'Next-track command unverified',
-            failed: 'Next-track command failed',
-        },
-        'previous-track': {
-            pending: 'Returning to previous track',
-            'provisional-confirmed': 'Previous track started, confirming',
-            'final-confirmed': 'Previous track started',
-            unverified: 'Previous-track command unverified',
-            failed: 'Previous-track command failed',
-        },
-        preset: {
-            pending: 'Starting preset',
-            'provisional-confirmed': 'Preset started, confirming',
-            'final-confirmed': 'Preset started',
-            unverified: 'Preset playback unverified',
-            failed: 'Preset playback failed',
-        },
-        recent: {
-            pending: 'Starting recent item',
-            'provisional-confirmed': 'Recent item started, confirming',
-            'final-confirmed': 'Recent item started',
-            unverified: 'Recent-item playback unverified',
-            failed: 'Recent-item playback failed',
-        },
-    };
-    return labels[command.action]?.[command.outcome] || '';
-}
-
 export function mergeStatusUpdate(previous, deviceId, status) {
     // Object.prototype.hasOwnProperty, not a plain previous[deviceId] truthy
     // check: a deviceId of "__proto__" or "constructor" would otherwise
@@ -322,146 +118,17 @@ export function DeviceDetail({
 }) {
     const device = devices[deviceId];
     const status = device?.status;
-    const [command, setCommand] = useState(null);
-    const commandRef = useRef({ generation: 0, active: null, timers: [] });
-
-    function clearCommandReadbacks() {
-        commandRef.current.timers.forEach(clearTimeout);
-        commandRef.current.timers = [];
-    }
-
-    useEffect(() => {
-        commandRef.current.generation += 1;
-        commandRef.current.active = null;
-        clearCommandReadbacks();
-        setCommand(null);
-
-        return () => {
-            commandRef.current.generation += 1;
-            commandRef.current.active = null;
-            clearCommandReadbacks();
-        };
-    }, [deviceId]);
-
-    useEffect(() => {
-        const revision = discreteCommandRevision(status, command);
-        if (!command || revision === null || command.startRevision === null ||
-            revision <= command.startRevision || command.outcome === 'failed' ||
-            command.outcome === 'unverified') return;
-
-        const matches = matchesDiscreteCommand(status, command);
-        if (command.outcome === 'final-confirmed') {
-            if (revision > command.confirmedRevision && !matches) {
-                setCommand(previous => previous?.generation === command.generation
-                    ? null : previous);
-            }
-            return;
-        }
-        if (discreteCommandFailed(status, command)) {
-            clearCommandReadbacks();
-            commandRef.current.active = null;
-            setCommand(previous => previous?.generation === command.generation
-                ? { ...previous, outcome: 'failed' }
-                : previous);
-        } else if (matches && command.outcome === 'pending') {
-            setCommand(previous => previous?.generation === command.generation
-                ? { ...previous, outcome: 'provisional-confirmed' }
-                : previous);
-        }
-    }, [command, status]);
-
-    function runDiscreteCommand(action, invoke, expected = null) {
-        if (commandRef.current.active) return;
-
-        clearCommandReadbacks();
-        const generation = commandRef.current.generation + 1;
-        const request = { action, expected };
-        const startRevision = discreteCommandRevision(status, request);
-        const active = { generation, latestReadback: -1, writeError: null };
-        commandRef.current.generation = generation;
-        commandRef.current.active = active;
-        setCommand({ ...request, generation, outcome: 'pending', startRevision });
-        const startedAt = Date.now();
-
-        commandReadbackDelays.forEach((delay, index) => {
-            const timer = setTimeout(async () => {
-                if (commandRef.current.active !== active) return;
-                active.latestReadback = index;
-
-                try {
-                    const response = await api.deviceNowPlaying(deviceId);
-                    if (commandRef.current.active !== active || active.latestReadback !== index) return;
-                    if (response?.success === false || !response?.data?.status) {
-                        throw new Error(response?.error || 'Device status unavailable');
-                    }
-
-                    const readbackStatus = response.data.status;
-                    const readbackRevision = discreteCommandRevision(readbackStatus, request);
-                    const revisionIsNewer = startRevision !== null && readbackRevision !== null &&
-                        readbackRevision > startRevision;
-                    onStatusReadback?.(deviceId, readbackStatus);
-
-                    if (revisionIsNewer && discreteCommandFailed(readbackStatus, request)) {
-                        clearCommandReadbacks();
-                        commandRef.current.active = null;
-                        setCommand({ ...request, generation, outcome: 'failed', startRevision });
-                    } else if (revisionIsNewer && matchesDiscreteCommand(readbackStatus, request)) {
-                        const isFinalReadback = index === commandReadbackDelays.length - 1;
-                        setCommand({
-                            ...request,
-                            generation,
-                            outcome: isFinalReadback ? 'final-confirmed' : 'provisional-confirmed',
-                            startRevision,
-                            confirmedRevision: readbackRevision,
-                        });
-                        if (isFinalReadback) {
-                            clearCommandReadbacks();
-                            commandRef.current.active = null;
-                        }
-                    } else if (index === commandReadbackDelays.length - 1) {
-                        commandRef.current.active = null;
-                        setCommand({
-                            ...request,
-                            generation,
-                            outcome: 'unverified',
-                            startRevision,
-                            error: active.writeError?.message,
-                        });
-                    }
-                } catch (_) {
-                    if (commandRef.current.active === active && active.latestReadback === index &&
-                        index === commandReadbackDelays.length - 1) {
-                        commandRef.current.active = null;
-                        setCommand({
-                            ...request,
-                            generation,
-                            outcome: 'unverified',
-                            startRevision,
-                            error: active.writeError?.message,
-                        });
-                    }
-                }
-            }, Math.max(0, delay - (Date.now() - startedAt)));
-            commandRef.current.timers.push(timer);
-        });
-
-        let write;
-        try {
-            write = invoke();
-        } catch (error) {
-            active.writeError = error;
-            return;
-        }
-        Promise.resolve(write).then(response => {
-            if (response?.success === false) throw new Error(response.error || 'Command rejected');
-        }).catch(error => {
-            if (commandRef.current.active === active) active.writeError = error;
-        });
-    }
-
-    const commandBusy = command?.outcome === 'pending' ||
-        command?.outcome === 'provisional-confirmed';
-    const commandStatus = discreteCommandText(command);
+    const {
+        command,
+        busy: commandBusy,
+        statusText: commandStatus,
+        run: runDiscreteCommand,
+    } = useDiscreteCommand({
+        deviceId,
+        status,
+        onStatusReadback,
+        readbackDelays: commandReadbackDelays,
+    });
     const source = status?.nowPlaying?.Source;
     const playStatus = status?.nowPlaying?.PlayStatus;
 
@@ -645,6 +312,9 @@ function App() {
     // 'connecting' until the first frame arrives, so a page opened while the
     // service is down does not claim the connection was lost.
     const [connection, setConnection] = useState('connecting');
+    const [contentPlaybackRequest, setContentPlaybackRequest] = useState(null);
+    const [contentPlaybackBusy, setContentPlaybackBusy] = useState(false);
+    const contentPlaybackRef = useRef({ generation: 0, busy: false });
 
     const getPageTitle = () => {
         if (page === 'devices') return 'Devices';
@@ -780,8 +450,43 @@ function App() {
         setDevices(previous => mergeDevicesSnapshot(previous, resp.data));
     }
 
-    function mergeDeviceReadback(deviceId, status) {
-        setDevices(previous => mergeStatusUpdate(previous, deviceId, status));
+    function mergeDeviceReadback(deviceId, status, readbackInfo = null) {
+        setDevices(previous => {
+            if (readbackInfo?.device_id &&
+                previous[deviceId]?.info?.device_id !== readbackInfo.device_id) {
+                return previous;
+            }
+            return mergeStatusUpdate(previous, deviceId, status);
+        });
+    }
+
+    function startContentPlayback(request) {
+        if (contentPlaybackRef.current.busy) return false;
+        const targetIdentity = devices[request.deviceId]?.info?.device_id;
+        if (!targetIdentity) {
+            showToast('Playback target is no longer available');
+            return false;
+        }
+
+        contentPlaybackRef.current.busy = true;
+        contentPlaybackRef.current.generation += 1;
+        setContentPlaybackBusy(true);
+        setContentPlaybackRequest({
+            ...request,
+            key: `content-playback-${contentPlaybackRef.current.generation}`,
+            targetIdentity,
+        });
+        return true;
+    }
+
+    function updateContentPlaybackState(state) {
+        contentPlaybackRef.current.busy = state.busy;
+        setContentPlaybackBusy(state.busy);
+    }
+
+    function clearContentPlayback() {
+        if (contentPlaybackRef.current.busy) return;
+        setContentPlaybackRequest(null);
     }
 
     async function removeDevice(id) {
@@ -866,6 +571,16 @@ function App() {
             <${Announcements} />
 
             <main class="main-content">
+                ${contentPlaybackRequest ? html`
+                    <${ContentPlaybackCommand}
+                        key=${contentPlaybackRequest.key}
+                        request=${contentPlaybackRequest}
+                        devices=${devices}
+                        onStatusReadback=${mergeDeviceReadback}
+                        onStateChange=${updateContentPlaybackState}
+                        onClear=${clearContentPlayback}
+                    />
+                ` : null}
                 ${page === 'devices' ? html`
                     <${DeviceList}
                         key="device-list"
@@ -887,15 +602,36 @@ function App() {
                         onNavigate=${navigate}
                     />
                 ` : page === 'tunein' ? html`
-                    <${TuneInBrowser} key="tunein-browser" devices=${devices} />
+                    <${TuneInBrowser}
+                        key="tunein-browser"
+                        devices=${devices}
+                        onPlaybackRequest=${startContentPlayback}
+                        playbackBusy=${contentPlaybackBusy}
+                    />
                 ` : page === 'radiobrowser' ? html`
-                    <${RadioBrowser} key="radiobrowser-browser" devices=${devices} />
+                    <${RadioBrowser}
+                        key="radiobrowser-browser"
+                        devices=${devices}
+                        onPlaybackRequest=${startContentPlayback}
+                        playbackBusy=${contentPlaybackBusy}
+                    />
                 ` : page === 'playurl' ? html`
-                    <${PlayURL} key="play-url" devices=${devices} serverServiceUrl=${version?.service_url || ''} />
+                    <${PlayURL}
+                        key="play-url"
+                        devices=${devices}
+                        serverServiceUrl=${version?.service_url || ''}
+                        onPlaybackRequest=${startContentPlayback}
+                        playbackBusy=${contentPlaybackBusy}
+                    />
                 ` : page === 'tts' ? html`
                     <${TTS} key="tts" devices=${devices} serverServiceUrl=${version?.service_url || ''} />
                 ` : page === 'library' ? html`
-                    <${Library} key="library" devices=${devices} />
+                    <${Library}
+                        key="library"
+                        devices=${devices}
+                        onPlaybackRequest=${startContentPlayback}
+                        playbackBusy=${contentPlaybackBusy}
+                    />
                 ` : null}
             </main>
 

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -90,12 +90,23 @@ function nowPlayingRevision(status) {
     return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
 }
 
+function discreteCommandRevision(status, action) {
+    return action?.startsWith('mute-') ? statusRevision(status) : nowPlayingRevision(status);
+}
+
 function matchesDiscreteCommand(status, action) {
     const nowPlaying = status?.nowPlaying;
     if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
     if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
     if (action === 'pause') return nowPlaying?.PlayStatus === 'PAUSE_STATE';
     if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
+    if (action === 'mute-on') return status?.volume?.MuteEnabled === true;
+    if (action === 'mute-off') return status?.volume?.MuteEnabled === false;
+    if (action === 'shuffle-on') return nowPlaying?.ShuffleSetting === 'SHUFFLE_ON';
+    if (action === 'shuffle-off') return nowPlaying?.ShuffleSetting === 'SHUFFLE_OFF';
+    if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
+    if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
+    if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
     return false;
 }
 
@@ -137,6 +148,55 @@ function discreteCommandText(command) {
             'final-confirmed': 'Playback started',
             unverified: 'Play command unverified',
             failed: 'Play command failed',
+        },
+        'mute-on': {
+            pending: 'Muting audio',
+            'provisional-confirmed': 'Audio muted, confirming',
+            'final-confirmed': 'Audio muted',
+            unverified: 'Mute command unverified',
+            failed: 'Mute command failed',
+        },
+        'mute-off': {
+            pending: 'Unmuting audio',
+            'provisional-confirmed': 'Audio unmuted, confirming',
+            'final-confirmed': 'Audio unmuted',
+            unverified: 'Unmute command unverified',
+            failed: 'Unmute command failed',
+        },
+        'shuffle-on': {
+            pending: 'Enabling shuffle',
+            'provisional-confirmed': 'Shuffle enabled, confirming',
+            'final-confirmed': 'Shuffle enabled',
+            unverified: 'Shuffle command unverified',
+            failed: 'Shuffle command failed',
+        },
+        'shuffle-off': {
+            pending: 'Disabling shuffle',
+            'provisional-confirmed': 'Shuffle disabled, confirming',
+            'final-confirmed': 'Shuffle disabled',
+            unverified: 'Shuffle command unverified',
+            failed: 'Shuffle command failed',
+        },
+        'repeat-all': {
+            pending: 'Enabling repeat all',
+            'provisional-confirmed': 'Repeat all enabled, confirming',
+            'final-confirmed': 'Repeat all enabled',
+            unverified: 'Repeat command unverified',
+            failed: 'Repeat command failed',
+        },
+        'repeat-one': {
+            pending: 'Enabling repeat one',
+            'provisional-confirmed': 'Repeat one enabled, confirming',
+            'final-confirmed': 'Repeat one enabled',
+            unverified: 'Repeat command unverified',
+            failed: 'Repeat command failed',
+        },
+        'repeat-off': {
+            pending: 'Disabling repeat',
+            'provisional-confirmed': 'Repeat disabled, confirming',
+            'final-confirmed': 'Repeat disabled',
+            unverified: 'Repeat command unverified',
+            failed: 'Repeat command failed',
         },
     };
     return labels[command.action]?.[command.outcome] || '';
@@ -192,7 +252,7 @@ export function DeviceDetail({
     }, [deviceId]);
 
     useEffect(() => {
-        const revision = nowPlayingRevision(status);
+        const revision = discreteCommandRevision(status, command?.action);
         if (!command || revision === null || command.startRevision === null ||
             revision <= command.startRevision || command.outcome === 'failed' ||
             command.outcome === 'unverified') return;
@@ -223,7 +283,7 @@ export function DeviceDetail({
 
         clearCommandReadbacks();
         const generation = commandRef.current.generation + 1;
-        const startRevision = nowPlayingRevision(status);
+        const startRevision = discreteCommandRevision(status, action);
         const active = { generation, latestReadback: -1, writeError: null };
         commandRef.current.generation = generation;
         commandRef.current.active = active;
@@ -243,7 +303,7 @@ export function DeviceDetail({
                     }
 
                     const readbackStatus = response.data.status;
-                    const readbackRevision = nowPlayingRevision(readbackStatus);
+                    const readbackRevision = discreteCommandRevision(readbackStatus, action);
                     const revisionIsNewer = startRevision !== null && readbackRevision !== null &&
                         readbackRevision > startRevision;
                     onStatusReadback?.(deviceId, readbackStatus);
@@ -325,6 +385,30 @@ export function DeviceDetail({
             () => api.key(deviceId, isPlaying ? 'PAUSE' : 'PLAY'));
     }
 
+    function toggleMute() {
+        const muted = status?.volume?.MuteEnabled;
+        if (typeof muted !== 'boolean') return;
+        runDiscreteCommand(muted ? 'mute-off' : 'mute-on',
+            () => api.key(deviceId, 'MUTE'));
+    }
+
+    function toggleShuffle() {
+        const shuffle = status?.nowPlaying?.ShuffleSetting;
+        if (!shuffle) return;
+        const target = shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON';
+        runDiscreteCommand(target === 'SHUFFLE_ON' ? 'shuffle-on' : 'shuffle-off',
+            () => api.key(deviceId, target));
+    }
+
+    function cycleRepeat() {
+        const repeat = status?.nowPlaying?.RepeatSetting;
+        if (!repeat) return;
+        const target = repeat === 'REPEAT_OFF' ? 'REPEAT_ALL'
+            : repeat === 'REPEAT_ALL' ? 'REPEAT_ONE' : 'REPEAT_OFF';
+        runDiscreteCommand(`repeat-${target.substring('REPEAT_'.length).toLowerCase()}`,
+            () => api.key(deviceId, target));
+    }
+
     if (!device) {
         return html`
             <div class="page-header">
@@ -359,6 +443,9 @@ export function DeviceDetail({
                 commandBusy=${commandBusy}
                 commandStatus=${commandStatus}
                 onTogglePlayback=${togglePlayback}
+                onToggleMute=${toggleMute}
+                onToggleShuffle=${toggleShuffle}
+                onCycleRepeat=${cycleRepeat}
             />
             <${Presets} deviceId=${deviceId} status=${device.status} />
             <${Sources}

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -22,7 +22,6 @@ import { removeDeviceAndRefresh } from './deviceRemoval.js';
 import {
     DISCRETE_COMMAND_READBACK_DELAYS_MS,
     contentExpectation,
-    playbackIdentity,
     useDiscreteCommand,
 } from './discreteCommand.js';
 
@@ -171,14 +170,12 @@ export function DeviceDetail({
 
     function previousTrack() {
         runDiscreteCommand('previous-track',
-            () => api.keyChecked(deviceId, 'PREV_TRACK'),
-            { previousIdentity: playbackIdentity(status?.nowPlaying) });
+            () => api.keyChecked(deviceId, 'PREV_TRACK'));
     }
 
     function nextTrack() {
         runDiscreteCommand('next-track',
-            () => api.keyChecked(deviceId, 'NEXT_TRACK'),
-            { previousIdentity: playbackIdentity(status?.nowPlaying) });
+            () => api.keyChecked(deviceId, 'NEXT_TRACK'));
     }
 
     function selectPreset(preset) {

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -22,6 +22,7 @@ import { removeDeviceAndRefresh } from './deviceRemoval.js';
 import {
     DISCRETE_COMMAND_READBACK_DELAYS_MS,
     contentExpectation,
+    trackSkipExpectation,
     useDiscreteCommand,
 } from './discreteCommand.js';
 
@@ -192,13 +193,15 @@ export function DeviceDetail({
     function previousTrack() {
         runDiscreteCommand('previous-track',
             () => api.keyChecked(deviceId, 'PREV_TRACK'),
-            { previousTrackID: status?.nowPlaying?.TrackID || '' });
+            trackSkipExpectation(status?.nowPlaying,
+                Boolean(status?.nowPlaying?.SkipPreviousEnabled)));
     }
 
     function nextTrack() {
         runDiscreteCommand('next-track',
             () => api.keyChecked(deviceId, 'NEXT_TRACK'),
-            { previousTrackID: status?.nowPlaying?.TrackID || '' });
+            trackSkipExpectation(status?.nowPlaying,
+                Boolean(status?.nowPlaying?.SkipEnabled)));
     }
 
     function selectPreset(preset) {

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -131,14 +131,26 @@ export function DeviceDetail({
     const source = status?.nowPlaying?.Source;
     const playStatus = status?.nowPlaying?.PlayStatus;
 
+    // A speaker that is offline, or that has not been polled yet, reports no
+    // state to predict an outcome from. Reconciling such a command is
+    // impossible, but disabling the control is worse: that is exactly the
+    // speaker you want to power cycle or prod. These fall back to the
+    // behaviour from before reconciliation -- send the key, report nothing --
+    // rather than going dead.
     function togglePower() {
-        if (!source) return;
+        if (!source) {
+            api.power(deviceId);
+            return;
+        }
         runDiscreteCommand(source === 'STANDBY' ? 'power-on' : 'power-off',
             () => api.powerChecked(deviceId));
     }
 
     function togglePlayback() {
-        if (!playStatus) return;
+        if (!playStatus) {
+            api.key(deviceId, 'PLAY');
+            return;
+        }
         const isPlaying = playStatus === 'PLAY_STATE';
         runDiscreteCommand(isPlaying ? 'pause' : 'play',
             () => api.keyChecked(deviceId, isPlaying ? 'PAUSE' : 'PLAY'));
@@ -146,14 +158,20 @@ export function DeviceDetail({
 
     function toggleMute() {
         const muted = status?.volume?.MuteEnabled;
-        if (typeof muted !== 'boolean') return;
+        if (typeof muted !== 'boolean') {
+            api.key(deviceId, 'MUTE');
+            return;
+        }
         runDiscreteCommand(muted ? 'mute-off' : 'mute-on',
             () => api.keyChecked(deviceId, 'MUTE'));
     }
 
     function toggleShuffle() {
         const shuffle = status?.nowPlaying?.ShuffleSetting;
-        if (!shuffle) return;
+        if (!shuffle) {
+            api.key(deviceId, 'SHUFFLE_ON');
+            return;
+        }
         const target = shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON';
         runDiscreteCommand(target === 'SHUFFLE_ON' ? 'shuffle-on' : 'shuffle-off',
             () => api.keyChecked(deviceId, target));
@@ -161,7 +179,10 @@ export function DeviceDetail({
 
     function cycleRepeat() {
         const repeat = status?.nowPlaying?.RepeatSetting;
-        if (!repeat) return;
+        if (!repeat) {
+            api.key(deviceId, 'REPEAT_OFF');
+            return;
+        }
         const target = repeat === 'REPEAT_OFF' ? 'REPEAT_ALL'
             : repeat === 'REPEAT_ALL' ? 'REPEAT_ONE' : 'REPEAT_OFF';
         runDiscreteCommand(`repeat-${target.substring('REPEAT_'.length).toLowerCase()}`,
@@ -219,7 +240,7 @@ export function DeviceDetail({
                     class="btn-icon command-btn ${command?.action?.startsWith('power-') ? command.outcome : ''}"
                     onClick=${togglePower}
                     title="Power"
-                    disabled=${commandBusy || !source}
+                    disabled=${commandBusy}
                     aria-busy=${command?.action?.startsWith('power-') && commandBusy ? 'true' : null}
                 >
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -135,21 +135,21 @@ export function DeviceDetail({
     function togglePower() {
         if (!source) return;
         runDiscreteCommand(source === 'STANDBY' ? 'power-on' : 'power-off',
-            () => api.power(deviceId));
+            () => api.powerChecked(deviceId));
     }
 
     function togglePlayback() {
         if (!playStatus) return;
         const isPlaying = playStatus === 'PLAY_STATE';
         runDiscreteCommand(isPlaying ? 'pause' : 'play',
-            () => api.key(deviceId, isPlaying ? 'PAUSE' : 'PLAY'));
+            () => api.keyChecked(deviceId, isPlaying ? 'PAUSE' : 'PLAY'));
     }
 
     function toggleMute() {
         const muted = status?.volume?.MuteEnabled;
         if (typeof muted !== 'boolean') return;
         runDiscreteCommand(muted ? 'mute-off' : 'mute-on',
-            () => api.key(deviceId, 'MUTE'));
+            () => api.keyChecked(deviceId, 'MUTE'));
     }
 
     function toggleShuffle() {
@@ -157,7 +157,7 @@ export function DeviceDetail({
         if (!shuffle) return;
         const target = shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON';
         runDiscreteCommand(target === 'SHUFFLE_ON' ? 'shuffle-on' : 'shuffle-off',
-            () => api.key(deviceId, target));
+            () => api.keyChecked(deviceId, target));
     }
 
     function cycleRepeat() {
@@ -166,32 +166,32 @@ export function DeviceDetail({
         const target = repeat === 'REPEAT_OFF' ? 'REPEAT_ALL'
             : repeat === 'REPEAT_ALL' ? 'REPEAT_ONE' : 'REPEAT_OFF';
         runDiscreteCommand(`repeat-${target.substring('REPEAT_'.length).toLowerCase()}`,
-            () => api.key(deviceId, target));
+            () => api.keyChecked(deviceId, target));
     }
 
     function previousTrack() {
         runDiscreteCommand('previous-track',
-            () => api.key(deviceId, 'PREV_TRACK'),
+            () => api.keyChecked(deviceId, 'PREV_TRACK'),
             { previousIdentity: playbackIdentity(status?.nowPlaying) });
     }
 
     function nextTrack() {
         runDiscreteCommand('next-track',
-            () => api.key(deviceId, 'NEXT_TRACK'),
+            () => api.keyChecked(deviceId, 'NEXT_TRACK'),
             { previousIdentity: playbackIdentity(status?.nowPlaying) });
     }
 
     function selectPreset(preset) {
         if (!preset?.ContentItem) return;
         runDiscreteCommand('preset',
-            () => api.control(deviceId, 'preset', preset.ID),
+            () => api.controlChecked(deviceId, 'preset', preset.ID),
             { ...contentExpectation(preset.ContentItem), targetId: String(preset.ID) });
     }
 
     function playRecent(item) {
         const content = item?.ContentItem;
         if (!content?.Location) return;
-        runDiscreteCommand('recent', () => api.play(deviceId, {
+        runDiscreteCommand('recent', () => api.playChecked(deviceId, {
             source: content.Source,
             type: content.Type,
             location: content.Location,

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -90,11 +90,65 @@ function nowPlayingRevision(status) {
     return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
 }
 
-function discreteCommandRevision(status, action) {
-    return action?.startsWith('mute-') ? statusRevision(status) : nowPlayingRevision(status);
+function commandAction(command) {
+    return typeof command === 'string' ? command : command?.action;
 }
 
-function matchesDiscreteCommand(status, action) {
+function discreteCommandRevision(status, command) {
+    return commandAction(command)?.startsWith('mute-')
+        ? statusRevision(status)
+        : nowPlayingRevision(status);
+}
+
+function playbackIdentity(nowPlaying) {
+    if (!nowPlaying) return '';
+    const item = nowPlaying.ContentItem || {};
+    return [
+        nowPlaying.Source,
+        nowPlaying.SourceAccount,
+        item.Source,
+        item.SourceAccount,
+        item.Location,
+        nowPlaying.TrackID,
+        nowPlaying.Track,
+        nowPlaying.StationName,
+    ].map(value => value || '').join('\u0000');
+}
+
+function contentExpectation(item) {
+    const source = item?.Source || '';
+    const sourceAccount = item?.SourceAccount && item.SourceAccount !== source
+        ? item.SourceAccount
+        : '';
+    return {
+        source,
+        sourceAccount,
+        location: item?.Location || '',
+        itemName: item?.ItemName || '',
+    };
+}
+
+function matchesContentExpectation(nowPlaying, expected) {
+    if (!nowPlaying || !expected) return false;
+    const item = nowPlaying.ContentItem || {};
+    const source = item.Source || nowPlaying.Source || '';
+    const account = item.SourceAccount || nowPlaying.SourceAccount || '';
+    if (expected.source && source !== expected.source) return false;
+    if (expected.sourceAccount && account !== expected.sourceAccount) return false;
+    if (expected.location) {
+        return item.Location === expected.location ||
+            nowPlaying.StationLocation === expected.location;
+    }
+    if (expected.itemName) return [
+        item.ItemName,
+        nowPlaying.Track,
+        nowPlaying.StationName,
+    ].includes(expected.itemName);
+    return Boolean(expected.source);
+}
+
+function matchesDiscreteCommand(status, command) {
+    const action = commandAction(command);
     const nowPlaying = status?.nowPlaying;
     if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
     if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
@@ -107,11 +161,21 @@ function matchesDiscreteCommand(status, action) {
     if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
     if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
     if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
+    if (action === 'next-track' || action === 'previous-track') {
+        const identity = playbackIdentity(nowPlaying);
+        return Boolean(identity) && identity !== command?.expected?.previousIdentity;
+    }
+    if (action === 'preset' || action === 'recent') {
+        return matchesContentExpectation(nowPlaying, command?.expected);
+    }
     return false;
 }
 
-function discreteCommandFailed(status, action) {
-    if (action !== 'play' && action !== 'pause') return false;
+function discreteCommandFailed(status, command) {
+    const action = commandAction(command);
+    if (!['play', 'pause', 'next-track', 'previous-track', 'preset', 'recent'].includes(action)) {
+        return false;
+    }
     const nowPlaying = status?.nowPlaying;
     return nowPlaying?.Source === 'INVALID_SOURCE' ||
         nowPlaying?.Source?.endsWith('_ERROR') ||
@@ -198,6 +262,34 @@ function discreteCommandText(command) {
             unverified: 'Repeat command unverified',
             failed: 'Repeat command failed',
         },
+        'next-track': {
+            pending: 'Skipping to next track',
+            'provisional-confirmed': 'Next track started, confirming',
+            'final-confirmed': 'Next track started',
+            unverified: 'Next-track command unverified',
+            failed: 'Next-track command failed',
+        },
+        'previous-track': {
+            pending: 'Returning to previous track',
+            'provisional-confirmed': 'Previous track started, confirming',
+            'final-confirmed': 'Previous track started',
+            unverified: 'Previous-track command unverified',
+            failed: 'Previous-track command failed',
+        },
+        preset: {
+            pending: 'Starting preset',
+            'provisional-confirmed': 'Preset started, confirming',
+            'final-confirmed': 'Preset started',
+            unverified: 'Preset playback unverified',
+            failed: 'Preset playback failed',
+        },
+        recent: {
+            pending: 'Starting recent item',
+            'provisional-confirmed': 'Recent item started, confirming',
+            'final-confirmed': 'Recent item started',
+            unverified: 'Recent-item playback unverified',
+            failed: 'Recent-item playback failed',
+        },
     };
     return labels[command.action]?.[command.outcome] || '';
 }
@@ -252,12 +344,12 @@ export function DeviceDetail({
     }, [deviceId]);
 
     useEffect(() => {
-        const revision = discreteCommandRevision(status, command?.action);
+        const revision = discreteCommandRevision(status, command);
         if (!command || revision === null || command.startRevision === null ||
             revision <= command.startRevision || command.outcome === 'failed' ||
             command.outcome === 'unverified') return;
 
-        const matches = matchesDiscreteCommand(status, command.action);
+        const matches = matchesDiscreteCommand(status, command);
         if (command.outcome === 'final-confirmed') {
             if (revision > command.confirmedRevision && !matches) {
                 setCommand(previous => previous?.generation === command.generation
@@ -265,7 +357,7 @@ export function DeviceDetail({
             }
             return;
         }
-        if (discreteCommandFailed(status, command.action)) {
+        if (discreteCommandFailed(status, command)) {
             clearCommandReadbacks();
             commandRef.current.active = null;
             setCommand(previous => previous?.generation === command.generation
@@ -278,16 +370,17 @@ export function DeviceDetail({
         }
     }, [command, status]);
 
-    function runDiscreteCommand(action, invoke) {
+    function runDiscreteCommand(action, invoke, expected = null) {
         if (commandRef.current.active) return;
 
         clearCommandReadbacks();
         const generation = commandRef.current.generation + 1;
-        const startRevision = discreteCommandRevision(status, action);
+        const request = { action, expected };
+        const startRevision = discreteCommandRevision(status, request);
         const active = { generation, latestReadback: -1, writeError: null };
         commandRef.current.generation = generation;
         commandRef.current.active = active;
-        setCommand({ action, generation, outcome: 'pending', startRevision });
+        setCommand({ ...request, generation, outcome: 'pending', startRevision });
         const startedAt = Date.now();
 
         commandReadbackDelays.forEach((delay, index) => {
@@ -303,19 +396,19 @@ export function DeviceDetail({
                     }
 
                     const readbackStatus = response.data.status;
-                    const readbackRevision = discreteCommandRevision(readbackStatus, action);
+                    const readbackRevision = discreteCommandRevision(readbackStatus, request);
                     const revisionIsNewer = startRevision !== null && readbackRevision !== null &&
                         readbackRevision > startRevision;
                     onStatusReadback?.(deviceId, readbackStatus);
 
-                    if (revisionIsNewer && discreteCommandFailed(readbackStatus, action)) {
+                    if (revisionIsNewer && discreteCommandFailed(readbackStatus, request)) {
                         clearCommandReadbacks();
                         commandRef.current.active = null;
-                        setCommand({ action, generation, outcome: 'failed', startRevision });
-                    } else if (revisionIsNewer && matchesDiscreteCommand(readbackStatus, action)) {
+                        setCommand({ ...request, generation, outcome: 'failed', startRevision });
+                    } else if (revisionIsNewer && matchesDiscreteCommand(readbackStatus, request)) {
                         const isFinalReadback = index === commandReadbackDelays.length - 1;
                         setCommand({
-                            action,
+                            ...request,
                             generation,
                             outcome: isFinalReadback ? 'final-confirmed' : 'provisional-confirmed',
                             startRevision,
@@ -328,7 +421,7 @@ export function DeviceDetail({
                     } else if (index === commandReadbackDelays.length - 1) {
                         commandRef.current.active = null;
                         setCommand({
-                            action,
+                            ...request,
                             generation,
                             outcome: 'unverified',
                             startRevision,
@@ -340,7 +433,7 @@ export function DeviceDetail({
                         index === commandReadbackDelays.length - 1) {
                         commandRef.current.active = null;
                         setCommand({
-                            action,
+                            ...request,
                             generation,
                             outcome: 'unverified',
                             startRevision,
@@ -409,6 +502,42 @@ export function DeviceDetail({
             () => api.key(deviceId, target));
     }
 
+    function previousTrack() {
+        runDiscreteCommand('previous-track',
+            () => api.key(deviceId, 'PREV_TRACK'),
+            { previousIdentity: playbackIdentity(status?.nowPlaying) });
+    }
+
+    function nextTrack() {
+        runDiscreteCommand('next-track',
+            () => api.key(deviceId, 'NEXT_TRACK'),
+            { previousIdentity: playbackIdentity(status?.nowPlaying) });
+    }
+
+    function selectPreset(preset) {
+        if (!preset?.ContentItem) return;
+        runDiscreteCommand('preset',
+            () => api.control(deviceId, 'preset', preset.ID),
+            { ...contentExpectation(preset.ContentItem), targetId: String(preset.ID) });
+    }
+
+    function playRecent(item) {
+        const content = item?.ContentItem;
+        if (!content?.Location) return;
+        runDiscreteCommand('recent', () => api.play(deviceId, {
+            source: content.Source,
+            type: content.Type,
+            location: content.Location,
+            sourceAccount: content.SourceAccount,
+            itemName: content.ItemName,
+            containerArt: content.ContainerArt,
+            isPresetable: content.IsPresetable,
+        }), {
+            ...contentExpectation(content),
+            targetId: String(item.ID || item.UTCTime || content.Location),
+        });
+    }
+
     if (!device) {
         return html`
             <div class="page-header">
@@ -446,8 +575,16 @@ export function DeviceDetail({
                 onToggleMute=${toggleMute}
                 onToggleShuffle=${toggleShuffle}
                 onCycleRepeat=${cycleRepeat}
+                onPreviousTrack=${previousTrack}
+                onNextTrack=${nextTrack}
             />
-            <${Presets} deviceId=${deviceId} status=${device.status} />
+            <${Presets}
+                deviceId=${deviceId}
+                status=${device.status}
+                command=${command}
+                commandBusy=${commandBusy}
+                onSelect=${selectPreset}
+            />
             <${Sources}
                 deviceId=${deviceId}
                 status=${device.status}
@@ -468,7 +605,12 @@ export function DeviceDetail({
                 </aside>
             ` : null}
             <${Zone} deviceId=${deviceId} devices=${devices} />
-            <${Recents} deviceId=${deviceId} />
+            <${Recents}
+                deviceId=${deviceId}
+                command=${command}
+                commandBusy=${commandBusy}
+                onPlay=${playRecent}
+            />
             ${!device.stereoPair ? html`
                 <div class="device-management-section">
                     <div class="section-title">Device management</div>

--- a/pkg/service/soundtouchweb/static/js/components/ContentPlaybackCommand.js
+++ b/pkg/service/soundtouchweb/static/js/components/ContentPlaybackCommand.js
@@ -1,0 +1,60 @@
+import { h } from 'preact';
+import { useEffect, useRef } from 'preact/hooks';
+import htm from 'htm';
+import { useDiscreteCommand } from '../discreteCommand.js';
+
+const html = htm.bind(h);
+
+export function ContentPlaybackCommand({
+    request,
+    devices,
+    onStatusReadback,
+    onStateChange,
+    onClear,
+}) {
+    const started = useRef(false);
+    const observedCommand = useRef(false);
+    const device = request ? devices[request.deviceId] : null;
+    const { command, busy, statusText, run } = useDiscreteCommand({
+        deviceId: request?.deviceId,
+        status: device?.status,
+        onStatusReadback,
+        readbackDelays: request?.readbackDelays,
+        targetIdentity: request?.targetIdentity,
+        currentTargetIdentity: device?.info?.device_id,
+    });
+
+    useEffect(() => {
+        if (!request || started.current) return;
+        started.current = true;
+        run(request.action, request.invoke, request.expected, {
+            expectedFromResponse: request.expectedFromResponse,
+        });
+    }, [request]);
+
+    useEffect(() => {
+        if (command) {
+            observedCommand.current = true;
+            onStateChange?.({ busy, outcome: command.outcome, error: command.error || '' });
+        } else if (started.current && observedCommand.current) {
+            onClear?.();
+        }
+    }, [busy, command, onClear, onStateChange]);
+
+    if (!request) return null;
+    const deviceName = device?.info?.name || request.deviceId;
+    return html`
+        <div class="content-command-status ${command?.outcome || 'pending'}" role="status" aria-live="polite">
+            <span>
+                <strong>${deviceName}</strong>: ${statusText || 'Starting playback'}
+                ${command?.error ? html`<small class="content-command-error">${command.error}</small>` : null}
+            </span>
+            <button
+                class="btn-secondary"
+                onClick=${onClear}
+                disabled=${busy}
+                title=${busy ? 'Waiting for device readback' : 'Dismiss'}
+            >Dismiss</button>
+        </div>
+    `;
+}

--- a/pkg/service/soundtouchweb/static/js/components/Controls.js
+++ b/pkg/service/soundtouchweb/static/js/components/Controls.js
@@ -160,7 +160,7 @@ export function Controls({
                 <button
                     class="ctrl-btn command-btn previous-btn ${previousCommand?.outcome || ''}"
                     onClick=${onPreviousTrack || (() => send('PREV_TRACK'))}
-                    disabled=${commandBusy || !np}
+                    disabled=${commandBusy}
                     aria-busy=${previousCommand && commandBusy ? 'true' : null}
                     title=${previousCommand && commandBusy ? commandStatus : 'Previous'}
                     aria-label="Previous"
@@ -170,7 +170,7 @@ export function Controls({
                 <button
                     class="ctrl-btn play-btn command-btn ${transportCommand?.outcome || ''}"
                     onClick=${onTogglePlayback || (() => send(isPlaying ? 'PAUSE' : 'PLAY'))}
-                    disabled=${commandBusy || !np?.PlayStatus}
+                    disabled=${commandBusy}
                     aria-busy=${transportCommand && commandBusy ? 'true' : null}
                     title=${transportCommand && commandBusy ? commandStatus : (isPlaying ? 'Pause' : 'Play')}
                     aria-label=${isPlaying ? 'Pause' : 'Play'}
@@ -180,7 +180,7 @@ export function Controls({
                 <button
                     class="ctrl-btn command-btn next-btn ${nextCommand?.outcome || ''}"
                     onClick=${onNextTrack || (() => send('NEXT_TRACK'))}
-                    disabled=${commandBusy || !np}
+                    disabled=${commandBusy}
                     aria-busy=${nextCommand && commandBusy ? 'true' : null}
                     title=${nextCommand && commandBusy ? commandStatus : 'Next'}
                     aria-label="Next"
@@ -190,7 +190,7 @@ export function Controls({
                 <button
                     class="ctrl-btn command-btn mute-btn ${isMuted ? 'active' : ''} ${muteCommand?.outcome || ''}"
                     onClick=${onToggleMute || (() => send('MUTE'))}
-                    disabled=${commandBusy || typeof status?.volume?.MuteEnabled !== 'boolean'}
+                    disabled=${commandBusy}
                     aria-busy=${muteCommand && commandBusy ? 'true' : null}
                     title=${muteCommand && commandBusy ? commandStatus : (isMuted ? 'Unmute' : 'Mute')}
                     aria-label=${isMuted ? 'Unmute' : 'Mute'}
@@ -201,7 +201,7 @@ export function Controls({
                 <button
                     class="ctrl-btn command-btn shuffle-btn ${shuffle === 'SHUFFLE_ON' ? 'active' : ''} ${shuffleCommand?.outcome || ''}"
                     onClick=${onToggleShuffle || (() => send(shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON'))}
-                    disabled=${commandBusy || !np?.ShuffleSetting}
+                    disabled=${commandBusy}
                     aria-busy=${shuffleCommand && commandBusy ? 'true' : null}
                     title=${shuffleCommand && commandBusy ? commandStatus : 'Shuffle'}
                     aria-label="Shuffle"
@@ -216,7 +216,7 @@ export function Controls({
                         else if (repeat === 'REPEAT_ALL') send('REPEAT_ONE');
                         else send('REPEAT_OFF');
                     })}
-                    disabled=${commandBusy || !np?.RepeatSetting}
+                    disabled=${commandBusy}
                     aria-busy=${repeatCommand && commandBusy ? 'true' : null}
                     title=${repeatCommand && commandBusy ? commandStatus : (repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat')}
                     aria-label=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'}

--- a/pkg/service/soundtouchweb/static/js/components/Controls.js
+++ b/pkg/service/soundtouchweb/static/js/components/Controls.js
@@ -88,6 +88,8 @@ export function Controls({
     onToggleMute,
     onToggleShuffle,
     onCycleRepeat,
+    onPreviousTrack,
+    onNextTrack,
 }) {
     const np = status?.nowPlaying;
     const isPlaying = np?.PlayStatus === 'PLAY_STATE';
@@ -121,6 +123,8 @@ export function Controls({
     const muteCommand = command?.action?.startsWith('mute-') ? command : null;
     const shuffleCommand = command?.action?.startsWith('shuffle-') ? command : null;
     const repeatCommand = command?.action?.startsWith('repeat-') ? command : null;
+    const previousCommand = command?.action === 'previous-track' ? command : null;
+    const nextCommand = command?.action === 'next-track' ? command : null;
 
     // One throttle per slider per mount. The local state still updates on every
     // input, so the handle keeps up with the pointer; only the network write is
@@ -153,7 +157,14 @@ export function Controls({
     return html`
         <div class="controls">
             <div class="transport">
-                <button class="ctrl-btn" onClick=${() => send('PREV_TRACK')} title="Previous" aria-label="Previous">
+                <button
+                    class="ctrl-btn command-btn previous-btn ${previousCommand?.outcome || ''}"
+                    onClick=${onPreviousTrack || (() => send('PREV_TRACK'))}
+                    disabled=${commandBusy || !np}
+                    aria-busy=${previousCommand && commandBusy ? 'true' : null}
+                    title=${previousCommand && commandBusy ? commandStatus : 'Previous'}
+                    aria-label="Previous"
+                >
                     ${IconPrev()}
                 </button>
                 <button
@@ -166,7 +177,14 @@ export function Controls({
                 >
                     ${isPlaying ? IconPause() : IconPlay()}
                 </button>
-                <button class="ctrl-btn" onClick=${() => send('NEXT_TRACK')} title="Next" aria-label="Next">
+                <button
+                    class="ctrl-btn command-btn next-btn ${nextCommand?.outcome || ''}"
+                    onClick=${onNextTrack || (() => send('NEXT_TRACK'))}
+                    disabled=${commandBusy || !np}
+                    aria-busy=${nextCommand && commandBusy ? 'true' : null}
+                    title=${nextCommand && commandBusy ? commandStatus : 'Next'}
+                    aria-label="Next"
+                >
                     ${IconNext()}
                 </button>
                 <button

--- a/pkg/service/soundtouchweb/static/js/components/Controls.js
+++ b/pkg/service/soundtouchweb/static/js/components/Controls.js
@@ -85,6 +85,9 @@ export function Controls({
     commandBusy = false,
     commandStatus = '',
     onTogglePlayback,
+    onToggleMute,
+    onToggleShuffle,
+    onCycleRepeat,
 }) {
     const np = status?.nowPlaying;
     const isPlaying = np?.PlayStatus === 'PLAY_STATE';
@@ -115,6 +118,9 @@ export function Controls({
     const send = (key) => api.key(deviceId, key);
     const transportCommand = command?.action === 'play' || command?.action === 'pause'
         ? command : null;
+    const muteCommand = command?.action?.startsWith('mute-') ? command : null;
+    const shuffleCommand = command?.action?.startsWith('shuffle-') ? command : null;
+    const repeatCommand = command?.action?.startsWith('repeat-') ? command : null;
 
     // One throttle per slider per mount. The local state still updates on every
     // input, so the handle keeps up with the pointer; only the network write is
@@ -144,16 +150,6 @@ export function Controls({
         writeBalance(deviceId, val);
     }
 
-    function toggleShuffle() {
-        send(shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON');
-    }
-
-    function cycleRepeat() {
-        if (repeat === 'REPEAT_OFF') send('REPEAT_ALL');
-        else if (repeat === 'REPEAT_ALL') send('REPEAT_ONE');
-        else send('REPEAT_OFF');
-    }
-
     return html`
         <div class="controls">
             <div class="transport">
@@ -165,7 +161,7 @@ export function Controls({
                     onClick=${onTogglePlayback || (() => send(isPlaying ? 'PAUSE' : 'PLAY'))}
                     disabled=${commandBusy || !np?.PlayStatus}
                     aria-busy=${transportCommand && commandBusy ? 'true' : null}
-                    title=${transportCommand ? commandStatus : (isPlaying ? 'Pause' : 'Play')}
+                    title=${transportCommand && commandBusy ? commandStatus : (isPlaying ? 'Pause' : 'Play')}
                     aria-label=${isPlaying ? 'Pause' : 'Play'}
                 >
                     ${isPlaying ? IconPause() : IconPlay()}
@@ -173,13 +169,41 @@ export function Controls({
                 <button class="ctrl-btn" onClick=${() => send('NEXT_TRACK')} title="Next" aria-label="Next">
                     ${IconNext()}
                 </button>
-                <button class="ctrl-btn ${isMuted ? 'active' : ''}" onClick=${() => send('MUTE')} title="Mute" aria-label="Mute" aria-pressed=${isMuted}>
+                <button
+                    class="ctrl-btn command-btn mute-btn ${isMuted ? 'active' : ''} ${muteCommand?.outcome || ''}"
+                    onClick=${onToggleMute || (() => send('MUTE'))}
+                    disabled=${commandBusy || typeof status?.volume?.MuteEnabled !== 'boolean'}
+                    aria-busy=${muteCommand && commandBusy ? 'true' : null}
+                    title=${muteCommand && commandBusy ? commandStatus : (isMuted ? 'Unmute' : 'Mute')}
+                    aria-label=${isMuted ? 'Unmute' : 'Mute'}
+                    aria-pressed=${isMuted}
+                >
                     ${IconVolume({ muted: isMuted })}
                 </button>
-                <button class="ctrl-btn ${shuffle === 'SHUFFLE_ON' ? 'active' : ''}" onClick=${toggleShuffle} title="Shuffle" aria-label="Shuffle" aria-pressed=${shuffle === 'SHUFFLE_ON'}>
+                <button
+                    class="ctrl-btn command-btn shuffle-btn ${shuffle === 'SHUFFLE_ON' ? 'active' : ''} ${shuffleCommand?.outcome || ''}"
+                    onClick=${onToggleShuffle || (() => send(shuffle === 'SHUFFLE_ON' ? 'SHUFFLE_OFF' : 'SHUFFLE_ON'))}
+                    disabled=${commandBusy || !np?.ShuffleSetting}
+                    aria-busy=${shuffleCommand && commandBusy ? 'true' : null}
+                    title=${shuffleCommand && commandBusy ? commandStatus : 'Shuffle'}
+                    aria-label="Shuffle"
+                    aria-pressed=${shuffle === 'SHUFFLE_ON'}
+                >
                     ${IconShuffle()}
                 </button>
-                <button class="ctrl-btn ${repeat !== 'REPEAT_OFF' ? 'active' : ''}" onClick=${cycleRepeat} title=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-label=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-pressed=${repeat !== 'REPEAT_OFF'}>
+                <button
+                    class="ctrl-btn command-btn repeat-btn ${repeat !== 'REPEAT_OFF' ? 'active' : ''} ${repeatCommand?.outcome || ''}"
+                    onClick=${onCycleRepeat || (() => {
+                        if (repeat === 'REPEAT_OFF') send('REPEAT_ALL');
+                        else if (repeat === 'REPEAT_ALL') send('REPEAT_ONE');
+                        else send('REPEAT_OFF');
+                    })}
+                    disabled=${commandBusy || !np?.RepeatSetting}
+                    aria-busy=${repeatCommand && commandBusy ? 'true' : null}
+                    title=${repeatCommand && commandBusy ? commandStatus : (repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat')}
+                    aria-label=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'}
+                    aria-pressed=${repeat !== 'REPEAT_OFF'}
+                >
                     ${IconRepeat({ one: repeat === 'REPEAT_ONE' })}
                 </button>
             </div>

--- a/pkg/service/soundtouchweb/static/js/components/Controls.js
+++ b/pkg/service/soundtouchweb/static/js/components/Controls.js
@@ -78,7 +78,14 @@ function balanceLabel(level) {
     return level < 0 ? `L${-level}` : `R${level}`;
 }
 
-export function Controls({ deviceId, status }) {
+export function Controls({
+    deviceId,
+    status,
+    command,
+    commandBusy = false,
+    commandStatus = '',
+    onTogglePlayback,
+}) {
     const np = status?.nowPlaying;
     const isPlaying = np?.PlayStatus === 'PLAY_STATE';
     const actualVolume = status?.volume?.ActualVolume ?? 0;
@@ -106,6 +113,8 @@ export function Controls({ deviceId, status }) {
     useEffect(() => { setLocalBalance(actualBalance); }, [actualBalance]);
 
     const send = (key) => api.key(deviceId, key);
+    const transportCommand = command?.action === 'play' || command?.action === 'pause'
+        ? command : null;
 
     // One throttle per slider per mount. The local state still updates on every
     // input, so the handle keeps up with the pointer; only the network write is
@@ -152,9 +161,11 @@ export function Controls({ deviceId, status }) {
                     ${IconPrev()}
                 </button>
                 <button
-                    class="ctrl-btn play-btn"
-                    onClick=${() => send(isPlaying ? 'PAUSE' : 'PLAY')}
-                    title=${isPlaying ? 'Pause' : 'Play'}
+                    class="ctrl-btn play-btn command-btn ${transportCommand?.outcome || ''}"
+                    onClick=${onTogglePlayback || (() => send(isPlaying ? 'PAUSE' : 'PLAY'))}
+                    disabled=${commandBusy || !np?.PlayStatus}
+                    aria-busy=${transportCommand && commandBusy ? 'true' : null}
+                    title=${transportCommand ? commandStatus : (isPlaying ? 'Pause' : 'Play')}
                     aria-label=${isPlaying ? 'Pause' : 'Play'}
                 >
                     ${isPlaying ? IconPause() : IconPlay()}
@@ -171,6 +182,9 @@ export function Controls({ deviceId, status }) {
                 <button class="ctrl-btn ${repeat !== 'REPEAT_OFF' ? 'active' : ''}" onClick=${cycleRepeat} title=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-label=${repeat === 'REPEAT_ONE' ? 'Repeat one' : repeat === 'REPEAT_ALL' ? 'Repeat all' : 'Repeat'} aria-pressed=${repeat !== 'REPEAT_OFF'}>
                     ${IconRepeat({ one: repeat === 'REPEAT_ONE' })}
                 </button>
+            </div>
+            <div class="discrete-command-status" role="status" aria-live="polite">
+                ${commandStatus}
             </div>
             <div class="volume-row">
                 <span class="volume-icon">${IconVolume({ size: 16 })}</span>

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -5,7 +5,12 @@ import { api } from '../api.js';
 
 const html = htm.bind(h);
 
-export function Library({ devices }) {
+export function Library({
+    devices,
+    onPlaybackRequest,
+    playbackBusy = false,
+    commandReadbackDelays,
+}) {
     const deviceEntries = Object.entries(devices);
     const firstDeviceId = deviceEntries.length > 0 ? deviceEntries[0][0] : null;
 
@@ -17,7 +22,6 @@ export function Library({ devices }) {
     const [entries, setEntries] = useState([]);
     const [loading, setLoading] = useState(false);
     const [finding, setFinding] = useState(false);
-    const [playingName, setPlayingName] = useState(null);
 
     // Sync deviceId when devices prop first arrives or changes enough to
     // invalidate the current selection.
@@ -112,18 +116,30 @@ export function Library({ devices }) {
         await browseLevel(server.account, frame.location, frame.type);
     }
 
-    async function playEntry(entry) {
+    function playEntry(entry) {
         // Pass the entry's own type so a folder selects as a container ("dir")
         // rather than a single track — that lets the speaker queue the folder so
         // next/previous and auto-advance work, instead of stopping after one item.
-        await api.libraryPlay(deviceId, {
-            account: server.account,
-            location: entry.location,
-            type: entry.type || 'track',
-            name: entry.name,
+        const selectedDeviceId = deviceId;
+        const selectedServer = server;
+        if (!selectedDeviceId || !selectedServer) return;
+        onPlaybackRequest?.({
+            deviceId: selectedDeviceId,
+            action: 'library',
+            readbackDelays: commandReadbackDelays,
+            invoke: () => api.libraryPlay(selectedDeviceId, {
+                account: selectedServer.account,
+                location: entry.location,
+                type: entry.type || 'track',
+                name: entry.name,
+            }),
+            expected: {
+                source: 'STORED_MUSIC',
+                sourceAccount: selectedServer.account,
+                location: entry.location,
+                itemName: entry.name,
+            },
         });
-        setPlayingName(entry.name);
-        setTimeout(() => setPlayingName(null), 3000);
     }
 
     function toggleFinding() {
@@ -249,12 +265,6 @@ export function Library({ devices }) {
                         </nav>
                     ` : null}
 
-                    ${playingName ? html`
-                        <div style="font-size:.875rem;color:var(--text-dim);margin-bottom:.5rem">
-                            Playing: <strong>${playingName}</strong>
-                        </div>
-                    ` : null}
-
                     ${entries.length === 0 && !loading ? html`
                         <p style="font-size:.875rem;color:var(--text-dim);padding:.5rem 0">No items found.</p>
                     ` : null}
@@ -275,6 +285,7 @@ export function Library({ devices }) {
                                     <button
                                         class="tunein-play-btn"
                                         title="${entry.isDir ? 'Play folder' : 'Play'} on ${devices[deviceId]?.info?.name || deviceId}"
+                                        disabled=${playbackBusy}
                                         onClick=${(e) => { e.stopPropagation(); playEntry(entry); }}
                                     >▶</button>
                                 ` : null}

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -127,7 +127,7 @@ export function Library({
             deviceId: selectedDeviceId,
             action: 'library',
             readbackDelays: commandReadbackDelays,
-            invoke: () => api.libraryPlay(selectedDeviceId, {
+            invoke: () => api.libraryPlayChecked(selectedDeviceId, {
                 account: selectedServer.account,
                 location: entry.location,
                 type: entry.type || 'track',

--- a/pkg/service/soundtouchweb/static/js/components/PlayURL.js
+++ b/pkg/service/soundtouchweb/static/js/components/PlayURL.js
@@ -7,12 +7,17 @@ const html = htm.bind(h);
 
 const LS_KEY = 'aftertouch_service_url';
 
-export function PlayURL({ devices, serverServiceUrl }) {
+export function PlayURL({
+    devices,
+    serverServiceUrl,
+    onPlaybackRequest,
+    playbackBusy = false,
+    commandReadbackDelays,
+}) {
     const [url, setUrl] = useState('');
     const [name, setName] = useState('');
     const [serviceUrl, setServiceUrl] = useState(() => localStorage.getItem(LS_KEY) || '');
     const [pendingPlay, setPendingPlay] = useState(null);
-    const [status, setStatus] = useState(null);
 
     useEffect(() => {
         if (serverServiceUrl && !localStorage.getItem(LS_KEY)) {
@@ -32,23 +37,35 @@ export function PlayURL({ devices, serverServiceUrl }) {
     function startPlay() {
         const trimmedUrl = url.trim();
         if (!trimmedUrl) return;
-        setStatus(null);
         setPendingPlay({ url: trimmedUrl, name: name.trim() || trimmedUrl });
     }
 
-    async function playOn(deviceId) {
+    function playOn(deviceId) {
         const item = pendingPlay;
-        setPendingPlay(null);
-        setStatus('Playing…');
-        try {
-            // When configured server-side, that value wins; send it so a stale
-            // localStorage override never matters.
-            const effectiveServiceUrl = serverServiceUrl || serviceUrl.trim();
-            const resp = await api.playURL(deviceId, item.url, item.name, '', effectiveServiceUrl);
-            setStatus(resp.success ? 'Playing — use ★ on the device page to save as preset' : 'Error: ' + (resp.error || 'Unknown error'));
-        } catch (e) {
-            setStatus('Error: ' + e.message);
-        }
+        if (!item) return;
+        // When configured server-side, that value wins; send it so a stale
+        // localStorage override never matters.
+        const effectiveServiceUrl = serverServiceUrl || serviceUrl.trim();
+        const accepted = onPlaybackRequest?.({
+            deviceId,
+            action: 'url',
+            readbackDelays: commandReadbackDelays,
+            invoke: () => api.playURL(deviceId, item.url, item.name, '', effectiveServiceUrl),
+            expected: {
+                source: 'LOCAL_INTERNET_RADIO',
+                itemName: item.name,
+            },
+            expectedFromResponse: response => {
+                const location = response?.data?.location;
+                if (!location) return null;
+                return {
+                    source: response.data.source || 'LOCAL_INTERNET_RADIO',
+                    location,
+                    itemName: response.data.itemName || item.name,
+                };
+            },
+        });
+        if (accepted !== false) setPendingPlay(null);
     }
 
     const deviceEntries = Object.entries(devices);
@@ -73,7 +90,7 @@ export function PlayURL({ devices, serverServiceUrl }) {
                     onInput=${(e) => setName(e.target.value)}
                     onKeyDown=${(e) => e.key === 'Enter' && startPlay()}
                 />
-                <button class="btn-primary" onClick=${startPlay} disabled=${!url.trim()}>▶ Play</button>
+                <button class="btn-primary" onClick=${startPlay} disabled=${!url.trim() || playbackBusy}>▶ Play</button>
             </div>
             <div class="tunein-toolbar" style="margin-top:.4rem">
                 <input
@@ -89,8 +106,6 @@ export function PlayURL({ devices, serverServiceUrl }) {
             ${serverServiceUrl
                 ? html`<div class="track-meta" style="margin-top:.2rem; opacity:.85">Configured server-side (soundtouch-player --service-url); edits here would be ignored.</div>`
                 : null}
-            ${status && html`<div class="track-meta" style="margin-top:.6rem">${status}</div>`}
-
             ${pendingPlay ? html`
                 <div class="overlay" onClick=${() => setPendingPlay(null)}>
                     <div class="device-picker" onClick=${(e) => e.stopPropagation()}>
@@ -99,7 +114,12 @@ export function PlayURL({ devices, serverServiceUrl }) {
                         <div class="picker-devices">
                             ${deviceEntries.length === 0 ? html`<p class="picker-no-devices">No devices found. Try discovering first.</p>` : null}
                             ${deviceEntries.map(([id, d]) => html`
-                                <button class="picker-device-btn" key=${id} onClick=${() => playOn(id)}>
+                                <button
+                                    class="picker-device-btn"
+                                    key=${id}
+                                    disabled=${playbackBusy}
+                                    onClick=${() => playOn(id)}
+                                >
                                     <div class="picker-device-info">
                                         <span class="picker-device-name">${d.info?.name || id}</span>
                                         <span class="picker-device-ip">${d.info?.ip_address || ''}</span>

--- a/pkg/service/soundtouchweb/static/js/components/PlayURL.js
+++ b/pkg/service/soundtouchweb/static/js/components/PlayURL.js
@@ -50,7 +50,7 @@ export function PlayURL({
             deviceId,
             action: 'url',
             readbackDelays: commandReadbackDelays,
-            invoke: () => api.playURL(deviceId, item.url, item.name, '', effectiveServiceUrl),
+            invoke: () => api.playURLChecked(deviceId, item.url, item.name, '', effectiveServiceUrl),
             expected: {
                 source: 'LOCAL_INTERNET_RADIO',
                 itemName: item.name,

--- a/pkg/service/soundtouchweb/static/js/components/Presets.js
+++ b/pkg/service/soundtouchweb/static/js/components/Presets.js
@@ -26,7 +26,7 @@ function sourceLabel(source) {
 // unreachable on touch devices and easy to miss everywhere else.  It shares
 // the star glyph and the gold --fav colour with the now-playing preset
 // picker (see NowPlaying.js) so both save paths read as the same gesture.
-function PresetSlot({ preset, deviceId, active, canSave }) {
+function PresetSlot({ preset, deviceId, active, canSave, command, commandBusy, onSelect }) {
     const [saveState, setSaveState] = useState(null); // null | 'saved' | 'error'
 
     const item = preset?.ContentItem;
@@ -58,7 +58,7 @@ function PresetSlot({ preset, deviceId, active, canSave }) {
 
     function select() {
         if (savableEmpty) store();
-        else if (!isEmpty) api.control(deviceId, 'preset', preset.ID);
+        else if (!isEmpty) (onSelect || (() => api.control(deviceId, 'preset', preset.ID)))(preset);
     }
 
     function save(e) {
@@ -82,7 +82,9 @@ function PresetSlot({ preset, deviceId, active, canSave }) {
                 class="preset-slot ${isEmpty ? 'empty' : ''} ${active ? 'active' : ''} ${savableEmpty ? 'savable' : ''}"
                 data-source=${item?.Source ?? ''}
                 onClick=${select}
-                disabled=${isEmpty && !savableEmpty}
+                disabled=${(isEmpty && !savableEmpty) || commandBusy}
+                aria-busy=${command?.action === 'preset' && commandBusy &&
+                    command?.expected?.targetId === String(preset.ID) ? 'true' : null}
                 title=${slotTitle}
             >
                 <span class="preset-thumb">
@@ -117,7 +119,7 @@ function PresetSlot({ preset, deviceId, active, canSave }) {
     `;
 }
 
-export function Presets({ deviceId, status }) {
+export function Presets({ deviceId, status, command, commandBusy = false, onSelect }) {
     const presets = status?.presets?.Preset ?? [];
     const currentSource = status?.nowPlaying?.Source;
     const currentLocation = status?.nowPlaying?.ContentItem?.Location;
@@ -147,6 +149,9 @@ export function Presets({ deviceId, status }) {
                         deviceId=${deviceId}
                         active=${isActive(preset)}
                         canSave=${canSave}
+                        command=${command}
+                        commandBusy=${commandBusy}
+                        onSelect=${onSelect}
                     />
                 `)}
             </div>

--- a/pkg/service/soundtouchweb/static/js/components/Presets.js
+++ b/pkg/service/soundtouchweb/static/js/components/Presets.js
@@ -82,7 +82,7 @@ function PresetSlot({ preset, deviceId, active, canSave, command, commandBusy, o
                 class="preset-slot ${isEmpty ? 'empty' : ''} ${active ? 'active' : ''} ${savableEmpty ? 'savable' : ''}"
                 data-source=${item?.Source ?? ''}
                 onClick=${select}
-                disabled=${(isEmpty && !savableEmpty) || commandBusy}
+                disabled=${!savableEmpty && (isEmpty || commandBusy)}
                 aria-busy=${command?.action === 'preset' && commandBusy &&
                     command?.expected?.targetId === String(preset.ID) ? 'true' : null}
                 title=${slotTitle}

--- a/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
@@ -12,7 +12,12 @@ function flattenSections(data) {
     );
 }
 
-export function RadioBrowser({ devices }) {
+export function RadioBrowser({
+    devices,
+    onPlaybackRequest,
+    playbackBusy = false,
+    commandReadbackDelays,
+}) {
     const [items, setItems] = useState([]);
     const [searchQuery, setSearchQuery] = useState('');
     const [loading, setLoading] = useState(false);
@@ -28,16 +33,28 @@ export function RadioBrowser({ devices }) {
         }
     }
 
-    async function playOn(deviceId) {
-        await api.radioBrowserPlay(deviceId, {
-            location: pendingPlay.location,
-            type: pendingPlay.type,
-            name: pendingPlay.name,
-            // The speaker keeps this on the ContentItem, so presets and
-            // recents saved from here show the station logo.
-            containerArt: pendingPlay.image,
+    function playOn(deviceId) {
+        const item = pendingPlay;
+        if (!item) return;
+        const accepted = onPlaybackRequest?.({
+            deviceId,
+            action: 'radiobrowser',
+            readbackDelays: commandReadbackDelays,
+            invoke: () => api.radioBrowserPlay(deviceId, {
+                location: item.location,
+                type: item.type,
+                name: item.name,
+                // The speaker keeps this on the ContentItem, so presets and
+                // recents saved from here show the station logo.
+                containerArt: pendingPlay.image,
+            }),
+            expected: {
+                source: 'RADIO_BROWSER',
+                location: item.location,
+                itemName: item.name,
+            },
         });
-        setPendingPlay(null);
+        if (accepted !== false) setPendingPlay(null);
     }
 
     const deviceEntries = Object.entries(devices);
@@ -73,6 +90,7 @@ export function RadioBrowser({ devices }) {
                                 <button
                                     class="tunein-play-btn"
                                     title="Play"
+                                    disabled=${playbackBusy}
                                     onClick=${() => {
                                         setPendingPlay({ location: play.href, type: play.type, name: item.name, image: item.imageUrl });
                                     }}
@@ -91,7 +109,12 @@ export function RadioBrowser({ devices }) {
                         <div class="picker-devices">
                             ${deviceEntries.length === 0 ? html`<p class="picker-no-devices">No devices found. Try discovering first.</p>` : null}
                             ${deviceEntries.map(([id, d]) => html`
-                                <button class="picker-device-btn" key=${id} onClick=${() => playOn(id)}>
+                                <button
+                                    class="picker-device-btn"
+                                    key=${id}
+                                    disabled=${playbackBusy}
+                                    onClick=${() => playOn(id)}
+                                >
                                     <div class="picker-device-info">
                                         <span class="picker-device-name">${d.info?.name || id}</span>
                                         <span class="picker-device-ip">${d.info?.ip_address || ''}</span>

--- a/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/RadioBrowser.js
@@ -40,7 +40,7 @@ export function RadioBrowser({
             deviceId,
             action: 'radiobrowser',
             readbackDelays: commandReadbackDelays,
-            invoke: () => api.radioBrowserPlay(deviceId, {
+            invoke: () => api.radioBrowserPlayChecked(deviceId, {
                 location: item.location,
                 type: item.type,
                 name: item.name,

--- a/pkg/service/soundtouchweb/static/js/components/Recents.js
+++ b/pkg/service/soundtouchweb/static/js/components/Recents.js
@@ -6,7 +6,7 @@ import { SourceIcon } from '../sourceIcons.js';
 
 const html = htm.bind(h);
 
-export function Recents({ deviceId }) {
+export function Recents({ deviceId, command, commandBusy = false, onPlay }) {
     const [items, setItems] = useState(null);
     const [loading, setLoading] = useState(true);
 
@@ -29,6 +29,10 @@ export function Recents({ deviceId }) {
     if (!items || items.length === 0) return null;
 
     function play(item) {
+        if (onPlay) {
+            onPlay(item);
+            return;
+        }
         const ci = item.ContentItem;
         if (!ci?.Location) return;
         api.play(deviceId, {
@@ -50,7 +54,15 @@ export function Recents({ deviceId }) {
                     const ci = item.ContentItem;
                     if (!ci) return null;
                     return html`
-                        <button class="recent-item" key=${item.ID || item.UTCTime} onClick=${() => play(item)}>
+                        <button
+                            class="recent-item"
+                            key=${item.ID || item.UTCTime}
+                            onClick=${() => play(item)}
+                            disabled=${commandBusy}
+                            aria-busy=${command?.action === 'recent' && commandBusy &&
+                                command?.expected?.targetId === String(item.ID || item.UTCTime || ci.Location)
+                                ? 'true' : null}
+                        >
                             ${ci.ContainerArt
                                 ? html`<img class="recent-art" src=${ci.ContainerArt} alt="" />`
                                 : html`<div class="recent-art recent-art-empty"><${SourceIcon} source=${ci.Source} className="recent-source-icon" /></div>`

--- a/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
@@ -35,7 +35,12 @@ function toSections(data) {
     }));
 }
 
-export function TuneInBrowser({ devices }) {
+export function TuneInBrowser({
+    devices,
+    onPlaybackRequest,
+    playbackBusy = false,
+    commandReadbackDelays,
+}) {
     const [sections, setSections] = useState([]);
     const [navStack, setNavStack] = useState([{ label: 'TuneIn', path: null }]);
     const [searchQuery, setSearchQuery] = useState('');
@@ -85,6 +90,7 @@ export function TuneInBrowser({ devices }) {
             setNavStack(s => [...s, { label: item.name, path }]);
             browse(path);
         } else if (play) {
+            if (playbackBusy) return;
             setPendingPlay({ ...play, name: item.name, image: item.imageUrl });
         }
     }
@@ -95,16 +101,28 @@ export function TuneInBrowser({ devices }) {
         browse(stack[stack.length - 1].path);
     }
 
-    async function playOn(deviceId) {
-        await api.tuneInPlay(deviceId, {
-            location: pendingPlay.location,
-            type: pendingPlay.type,
-            name: pendingPlay.name,
-            // The speaker keeps this on the ContentItem, so presets and
-            // recents saved from here show the station logo.
-            containerArt: pendingPlay.image,
+    function playOn(deviceId) {
+        const item = pendingPlay;
+        if (!item) return;
+        const accepted = onPlaybackRequest?.({
+            deviceId,
+            action: 'tunein',
+            readbackDelays: commandReadbackDelays,
+            invoke: () => api.tuneInPlay(deviceId, {
+                location: item.location,
+                type: item.type,
+                name: item.name,
+                // The speaker keeps this on the ContentItem, so presets and
+                // recents saved from here show the station logo.
+                containerArt: pendingPlay.image,
+            }),
+            expected: {
+                source: 'TUNEIN',
+                location: item.location,
+                itemName: item.name,
+            },
         });
-        setPendingPlay(null);
+        if (accepted !== false) setPendingPlay(null);
     }
 
     const deviceEntries = Object.entries(devices);
@@ -160,6 +178,7 @@ export function TuneInBrowser({ devices }) {
                                         <button
                                             class="tunein-play-btn"
                                             title="Play"
+                                            disabled=${playbackBusy}
                                             onClick=${(e) => {
                                                 e.stopPropagation();
                                                 setPendingPlay({ ...play, name: item.name, image: item.imageUrl });
@@ -187,7 +206,12 @@ export function TuneInBrowser({ devices }) {
                         <div class="picker-devices">
                             ${deviceEntries.length === 0 ? html`<p class="picker-no-devices">No devices found. Try discovering first.</p>` : null}
                             ${deviceEntries.map(([id, d]) => html`
-                                <button class="picker-device-btn" key=${id} onClick=${() => playOn(id)}>
+                                <button
+                                    class="picker-device-btn"
+                                    key=${id}
+                                    disabled=${playbackBusy}
+                                    onClick=${() => playOn(id)}
+                                >
                                     <div class="picker-device-info">
                                         <span class="picker-device-name">${d.info?.name || id}</span>
                                         <span class="picker-device-ip">${d.info?.ip_address || ''}</span>

--- a/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
+++ b/pkg/service/soundtouchweb/static/js/components/TuneInBrowser.js
@@ -108,7 +108,7 @@ export function TuneInBrowser({
             deviceId,
             action: 'tunein',
             readbackDelays: commandReadbackDelays,
-            invoke: () => api.tuneInPlay(deviceId, {
+            invoke: () => api.tuneInPlayChecked(deviceId, {
                 location: item.location,
                 type: item.type,
                 name: item.name,

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -70,13 +70,17 @@ function matchesContentExpectation(nowPlaying, expected) {
     return Boolean(expected.source);
 }
 
-function matchesCommand(status, command) {
+export function matchesCommand(status, command) {
     if (command?.expectationReady === false) return false;
     const action = commandAction(command);
     const nowPlaying = status?.nowPlaying;
     if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
     if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
-    if (action === 'pause') return nowPlaying?.PlayStatus === 'PAUSE_STATE';
+    if (action === 'pause') {
+        return nowPlaying?.PlayStatus === 'PAUSE_STATE' ||
+            (nowPlaying?.PlayStatus === 'STOP_STATE' &&
+                Boolean(nowPlaying.Source) && nowPlaying.Source !== 'STANDBY');
+    }
     if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
     if (action === 'mute-on') return status?.volume?.MuteEnabled === true;
     if (action === 'mute-off') return status?.volume?.MuteEnabled === false;

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -23,19 +23,15 @@ function commandRevision(status, command) {
         : nowPlayingRevision(status);
 }
 
-export function playbackIdentity(nowPlaying) {
-    if (!nowPlaying) return '';
-    const item = nowPlaying.ContentItem || {};
-    return [
-        nowPlaying.Source,
-        nowPlaying.SourceAccount,
-        item.Source,
-        item.SourceAccount,
-        item.Location,
-        nowPlaying.TrackID,
-        nowPlaying.Track,
-        nowPlaying.StationName,
-    ].map(value => value || '').join('\u0000');
+// Track skips cannot be confirmed by reading the speaker back. Confirming on
+// "what is playing changed" is wrong in both directions: a live stream rolls
+// its track metadata over by itself, so a skip that did nothing looks
+// confirmed, while AUX, PRODUCT and radio have no track concept at all, so a
+// skip that worked never changes anything and would always end unverified
+// after a full readback window of dead transport. A write the speaker
+// accepted is the only honest evidence available, so these settle on it.
+function settlesOnWrite(action) {
+    return action === 'next-track' || action === 'previous-track';
 }
 
 export function contentExpectation(item) {
@@ -98,10 +94,6 @@ export function matchesCommand(status, command) {
     if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
     if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
     if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
-    if (action === 'next-track' || action === 'previous-track') {
-        const identity = playbackIdentity(nowPlaying);
-        return Boolean(identity) && identity !== command?.expected?.previousIdentity;
-    }
     if (['preset', 'recent', 'tunein', 'radiobrowser', 'url', 'library'].includes(action)) {
         return matchesContentExpectation(nowPlaying, command?.expected);
     }
@@ -111,7 +103,7 @@ export function matchesCommand(status, command) {
 function commandFailed(status, command) {
     const action = commandAction(command);
     if (![
-        'play', 'pause', 'next-track', 'previous-track', 'preset', 'recent',
+        'play', 'pause', 'preset', 'recent',
         'tunein', 'radiobrowser', 'url', 'library',
     ].includes(action)) return false;
     const nowPlaying = status?.nowPlaying;
@@ -247,6 +239,8 @@ export function useDiscreteCommand({
         commandRef.current.active = active;
         setCommand({ ...request, generation, outcome: 'pending', startRevision });
         const startedAt = Date.now();
+        // A command that settles on its write schedules no readbacks at all.
+        const delays = settlesOnWrite(action) ? [] : readbackDelays;
 
         function fail(error) {
             if (commandRef.current.active !== active) return;
@@ -287,7 +281,23 @@ export function useDiscreteCommand({
             });
         }
 
-        readbackDelays.forEach((delay, index) => {
+        // Settles a command the speaker accepted but nothing will read back.
+        function confirmOnWrite() {
+            if (commandRef.current.active !== active) return;
+            clearReadbacks();
+            commandRef.current.active = null;
+            setCommand(previous => previous?.generation === generation
+                ? {
+                    ...active.request,
+                    generation,
+                    outcome: 'final-confirmed',
+                    startRevision,
+                    confirmedRevision: commandRevision(statusRef.current, active.request),
+                }
+                : previous);
+        }
+
+        delays.forEach((delay, index) => {
             const timer = setTimeout(async () => {
                 if (commandRef.current.active !== active) return;
                 active.latestReadback = index;
@@ -342,7 +352,7 @@ export function useDiscreteCommand({
                         // last deadline passes. So keep the remaining
                         // readbacks only as a fallback for a device whose
                         // events we are not receiving.
-                        const isFinalReadback = index === readbackDelays.length - 1;
+                        const isFinalReadback = index === delays.length - 1;
                         const eventStreamWatching = readbackStatus?.webSocketConnected === true;
                         const settled = isFinalReadback || eventStreamWatching;
                         setCommand({
@@ -356,12 +366,12 @@ export function useDiscreteCommand({
                             clearReadbacks();
                             commandRef.current.active = null;
                         }
-                    } else if (index === readbackDelays.length - 1) {
+                    } else if (index === delays.length - 1) {
                         unverified();
                     }
                 } catch (error) {
                     if (commandRef.current.active === active && active.latestReadback === index &&
-                        index === readbackDelays.length - 1) {
+                        index === delays.length - 1) {
                         unverified(error);
                     }
                 }
@@ -389,6 +399,7 @@ export function useDiscreteCommand({
             // Checked writes reject instead, and are classified below.
             if (response?.success === false) {
                 active.writeError = new Error(response.error || 'Command rejected');
+                if (settlesOnWrite(action)) unverified();
                 return;
             }
             if (options.expectedFromResponse) {
@@ -412,6 +423,7 @@ export function useDiscreteCommand({
                     ? { ...previous, expected: refinedExpected, expectationReady: true }
                     : previous);
             }
+            if (settlesOnWrite(action)) confirmOnWrite();
         }).catch(error => {
             if (commandRef.current.active !== active) return;
             // A definitive refusal (4xx) means the speaker never saw the
@@ -427,6 +439,9 @@ export function useDiscreteCommand({
                 return;
             }
             active.writeError = error;
+            // Nothing will read this one back, so the ambiguous failure is as
+            // far as it gets.
+            if (settlesOnWrite(action)) unverified(error);
         });
         return true;
     }

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -320,15 +320,30 @@ export function useDiscreteCommand({
                     if (revisionIsNewer && commandFailed(canonicalStatus, currentRequest)) {
                         fail(new Error('Device rejected the selected source'));
                     } else if (revisionIsNewer && matchesCommand(canonicalStatus, currentRequest)) {
+                        // A match is not always the end of the story: the
+                        // speaker can still transition into an error source a
+                        // few seconds later, so something has to keep watching.
+                        //
+                        // The event stream is the better watcher when it is
+                        // live: it reports that transition as it happens, and
+                        // the status effect above already turns it into a
+                        // failure. Polling on top of that only re-asks a
+                        // question we are already subscribed to the answer of,
+                        // and keeps every command button disabled until the
+                        // last deadline passes. So keep the remaining
+                        // readbacks only as a fallback for a device whose
+                        // events we are not receiving.
                         const isFinalReadback = index === readbackDelays.length - 1;
+                        const eventStreamWatching = readbackStatus?.webSocketConnected === true;
+                        const settled = isFinalReadback || eventStreamWatching;
                         setCommand({
                             ...currentRequest,
                             generation,
-                            outcome: isFinalReadback ? 'final-confirmed' : 'provisional-confirmed',
+                            outcome: settled ? 'final-confirmed' : 'provisional-confirmed',
                             startRevision,
                             confirmedRevision: canonicalRevision,
                         });
-                        if (isFinalReadback) {
+                        if (settled) {
                             clearReadbacks();
                             commandRef.current.active = null;
                         }

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -17,10 +17,32 @@ function commandAction(command) {
     return typeof command === 'string' ? command : command?.action;
 }
 
+function statusEpoch(status) {
+    const epoch = status?.epoch;
+    return Number.isSafeInteger(epoch) ? epoch : null;
+}
+
+// The revision a command is verified against, tagged with the epoch it was
+// counted in: mute is volume state and advances the aggregate revision, every
+// other command advances the now-playing one.
 function commandRevision(status, command) {
-    return commandAction(command)?.startsWith('mute-')
+    const revision = commandAction(command)?.startsWith('mute-')
         ? statusRevision(status)
         : nowPlayingRevision(status);
+    return revision === null ? null : { epoch: statusEpoch(status), revision };
+}
+
+// Revisions are only comparable within one epoch. A device id backed by a new
+// DeviceConnection, or a restarted service, restarts its revisions at 0, so a
+// reconnect in the middle of a command would otherwise leave every readback
+// looking older than the revision the command started at, and the command
+// could never confirm. Same rule as app.js acceptsNewerStatus.
+function isNewerRevision(start, candidate) {
+    if (!start || !candidate) return false;
+    if (start.epoch !== null && candidate.epoch !== null && candidate.epoch !== start.epoch) {
+        return candidate.epoch > start.epoch;
+    }
+    return candidate.revision > start.revision;
 }
 
 // Track skips cannot be confirmed by reading the speaker back. Confirming on
@@ -191,13 +213,12 @@ export function useDiscreteCommand({
 
     useEffect(() => {
         const revision = commandRevision(status, command);
-        if (!command || revision === null || command.startRevision === null ||
-            revision <= command.startRevision || command.outcome === 'failed' ||
-            command.outcome === 'unverified') return;
+        if (!command || !isNewerRevision(command.startRevision, revision) ||
+            command.outcome === 'failed' || command.outcome === 'unverified') return;
 
         const matches = matchesCommand(status, command);
         if (command.outcome === 'final-confirmed') {
-            if (revision > command.confirmedRevision && !matches) {
+            if (isNewerRevision(command.confirmedRevision, revision) && !matches) {
                 setCommand(previous => previous?.generation === command.generation
                     ? null : previous);
             }
@@ -328,12 +349,11 @@ export function useDiscreteCommand({
                     const currentStatus = statusRef.current;
                     const currentRevision = commandRevision(currentStatus, currentRequest);
                     const canonicalStatus = currentRevision !== null &&
-                        (readbackRevision === null || currentRevision >= readbackRevision)
+                        !isNewerRevision(currentRevision, readbackRevision)
                         ? currentStatus
                         : readbackStatus;
                     const canonicalRevision = commandRevision(canonicalStatus, currentRequest);
-                    const revisionIsNewer = startRevision !== null && canonicalRevision !== null &&
-                        canonicalRevision > startRevision;
+                    const revisionIsNewer = isNewerRevision(startRevision, canonicalRevision);
                     onStatusReadback?.(deviceId, readbackStatus, response.data.info);
 
                     if (revisionIsNewer && commandFailed(canonicalStatus, currentRequest)) {

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -81,7 +81,16 @@ export function matchesCommand(status, command) {
             (nowPlaying?.PlayStatus === 'STOP_STATE' &&
                 Boolean(nowPlaying.Source) && nowPlaying.Source !== 'STANDBY');
     }
-    if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
+    if (action === 'play') {
+        // Internet radio reports BUFFERING_STATE for seconds at a time before
+        // the first audio arrives, sometimes past the last readback deadline.
+        // That is the command working, so treat it as confirmed -- but only
+        // for a real source, since a speaker in standby is not starting
+        // anything.
+        return nowPlaying?.PlayStatus === 'PLAY_STATE' ||
+            (nowPlaying?.PlayStatus === 'BUFFERING_STATE' &&
+                Boolean(nowPlaying.Source) && nowPlaying.Source !== 'STANDBY');
+    }
     if (action === 'mute-on') return status?.volume?.MuteEnabled === true;
     if (action === 'mute-off') return status?.volume?.MuteEnabled === false;
     if (action === 'shuffle-on') return nowPlaying?.ShuffleSetting === 'SHUFFLE_ON';

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -56,16 +56,52 @@ function isTrackSkip(action) {
     return action === 'next-track' || action === 'previous-track';
 }
 
-// A skip is verifiable exactly where the speaker reports a trackID. That is a
-// stable per-track identity (`spotify:track:...` in the captured firmware
-// responses), so unlike track/stationName it does not move when a live stream
-// rolls its own title metadata over, and it does change when a skip really
-// happens. Sources with no track concept -- AUX, PRODUCT, internet radio --
-// report no trackID at all, and there no readback can ever say anything, so
-// the command settles on a write the speaker accepted instead of spending the
-// whole readback window with the transport dead to end "unverified".
+// What identifies "the same track" where the speaker reports no trackID.
+// Stringified so an absent field cannot merge into its neighbour.
+export function trackMetadataIdentity(nowPlaying) {
+    return JSON.stringify([
+        nowPlaying?.Track,
+        nowPlaying?.Artist,
+        nowPlaying?.Album,
+        nowPlaying?.ContentItem?.Location,
+    ].map(value => value || ''));
+}
+
+const EMPTY_TRACK_IDENTITY = trackMetadataIdentity(null);
+
+// What a skip against this source can be confirmed with, measured on a
+// SoundTouch 10 (server version 4) by walking its sources:
+//
+//   SPOTIFY       trackID, skipEnabled          -> the trackID is the signal
+//   STORED_MUSIC  no trackID, skipEnabled       -> track metadata is the signal
+//   TUNEIN        no trackID, no skipEnabled    -> nothing to verify
+//   RADIO_BROWSER no trackID, no skipEnabled    -> nothing to verify
+//   AUX           no trackID, no skipEnabled    -> nothing to verify
+//
+// trackID is preferred wherever it exists: it is a stable per-track identity
+// (`spotify:track:...`), so it survives a stream rewriting its own title and
+// still moves on a real skip.
+//
+// Track metadata is the fallback, and only where the speaker claims the skip
+// is supported. That claim is what separates a library, whose title changes
+// only when the track really changes, from live radio, which rewrites its
+// title while the same stream plays on and claims no skip support at all.
+//
+// With neither, no readback can ever say anything, so the command settles on a
+// write the speaker accepted instead of spending the whole readback window
+// with the transport dead to end "unverified".
+export function trackSkipExpectation(nowPlaying, skipSupported) {
+    return {
+        previousTrackID: nowPlaying?.TrackID || '',
+        previousTrackIdentity: skipSupported ? trackMetadataIdentity(nowPlaying) : '',
+    };
+}
+
 function settlesOnWrite(action, expected) {
-    return isTrackSkip(action) && !expected?.previousTrackID;
+    return isTrackSkip(action) &&
+        !expected?.previousTrackID &&
+        (!expected?.previousTrackIdentity ||
+            expected.previousTrackIdentity === EMPTY_TRACK_IDENTITY);
 }
 
 export function contentExpectation(item) {
@@ -129,8 +165,17 @@ export function matchesCommand(status, command) {
     if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
     if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
     if (isTrackSkip(action)) {
-        const trackID = nowPlaying?.TrackID;
-        return Boolean(trackID) && trackID !== command?.expected?.previousTrackID;
+        const expected = command?.expected;
+        if (expected?.previousTrackID) {
+            const trackID = nowPlaying?.TrackID;
+            return Boolean(trackID) && trackID !== expected.previousTrackID;
+        }
+        if (expected?.previousTrackIdentity) {
+            const identity = trackMetadataIdentity(nowPlaying);
+            return identity !== EMPTY_TRACK_IDENTITY &&
+                identity !== expected.previousTrackIdentity;
+        }
+        return false;
     }
     if (['preset', 'recent', 'tunein', 'radiobrowser', 'url', 'library'].includes(action)) {
         return matchesContentExpectation(nowPlaying, command?.expected);

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -375,8 +375,11 @@ export function useDiscreteCommand({
         }
         Promise.resolve(write).then(response => {
             if (commandRef.current.active !== active) return;
+            // A response-level failure carries no status code, so it is no
+            // proof the speaker never acted: record it and keep verifying.
+            // Checked writes reject instead, and are classified below.
             if (response?.success === false) {
-                fail(new Error(response.error || 'Command rejected'));
+                active.writeError = new Error(response.error || 'Command rejected');
                 return;
             }
             if (options.expectedFromResponse) {
@@ -401,7 +404,20 @@ export function useDiscreteCommand({
                     : previous);
             }
         }).catch(error => {
-            if (commandRef.current.active === active) active.writeError = error;
+            if (commandRef.current.active !== active) return;
+            // A definitive refusal (4xx) means the speaker never saw the
+            // command, so there is nothing for the readbacks to confirm and
+            // reporting it now beats waiting out the readback window. Anything
+            // else stays pending: a 5xx or a transport error does not tell us
+            // whether the speaker acted -- a request that timed out after the
+            // speaker already switched looks exactly like one it never
+            // received -- so we keep verifying and carry the reason into
+            // whatever outcome the readbacks reach.
+            if (error?.definitive) {
+                fail(error);
+                return;
+            }
+            active.writeError = error;
         });
         return true;
     }

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -52,8 +52,20 @@ function isNewerRevision(start, candidate) {
 // skip that worked never changes anything and would always end unverified
 // after a full readback window of dead transport. A write the speaker
 // accepted is the only honest evidence available, so these settle on it.
-function settlesOnWrite(action) {
+function isTrackSkip(action) {
     return action === 'next-track' || action === 'previous-track';
+}
+
+// A skip is verifiable exactly where the speaker reports a trackID. That is a
+// stable per-track identity (`spotify:track:...` in the captured firmware
+// responses), so unlike track/stationName it does not move when a live stream
+// rolls its own title metadata over, and it does change when a skip really
+// happens. Sources with no track concept -- AUX, PRODUCT, internet radio --
+// report no trackID at all, and there no readback can ever say anything, so
+// the command settles on a write the speaker accepted instead of spending the
+// whole readback window with the transport dead to end "unverified".
+function settlesOnWrite(action, expected) {
+    return isTrackSkip(action) && !expected?.previousTrackID;
 }
 
 export function contentExpectation(item) {
@@ -116,6 +128,10 @@ export function matchesCommand(status, command) {
     if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
     if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
     if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
+    if (isTrackSkip(action)) {
+        const trackID = nowPlaying?.TrackID;
+        return Boolean(trackID) && trackID !== command?.expected?.previousTrackID;
+    }
     if (['preset', 'recent', 'tunein', 'radiobrowser', 'url', 'library'].includes(action)) {
         return matchesContentExpectation(nowPlaying, command?.expected);
     }
@@ -125,7 +141,7 @@ export function matchesCommand(status, command) {
 function commandFailed(status, command) {
     const action = commandAction(command);
     if (![
-        'play', 'pause', 'preset', 'recent',
+        'play', 'pause', 'next-track', 'previous-track', 'preset', 'recent',
         'tunein', 'radiobrowser', 'url', 'library',
     ].includes(action)) return false;
     const nowPlaying = status?.nowPlaying;
@@ -261,7 +277,7 @@ export function useDiscreteCommand({
         setCommand({ ...request, generation, outcome: 'pending', startRevision });
         const startedAt = Date.now();
         // A command that settles on its write schedules no readbacks at all.
-        const delays = settlesOnWrite(action) ? [] : readbackDelays;
+        const delays = settlesOnWrite(action, expected) ? [] : readbackDelays;
 
         function fail(error) {
             if (commandRef.current.active !== active) return;
@@ -419,7 +435,7 @@ export function useDiscreteCommand({
             // Checked writes reject instead, and are classified below.
             if (response?.success === false) {
                 active.writeError = new Error(response.error || 'Command rejected');
-                if (settlesOnWrite(action)) unverified();
+                if (settlesOnWrite(action, expected)) unverified();
                 return;
             }
             if (options.expectedFromResponse) {
@@ -443,7 +459,7 @@ export function useDiscreteCommand({
                     ? { ...previous, expected: refinedExpected, expectationReady: true }
                     : previous);
             }
-            if (settlesOnWrite(action)) confirmOnWrite();
+            if (settlesOnWrite(action, expected)) confirmOnWrite();
         }).catch(error => {
             if (commandRef.current.active !== active) return;
             // A definitive refusal (4xx) means the speaker never saw the
@@ -461,7 +477,7 @@ export function useDiscreteCommand({
             active.writeError = error;
             // Nothing will read this one back, so the ambiguous failure is as
             // far as it gets.
-            if (settlesOnWrite(action)) unverified(error);
+            if (settlesOnWrite(action, expected)) unverified(error);
         });
         return true;
     }

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -1,0 +1,379 @@
+import { useState, useEffect, useRef } from 'preact/hooks';
+import { api } from './api.js';
+
+export const DISCRETE_COMMAND_READBACK_DELAYS_MS = [2000, 5000, 10000];
+
+function statusRevision(status) {
+    const revision = status?.revision;
+    return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
+}
+
+function nowPlayingRevision(status) {
+    const revision = status?.nowPlayingRevision;
+    return Number.isSafeInteger(revision) && revision >= 0 ? revision : null;
+}
+
+function commandAction(command) {
+    return typeof command === 'string' ? command : command?.action;
+}
+
+function commandRevision(status, command) {
+    return commandAction(command)?.startsWith('mute-')
+        ? statusRevision(status)
+        : nowPlayingRevision(status);
+}
+
+export function playbackIdentity(nowPlaying) {
+    if (!nowPlaying) return '';
+    const item = nowPlaying.ContentItem || {};
+    return [
+        nowPlaying.Source,
+        nowPlaying.SourceAccount,
+        item.Source,
+        item.SourceAccount,
+        item.Location,
+        nowPlaying.TrackID,
+        nowPlaying.Track,
+        nowPlaying.StationName,
+    ].map(value => value || '').join('\u0000');
+}
+
+export function contentExpectation(item) {
+    const source = item?.Source || '';
+    const sourceAccount = item?.SourceAccount && item.SourceAccount !== source
+        ? item.SourceAccount
+        : '';
+    return {
+        source,
+        sourceAccount,
+        location: item?.Location || '',
+        itemName: item?.ItemName || '',
+    };
+}
+
+function matchesContentExpectation(nowPlaying, expected) {
+    if (!nowPlaying || !expected) return false;
+    const item = nowPlaying.ContentItem || {};
+    const source = item.Source || nowPlaying.Source || '';
+    const account = item.SourceAccount || nowPlaying.SourceAccount || '';
+    if (expected.source && source !== expected.source) return false;
+    if (expected.sourceAccount && account !== expected.sourceAccount) return false;
+    if (expected.location) {
+        return item.Location === expected.location ||
+            nowPlaying.StationLocation === expected.location;
+    }
+    if (expected.itemName) return [
+        item.ItemName,
+        nowPlaying.Track,
+        nowPlaying.StationName,
+    ].includes(expected.itemName);
+    return Boolean(expected.source);
+}
+
+function matchesCommand(status, command) {
+    if (command?.expectationReady === false) return false;
+    const action = commandAction(command);
+    const nowPlaying = status?.nowPlaying;
+    if (action === 'power-off') return nowPlaying?.Source === 'STANDBY';
+    if (action === 'power-on') return Boolean(nowPlaying?.Source) && nowPlaying.Source !== 'STANDBY';
+    if (action === 'pause') return nowPlaying?.PlayStatus === 'PAUSE_STATE';
+    if (action === 'play') return nowPlaying?.PlayStatus === 'PLAY_STATE';
+    if (action === 'mute-on') return status?.volume?.MuteEnabled === true;
+    if (action === 'mute-off') return status?.volume?.MuteEnabled === false;
+    if (action === 'shuffle-on') return nowPlaying?.ShuffleSetting === 'SHUFFLE_ON';
+    if (action === 'shuffle-off') return nowPlaying?.ShuffleSetting === 'SHUFFLE_OFF';
+    if (action === 'repeat-all') return nowPlaying?.RepeatSetting === 'REPEAT_ALL';
+    if (action === 'repeat-one') return nowPlaying?.RepeatSetting === 'REPEAT_ONE';
+    if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
+    if (action === 'next-track' || action === 'previous-track') {
+        const identity = playbackIdentity(nowPlaying);
+        return Boolean(identity) && identity !== command?.expected?.previousIdentity;
+    }
+    if (['preset', 'recent', 'tunein', 'radiobrowser', 'url', 'library'].includes(action)) {
+        return matchesContentExpectation(nowPlaying, command?.expected);
+    }
+    return false;
+}
+
+function commandFailed(status, command) {
+    const action = commandAction(command);
+    if (![
+        'play', 'pause', 'next-track', 'previous-track', 'preset', 'recent',
+        'tunein', 'radiobrowser', 'url', 'library',
+    ].includes(action)) return false;
+    const nowPlaying = status?.nowPlaying;
+    return nowPlaying?.Source === 'INVALID_SOURCE' ||
+        nowPlaying?.Source?.endsWith('_ERROR') ||
+        nowPlaying?.PlayStatus === 'INVALID_PLAY_STATE';
+}
+
+export function commandText(command) {
+    if (!command) return '';
+    const labels = {
+        'power-off': ['Turning device off', 'Device powered off, confirming', 'Device powered off', 'Power command unverified', 'Power command failed'],
+        'power-on': ['Waking device', 'Device awake, confirming', 'Device awake', 'Power command unverified', 'Power command failed'],
+        pause: ['Pausing playback', 'Playback paused, confirming', 'Playback paused', 'Pause command unverified', 'Pause command failed'],
+        play: ['Starting playback', 'Playback started, confirming', 'Playback started', 'Play command unverified', 'Play command failed'],
+        'mute-on': ['Muting audio', 'Audio muted, confirming', 'Audio muted', 'Mute command unverified', 'Mute command failed'],
+        'mute-off': ['Unmuting audio', 'Audio unmuted, confirming', 'Audio unmuted', 'Unmute command unverified', 'Unmute command failed'],
+        'shuffle-on': ['Enabling shuffle', 'Shuffle enabled, confirming', 'Shuffle enabled', 'Shuffle command unverified', 'Shuffle command failed'],
+        'shuffle-off': ['Disabling shuffle', 'Shuffle disabled, confirming', 'Shuffle disabled', 'Shuffle command unverified', 'Shuffle command failed'],
+        'repeat-all': ['Enabling repeat all', 'Repeat all enabled, confirming', 'Repeat all enabled', 'Repeat command unverified', 'Repeat command failed'],
+        'repeat-one': ['Enabling repeat one', 'Repeat one enabled, confirming', 'Repeat one enabled', 'Repeat command unverified', 'Repeat command failed'],
+        'repeat-off': ['Disabling repeat', 'Repeat disabled, confirming', 'Repeat disabled', 'Repeat command unverified', 'Repeat command failed'],
+        'next-track': ['Skipping to next track', 'Next track started, confirming', 'Next track started', 'Next-track command unverified', 'Next-track command failed'],
+        'previous-track': ['Returning to previous track', 'Previous track started, confirming', 'Previous track started', 'Previous-track command unverified', 'Previous-track command failed'],
+        preset: ['Starting preset', 'Preset started, confirming', 'Preset started', 'Preset playback unverified', 'Preset playback failed'],
+        recent: ['Starting recent item', 'Recent item started, confirming', 'Recent item started', 'Recent-item playback unverified', 'Recent-item playback failed'],
+        tunein: ['Starting TuneIn item', 'TuneIn item started, confirming', 'TuneIn item started', 'TuneIn playback unverified', 'TuneIn playback failed'],
+        radiobrowser: ['Starting RadioBrowser station', 'RadioBrowser station started, confirming', 'RadioBrowser station started', 'RadioBrowser playback unverified', 'RadioBrowser playback failed'],
+        url: ['Starting stream URL', 'Stream URL started, confirming', 'Stream URL started', 'Stream URL playback unverified', 'Stream URL playback failed'],
+        library: ['Starting library item', 'Library item started, confirming', 'Library item started', 'Library playback unverified', 'Library playback failed'],
+    };
+    const outcomes = ['pending', 'provisional-confirmed', 'final-confirmed', 'unverified', 'failed'];
+    const index = outcomes.indexOf(command.outcome);
+    return index >= 0 ? labels[command.action]?.[index] || '' : '';
+}
+
+export function useDiscreteCommand({
+    deviceId,
+    status,
+    onStatusReadback,
+    readbackDelays = DISCRETE_COMMAND_READBACK_DELAYS_MS,
+    targetIdentity = null,
+    currentTargetIdentity = null,
+}) {
+    const [command, setCommand] = useState(null);
+    const commandRef = useRef({ generation: 0, active: null, timers: [] });
+    const statusRef = useRef(status);
+    const currentTargetIdentityRef = useRef(currentTargetIdentity);
+    statusRef.current = status;
+    currentTargetIdentityRef.current = currentTargetIdentity;
+
+    function clearReadbacks() {
+        commandRef.current.timers.forEach(clearTimeout);
+        commandRef.current.timers = [];
+    }
+
+    useEffect(() => {
+        commandRef.current.generation += 1;
+        commandRef.current.active = null;
+        clearReadbacks();
+        setCommand(null);
+        return () => {
+            commandRef.current.generation += 1;
+            commandRef.current.active = null;
+            clearReadbacks();
+        };
+    }, [deviceId]);
+
+    useEffect(() => {
+        if (!command?.targetIdentity || currentTargetIdentity === command.targetIdentity ||
+            command.outcome === 'failed' || command.outcome === 'unverified') return;
+
+        if (command.outcome === 'final-confirmed') {
+            setCommand(previous => previous?.generation === command.generation
+                ? null : previous);
+            return;
+        }
+
+        clearReadbacks();
+        commandRef.current.active = null;
+        setCommand(previous => previous?.generation === command.generation
+            ? { ...previous, outcome: 'failed', error: 'Playback target changed' }
+            : previous);
+    }, [command, currentTargetIdentity]);
+
+    useEffect(() => {
+        const revision = commandRevision(status, command);
+        if (!command || revision === null || command.startRevision === null ||
+            revision <= command.startRevision || command.outcome === 'failed' ||
+            command.outcome === 'unverified') return;
+
+        const matches = matchesCommand(status, command);
+        if (command.outcome === 'final-confirmed') {
+            if (revision > command.confirmedRevision && !matches) {
+                setCommand(previous => previous?.generation === command.generation
+                    ? null : previous);
+            }
+            return;
+        }
+        if (commandFailed(status, command)) {
+            clearReadbacks();
+            commandRef.current.active = null;
+            setCommand(previous => previous?.generation === command.generation
+                ? { ...previous, outcome: 'failed' }
+                : previous);
+        } else if (matches && command.outcome === 'pending') {
+            setCommand(previous => previous?.generation === command.generation
+                ? { ...previous, outcome: 'provisional-confirmed' }
+                : previous);
+        }
+    }, [command, status]);
+
+    function run(action, invoke, expected = null, options = {}) {
+        if (commandRef.current.active) return false;
+
+        clearReadbacks();
+        const generation = commandRef.current.generation + 1;
+        const request = {
+            action,
+            expected,
+            expectationReady: !options.expectedFromResponse,
+            targetIdentity,
+        };
+        const startRevision = commandRevision(status, request);
+        const active = {
+            generation,
+            latestReadback: -1,
+            writeError: null,
+            request,
+            startRevision,
+        };
+        commandRef.current.generation = generation;
+        commandRef.current.active = active;
+        setCommand({ ...request, generation, outcome: 'pending', startRevision });
+        const startedAt = Date.now();
+
+        function fail(error) {
+            if (commandRef.current.active !== active) return;
+            clearReadbacks();
+            commandRef.current.active = null;
+            setCommand({
+                ...active.request,
+                generation,
+                outcome: 'failed',
+                startRevision,
+                error: error?.message || String(error || 'Command rejected'),
+            });
+        }
+
+        function unverified(error) {
+            if (commandRef.current.active !== active) return;
+            commandRef.current.active = null;
+            setCommand({
+                ...active.request,
+                generation,
+                outcome: 'unverified',
+                startRevision,
+                error: active.writeError?.message || error?.message,
+            });
+        }
+
+        readbackDelays.forEach((delay, index) => {
+            const timer = setTimeout(async () => {
+                if (commandRef.current.active !== active) return;
+                active.latestReadback = index;
+                try {
+                    // Mute is volume state, which the lightweight now-playing
+                    // endpoint does not refresh from the speaker. Other
+                    // discrete commands only need the much cheaper media
+                    // readback.
+                    const response = commandAction(active.request)?.startsWith('mute-')
+                        ? await api.device(deviceId)
+                        : await api.deviceNowPlaying(deviceId);
+                    if (commandRef.current.active !== active || active.latestReadback !== index) return;
+                    if (response?.success === false || !response?.data?.status) {
+                        throw new Error(response?.error || 'Device status unavailable');
+                    }
+
+                    const currentRequest = active.request;
+                    if (currentRequest.targetIdentity && (
+                        currentTargetIdentityRef.current !== currentRequest.targetIdentity ||
+                        response.data.info?.device_id !== currentRequest.targetIdentity
+                    )) {
+                        fail(new Error('Playback target changed'));
+                        return;
+                    }
+
+                    const readbackStatus = response.data.status;
+                    const readbackRevision = commandRevision(readbackStatus, currentRequest);
+                    const currentStatus = statusRef.current;
+                    const currentRevision = commandRevision(currentStatus, currentRequest);
+                    const canonicalStatus = currentRevision !== null &&
+                        (readbackRevision === null || currentRevision >= readbackRevision)
+                        ? currentStatus
+                        : readbackStatus;
+                    const canonicalRevision = commandRevision(canonicalStatus, currentRequest);
+                    const revisionIsNewer = startRevision !== null && canonicalRevision !== null &&
+                        canonicalRevision > startRevision;
+                    onStatusReadback?.(deviceId, readbackStatus, response.data.info);
+
+                    if (revisionIsNewer && commandFailed(canonicalStatus, currentRequest)) {
+                        fail(new Error('Device rejected the selected source'));
+                    } else if (revisionIsNewer && matchesCommand(canonicalStatus, currentRequest)) {
+                        const isFinalReadback = index === readbackDelays.length - 1;
+                        setCommand({
+                            ...currentRequest,
+                            generation,
+                            outcome: isFinalReadback ? 'final-confirmed' : 'provisional-confirmed',
+                            startRevision,
+                            confirmedRevision: canonicalRevision,
+                        });
+                        if (isFinalReadback) {
+                            clearReadbacks();
+                            commandRef.current.active = null;
+                        }
+                    } else if (index === readbackDelays.length - 1) {
+                        unverified();
+                    }
+                } catch (error) {
+                    if (commandRef.current.active === active && active.latestReadback === index &&
+                        index === readbackDelays.length - 1) {
+                        unverified(error);
+                    }
+                }
+            }, Math.max(0, delay - (Date.now() - startedAt)));
+            commandRef.current.timers.push(timer);
+        });
+
+        if (request.targetIdentity &&
+            currentTargetIdentityRef.current !== request.targetIdentity) {
+            fail(new Error('Playback target changed'));
+            return true;
+        }
+
+        let write;
+        try {
+            write = invoke();
+        } catch (error) {
+            fail(error);
+            return true;
+        }
+        Promise.resolve(write).then(response => {
+            if (commandRef.current.active !== active) return;
+            if (response?.success === false) {
+                fail(new Error(response.error || 'Command rejected'));
+                return;
+            }
+            if (options.expectedFromResponse) {
+                let refinedExpected;
+                try {
+                    refinedExpected = options.expectedFromResponse(response);
+                } catch (error) {
+                    fail(error);
+                    return;
+                }
+                if (!refinedExpected) {
+                    fail(new Error('Command response did not identify the selected content'));
+                    return;
+                }
+                active.request = {
+                    ...active.request,
+                    expected: refinedExpected,
+                    expectationReady: true,
+                };
+                setCommand(previous => previous?.generation === generation
+                    ? { ...previous, expected: refinedExpected, expectationReady: true }
+                    : previous);
+            }
+        }).catch(error => {
+            if (commandRef.current.active === active) active.writeError = error;
+        });
+        return true;
+    }
+
+    const busy = command?.outcome === 'pending' ||
+        command?.outcome === 'provisional-confirmed';
+    return { command, busy, statusText: commandText(command), run };
+}

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -90,10 +90,16 @@ const EMPTY_TRACK_IDENTITY = trackMetadataIdentity(null);
 // With neither, no readback can ever say anything, so the command settles on a
 // write the speaker accepted instead of spending the whole readback window
 // with the transport dead to end "unverified".
+function nowPlayingPosition(nowPlaying) {
+    const position = nowPlaying?.Time?.Position;
+    return Number.isSafeInteger(position) && position >= 0 ? position : null;
+}
+
 export function trackSkipExpectation(nowPlaying, skipSupported) {
     return {
         previousTrackID: nowPlaying?.TrackID || '',
         previousTrackIdentity: skipSupported ? trackMetadataIdentity(nowPlaying) : '',
+        previousPosition: nowPlayingPosition(nowPlaying),
     };
 }
 
@@ -166,6 +172,16 @@ export function matchesCommand(status, command) {
     if (action === 'repeat-off') return nowPlaying?.RepeatSetting === 'REPEAT_OFF';
     if (isTrackSkip(action)) {
         const expected = command?.expected;
+        // Measured on a SoundTouch 10: the first PREV_TRACK restarts the
+        // track that is playing, and only a second press steps back. A
+        // restart moves no identity at all, so the play position falling back
+        // is the only evidence that the press did anything -- without it a
+        // working Previous reports "unverified" every time it lands on a
+        // track that is already under way.
+        if (action === 'previous-track' && expected?.previousPosition > 0) {
+            const position = nowPlayingPosition(nowPlaying);
+            if (position !== null && position < expected.previousPosition) return true;
+        }
         if (expected?.previousTrackID) {
             const trackID = nowPlaying?.TrackID;
             return Boolean(trackID) && trackID !== expected.previousTrackID;

--- a/pkg/service/soundtouchweb/static/js/discreteCommand.js
+++ b/pkg/service/soundtouchweb/static/js/discreteCommand.js
@@ -252,15 +252,29 @@ export function useDiscreteCommand({
             });
         }
 
+        // Called when the readback window closes without this round matching.
+        // "Unverified" is only honest for a command nothing ever confirmed: a
+        // nowPlayingUpdated event may already have confirmed it at t=1s, and a
+        // failed readback at t=10s must not retract that. Such a command is
+        // settled as confirmed instead, since no further readback will run.
         function unverified(error) {
             if (commandRef.current.active !== active) return;
             commandRef.current.active = null;
-            setCommand({
-                ...active.request,
-                generation,
-                outcome: 'unverified',
-                startRevision,
-                error: active.writeError?.message || error?.message,
+            setCommand(previous => {
+                if (previous?.generation !== generation) return previous;
+                if (previous.outcome === 'provisional-confirmed' ||
+                    previous.outcome === 'final-confirmed') {
+                    return { ...previous, outcome: 'final-confirmed' };
+                }
+                if (previous.outcome === 'failed') return previous;
+
+                return {
+                    ...active.request,
+                    generation,
+                    outcome: 'unverified',
+                    startRevision,
+                    error: active.writeError?.message || error?.message,
+                };
             });
         }
 


### PR DESCRIPTION
## Summary

The embedded player currently treats many discrete commands as complete when
their HTTP request returns. A delayed speaker response can therefore leave the
UI optimistic, while retrying a non-idempotent action would risk applying it a
second time.

This change extends the reconciliation model from source selection in `#670`
to the remaining discrete player actions:

- sends power, transport, mute, playback-mode, track, preset, recent, provider,
  URL, and library mutations exactly once;
- reports pending, confirmed, unverified, and failed outcomes from bounded
  authoritative now-playing or status readback;
- starts absolute readback delays without waiting for a slow mutation response;
- fences delayed results when the selected device, command generation, or
  authoritative state revision changes;
- shares one command-state implementation across content providers without
  replaying a selection merely because confirmation was delayed; and
- accepts the firmware's active-source `STOP_STATE` as a confirmed pause while
  continuing to reject standby and an empty source.

The branch contains five reviewable commits directly on current `origin/main`
at `8aa2db1`. The feature diff therefore contains no synthetic prerequisite or
integration-only commit.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [ ] `make check` passes (the Docker-based HTTP integration target was not run)
- [ ] Tested against a real SoundTouch device
- [x] `node --test pkg/service/soundtouchweb/frontend_test/*.test.mjs`
- [x] `go test -race -count=1 ./pkg/service/soundtouchweb`
- [x] `go vet ./pkg/service/soundtouchweb`
- [x] `go test -tags browsertest -count=1 ./pkg/service/soundtouchweb`

On exact head `b487736`, all 28 frontend module tests and the complete tagged
Chromium suite pass, including one-write, endpoint-selection, absolute-delay,
target-fencing, provider/library, and active-source pause regressions. The
changed Go package also passes under the race detector and `go vet`. No
real-device result is claimed by this PR.

The clean local feature range is `8aa2db1..b487736`.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] No CLI or documentation update is required for this player-state correction
