### PR TITLE
docs: bring /balance documentation in line with the measured shape

### DIFF
--- a/cmd/soundtouch-cli/main.go
+++ b/cmd/soundtouch-cli/main.go
@@ -1308,7 +1308,7 @@ func main() {
 							&cli.IntFlag{
 								Name:     "level",
 								Aliases:  []string{"l"},
-								Usage:    "Balance level (-50 to 50, negative=left, positive=right)",
+								Usage:    "Balance level within the range the speaker reports (-7 to 7 on a SoundTouch 10); negative=left, positive=right",
 								Required: true,
 							},
 						},
@@ -1322,7 +1322,7 @@ func main() {
 							&cli.IntFlag{
 								Name:    "amount",
 								Aliases: []string{"a"},
-								Usage:   "Amount to shift left (1-10, default: 5)",
+								Usage:   "Amount to shift left, clamped to the speaker's reported range",
 								Value:   5,
 							},
 						},
@@ -1336,7 +1336,7 @@ func main() {
 							&cli.IntFlag{
 								Name:    "amount",
 								Aliases: []string{"a"},
-								Usage:   "Amount to shift right (1-10, default: 5)",
+								Usage:   "Amount to shift right, clamped to the speaker's reported range",
 								Value:   5,
 							},
 						},

--- a/docs/content/docs/analysis/API-COVERAGE.md
+++ b/docs/content/docs/analysis/API-COVERAGE.md
@@ -71,7 +71,8 @@ This Go implementation provides near-complete coverage of the Bose SoundTouch We
 | Endpoint        | Method   | Status       | Notes                                                              |
 |-----------------|----------|--------------|--------------------------------------------------------------------|
 | `/name`         | GET      | 🔍 **Extra** | Official API only documents POST, but GET works with real hardware |
-| `/balance`      | GET/POST | 🔍 **Extra** | Stereo balance control (-50 to +50) - not in API v1.0              |
+| `/balance`      | GET      | 🔍 **Extra** | Stereo pair balance, device-reported range (-7..7 on an ST-10)     |
+| `/balance`      | POST     | ❌ **Hangs** | HTTP write never returns; write over the WebSocket instead         |
 | `/clockTime`    | GET/POST | 🔍 **Extra** | Device time management - works with real devices                   |
 | `/clockDisplay` | GET/POST | 🔍 **Extra** | Clock display settings and brightness                              |
 | `/networkInfo`  | GET      | 🔍 **Extra** | Network connectivity information                                   |

--- a/docs/content/docs/analysis/WIKI-COMPARISON.md
+++ b/docs/content/docs/analysis/WIKI-COMPARISON.md
@@ -21,61 +21,61 @@ The SoundTouch Plus community wiki documents **87 distinct API endpoints** with 
 
 ### ✅ Already Implemented (23 endpoints)
 
-| Endpoint                     | Wiki Status  | Our Status | Notes                             |
-|------------------------------|--------------|------------|-----------------------------------|
-| `/info`                      | ✅ Documented | ✅ Complete | Device information                |
-| `/now_playing`               | ✅ Documented | ✅ Complete | Current playback status           |
-| `/key`                       | ✅ Documented | ✅ Complete | Key press/release simulation      |
-| `/volume`                    | ✅ Documented | ✅ Complete | Volume and mute control           |
-| `/bass`                      | ✅ Documented | ✅ Complete | Bass level control                |
-| `/bassCapabilities`          | ✅ Documented | ✅ Complete | Bass capability detection         |
-| `/sources`                   | ✅ Documented | ✅ Complete | Available audio sources           |
-| `/select`                    | ✅ Documented | ✅ Complete | Source selection                  |
-| `/presets`                   | ✅ Documented | ✅ Complete | Preset configurations (read-only) |
-| `/getZone`                   | ✅ Documented | ✅ Complete | Zone status and membership        |
-| `/setZone`                   | ✅ Documented | ✅ Complete | Zone creation and management      |
-| `/addZoneSlave`              | ✅ Documented | ✅ Complete | Add device to zone                |
-| `/removeZoneSlave`           | ✅ Documented | ✅ Complete | Remove device from zone           |
-| `/capabilities`              | ✅ Documented | ✅ Complete | Device feature capabilities       |
-| `/audiodspcontrols`          | ✅ Documented | ✅ Complete | Audio DSP modes and video sync    |
-| `/audioproducttonecontrols`  | ✅ Documented | ✅ Complete | Advanced bass/treble controls     |
-| `/audioproductlevelcontrols` | ✅ Documented | ✅ Complete | Speaker level controls            |
-| `/name` (GET/POST)           | ✅ Documented | ✅ Complete | Device name management            |
+| Endpoint                     | Wiki Status   | Our Status   | Notes                             |
+|------------------------------|---------------|--------------|-----------------------------------|
+| `/info`                      | ✅ Documented | ✅ Complete  | Device information                |
+| `/now_playing`               | ✅ Documented | ✅ Complete  | Current playback status           |
+| `/key`                       | ✅ Documented | ✅ Complete  | Key press/release simulation      |
+| `/volume`                    | ✅ Documented | ✅ Complete  | Volume and mute control           |
+| `/bass`                      | ✅ Documented | ✅ Complete  | Bass level control                |
+| `/bassCapabilities`          | ✅ Documented | ✅ Complete  | Bass capability detection         |
+| `/sources`                   | ✅ Documented | ✅ Complete  | Available audio sources           |
+| `/select`                    | ✅ Documented | ✅ Complete  | Source selection                  |
+| `/presets`                   | ✅ Documented | ✅ Complete  | Preset configurations (read-only) |
+| `/getZone`                   | ✅ Documented | ✅ Complete  | Zone status and membership        |
+| `/setZone`                   | ✅ Documented | ✅ Complete  | Zone creation and management      |
+| `/addZoneSlave`              | ✅ Documented | ✅ Complete  | Add device to zone                |
+| `/removeZoneSlave`           | ✅ Documented | ✅ Complete  | Remove device from zone           |
+| `/capabilities`              | ✅ Documented | ✅ Complete  | Device feature capabilities       |
+| `/audiodspcontrols`          | ✅ Documented | ✅ Complete  | Audio DSP modes and video sync    |
+| `/audioproducttonecontrols`  | ✅ Documented | ✅ Complete  | Advanced bass/treble controls     |
+| `/audioproductlevelcontrols` | ✅ Documented | ✅ Complete  | Speaker level controls            |
+| `/name` (GET/POST)           | ✅ Documented | ✅ Complete  | Device name management            |
 | `/balance`                   | ✅ Documented | ⚠️ Read-only | Stereo pair; WS write, HTTP read  |
-| `/clockTime`                 | ✅ Documented | ✅ Complete | Device time management            |
-| `/clockDisplay`              | ✅ Documented | ✅ Complete | Clock display settings            |
-| `/networkInfo`               | ✅ Documented | ✅ Complete | Network connectivity info         |
-| `/requestToken`              | ✅ Documented | ✅ Complete | Bearer token generation           |
+| `/clockTime`                 | ✅ Documented | ✅ Complete  | Device time management            |
+| `/clockDisplay`              | ✅ Documented | ✅ Complete  | Clock display settings            |
+| `/networkInfo`               | ✅ Documented | ✅ Complete  | Network connectivity info         |
+| `/requestToken`              | ✅ Documented | ✅ Complete  | Bearer token generation           |
 
 ### 🔥 High Priority Missing (20 endpoints)
 
 | Endpoint                     | Wiki Status | Priority | Use Case                           |
 |------------------------------|-------------|----------|------------------------------------|
-| `/storePreset`               | ✅ Detailed  | **HIGH** | Save stations/playlists to presets |
-| `/removePreset`              | ✅ Detailed  | **HIGH** | Delete saved presets               |
-| `/selectPreset`              | ✅ Detailed  | **HIGH** | Play preset by ID                  |
-| `/setMusicServiceAccount`    | ✅ Detailed  | **HIGH** | Add Spotify/Pandora accounts       |
-| `/removeMusicServiceAccount` | ✅ Detailed  | **HIGH** | Remove music service accounts      |
-| `/searchStation`             | ✅ Detailed  | **HIGH** | Find Pandora/Spotify content       |
-| `/addStation`                | ✅ Detailed  | **HIGH** | Add stations to favorites          |
-| `/removeStation`             | ✅ Detailed  | **HIGH** | Remove stations from favorites     |
-| `/navigate`                  | ✅ Detailed  | **HIGH** | Browse music libraries/services    |
-| `/search`                    | ✅ Detailed  | **HIGH** | Search music content               |
-| `/userPlayControl`           | ✅ Detailed  | **HIGH** | Play/pause/stop controls           |
-| `/userRating`                | ✅ Detailed  | **HIGH** | Thumbs up/down ratings             |
-| `/recents`                   | ✅ Detailed  | **HIGH** | Recently played content            |
-| `/standby`                   | ✅ Detailed  | **HIGH** | Power management                   |
-| `/powerManagement`           | ✅ Detailed  | **HIGH** | Power state information            |
-| `/lowPowerStandby`           | ✅ Detailed  | **HIGH** | Low-power mode                     |
-| `/listMediaServers`          | ✅ Detailed  | **HIGH** | UPnP/DLNA server discovery         |
-| `/serviceAvailability`       | ✅ Detailed  | **HIGH** | Source availability status         |
-| `/introspect`                | ✅ Detailed  | **HIGH** | Music service account status       |
-| `/language`                  | ✅ Detailed  | **HIGH** | Device language settings           |
+| `/storePreset`               | ✅ Detailed | **HIGH** | Save stations/playlists to presets |
+| `/removePreset`              | ✅ Detailed | **HIGH** | Delete saved presets               |
+| `/selectPreset`              | ✅ Detailed | **HIGH** | Play preset by ID                  |
+| `/setMusicServiceAccount`    | ✅ Detailed | **HIGH** | Add Spotify/Pandora accounts       |
+| `/removeMusicServiceAccount` | ✅ Detailed | **HIGH** | Remove music service accounts      |
+| `/searchStation`             | ✅ Detailed | **HIGH** | Find Pandora/Spotify content       |
+| `/addStation`                | ✅ Detailed | **HIGH** | Add stations to favorites          |
+| `/removeStation`             | ✅ Detailed | **HIGH** | Remove stations from favorites     |
+| `/navigate`                  | ✅ Detailed | **HIGH** | Browse music libraries/services    |
+| `/search`                    | ✅ Detailed | **HIGH** | Search music content               |
+| `/userPlayControl`           | ✅ Detailed | **HIGH** | Play/pause/stop controls           |
+| `/userRating`                | ✅ Detailed | **HIGH** | Thumbs up/down ratings             |
+| `/recents`                   | ✅ Detailed | **HIGH** | Recently played content            |
+| `/standby`                   | ✅ Detailed | **HIGH** | Power management                   |
+| `/powerManagement`           | ✅ Detailed | **HIGH** | Power state information            |
+| `/lowPowerStandby`           | ✅ Detailed | **HIGH** | Low-power mode                     |
+| `/listMediaServers`          | ✅ Detailed | **HIGH** | UPnP/DLNA server discovery         |
+| `/serviceAvailability`       | ✅ Detailed | **HIGH** | Source availability status         |
+| `/introspect`                | ✅ Detailed | **HIGH** | Music service account status       |
+| `/language`                  | ✅ Detailed | **HIGH** | Device language settings           |
 
 ### 🎵 Music Service Management (12 endpoints)
 
-| Category               | Endpoints                                               | Wiki Coverage       | Notes                           |
-|------------------------|---------------------------------------------------------|---------------------|---------------------------------|
+| Category               | Endpoints                                               | Wiki Coverage        | Notes                           |
+|------------------------|---------------------------------------------------------|----------------------|---------------------------------|
 | **Account Management** | `/setMusicServiceAccount`, `/removeMusicServiceAccount` | ✅ Full XML examples | Pandora, Spotify, NAS setup     |
 | **Station Management** | `/searchStation`, `/addStation`, `/removeStation`       | ✅ Pandora tested    | Station discovery and favorites |
 | **Content Navigation** | `/navigate`, `/search`                                  | ✅ Detailed examples | Music library browsing          |
@@ -83,8 +83,8 @@ The SoundTouch Plus community wiki documents **87 distinct API endpoints** with 
 
 ### 🏠 Smart Home Integration (15 endpoints)
 
-| Category               | Endpoints                                                                        | Wiki Coverage      | Notes                        |
-|------------------------|----------------------------------------------------------------------------------|--------------------|------------------------------|
+| Category               | Endpoints                                                                        | Wiki Coverage       | Notes                        |
+|------------------------|----------------------------------------------------------------------------------|---------------------|------------------------------|
 | **Notifications**      | `/speaker`, `/playNotification`                                                  | ✅ TTS examples     | Text-to-speech, URL playback |
 | **Power Management**   | `/standby`, `/powerManagement`, `/lowPowerStandby`                               | ✅ Complete         | Smart home automation        |
 | **Network Management** | `/performWirelessSiteSurvey`, `/addWirelessProfile`, `/getActiveWirelessProfile` | ✅ WiFi setup       | Network configuration        |
@@ -93,8 +93,8 @@ The SoundTouch Plus community wiki documents **87 distinct API endpoints** with 
 
 ### 📱 Advanced Device Features (19 endpoints)
 
-| Category             | Endpoints                                                                     | Wiki Coverage       | Notes                   |
-|----------------------|-------------------------------------------------------------------------------|---------------------|-------------------------|
+| Category             | Endpoints                                                                     | Wiki Coverage        | Notes                   |
+|----------------------|-------------------------------------------------------------------------------|----------------------|-------------------------|
 | **Stereo Pairs**     | `/getGroup`, `/addGroup`, `/removeGroup`, `/updateGroup`                      | ✅ ST-10 specific    | L/R speaker pairing     |
 | **System Info**      | `/soundTouchConfigurationStatus`, `/systemtimeout`, `/rebroadcastlatencymode` | ✅ Configuration     | Device state management |
 | **Software Updates** | `/swUpdateCheck`, `/swUpdateQuery`, `/swUpdateAbort`, `/swUpdateStart`        | ✅ Update process    | Firmware management     |

--- a/docs/content/docs/analysis/WIKI-COMPARISON.md
+++ b/docs/content/docs/analysis/WIKI-COMPARISON.md
@@ -41,7 +41,7 @@ The SoundTouch Plus community wiki documents **87 distinct API endpoints** with 
 | `/audioproducttonecontrols`  | ✅ Documented | ✅ Complete | Advanced bass/treble controls     |
 | `/audioproductlevelcontrols` | ✅ Documented | ✅ Complete | Speaker level controls            |
 | `/name` (GET/POST)           | ✅ Documented | ✅ Complete | Device name management            |
-| `/balance`                   | ✅ Documented | ✅ Complete | Stereo balance control            |
+| `/balance`                   | ✅ Documented | ⚠️ Read-only | Stereo pair; WS write, HTTP read  |
 | `/clockTime`                 | ✅ Documented | ✅ Complete | Device time management            |
 | `/clockDisplay`              | ✅ Documented | ✅ Complete | Clock display settings            |
 | `/networkInfo`               | ✅ Documented | ✅ Complete | Network connectivity info         |

--- a/docs/content/docs/guides/CLI-REFERENCE.md
+++ b/docs/content/docs/guides/CLI-REFERENCE.md
@@ -699,26 +699,36 @@ soundtouch-cli --host 192.0.2.10 bass down
 
 ### Balance Control
 
-Adjust left/right balance.
+Adjust the left/right balance of a stereo **pair** (two SoundTouch 10s taking the
+LEFT and RIGHT channel). A speaker that is not in a pair reports balance as
+unavailable. Either member of the pair can be addressed: both report the same
+value and both accept the setting.
+
+The range comes from the speaker, not from the CLI: `-7` to `7`, default `0`, on
+a SoundTouch 10. `balance get` prints it.
+
+Writing the balance opens a WebSocket to the speaker, because the HTTP `POST
+/balance` endpoint hangs instead of applying the change. `balance get` is a plain
+HTTP read.
 
 #### `balance <subcommand>`
 
 Balance control commands.
 
 ```bash
-# Get current balance
+# Get current balance, including the range the speaker reports
 soundtouch-cli --host <device> balance get
 
-# Set balance (-50 to 50, negative=left, positive=right)
-soundtouch-cli --host <device> balance set --level <-50 to 50>
+# Set balance (negative=left, positive=right, within the reported range)
+soundtouch-cli --host <device> balance set --level <level>
 
-# Shift balance left
-soundtouch-cli --host <device> balance left [--amount <1-10>]
+# Shift balance left (clamped to the speaker's range)
+soundtouch-cli --host <device> balance left [--amount <n>]
 
-# Shift balance right
-soundtouch-cli --host <device> balance right [--amount <1-10>]
+# Shift balance right (clamped to the speaker's range)
+soundtouch-cli --host <device> balance right [--amount <n>]
 
-# Center balance
+# Center balance, at whatever the speaker reports as its default
 soundtouch-cli --host <device> balance center
 ```
 
@@ -727,10 +737,13 @@ soundtouch-cli --host <device> balance center
 # Get balance
 soundtouch-cli --host 192.0.2.10 balance get
 
-# Set balance 10 units to the right
-soundtouch-cli --host 192.0.2.10 balance set --level 10
+# Hard right, on a speaker reporting a -7..7 range
+soundtouch-cli --host 192.0.2.10 balance set --level 7
 
-# Shift left by 5 units (default)
+# Slightly left
+soundtouch-cli --host 192.0.2.10 balance set --level -3
+
+# Shift left by 5 units (default), clamped at the range end
 soundtouch-cli --host 192.0.2.10 balance left
 
 # Center the balance
@@ -1571,7 +1584,7 @@ soundtouch-cli --host 192.0.2.10 balance get
 
 # Adjust for better sound
 soundtouch-cli --host 192.0.2.10 bass set --level 2      # Slight bass boost
-soundtouch-cli --host 192.0.2.10 balance set --level -5  # Slightly left
+soundtouch-cli --host 192.0.2.10 balance set --level -3  # Slightly left
 soundtouch-cli --host 192.0.2.10 volume set --level 35   # Good listening level
 ```
 

--- a/docs/content/docs/guides/TROUBLESHOOTING.md
+++ b/docs/content/docs/guides/TROUBLESHOOTING.md
@@ -827,12 +827,16 @@ if err == nil {
 2. **Use safe methods:**
 ```go
 client.SetBassSafe(-5)       // Won't fail on unsupported devices
-client.SetBalanceSafe(10)    // Falls back gracefully
 ```
 
+There is no safe variant for balance, and no HTTP write at all: `POST /balance`
+hangs, so `Client.SetBalance` returns an error telling you to use
+`WebSocketClient.SetBalance` instead. Check `Balance.Available` from a read
+first; a speaker that is not in a stereo pair reports `false`.
+
 3. **Device-specific features:**
-- SoundTouch 10: Basic bass only
-- SoundTouch 20/30: Full bass and balance
+- Balance: stereo pairs only (two SoundTouch 10s); either member reports and
+  accepts it, an unpaired speaker reports it as unavailable
 - Soundbar models: Advanced audio controls
 
 ---

--- a/docs/content/docs/reference/API-COOKBOOK.md
+++ b/docs/content/docs/reference/API-COOKBOOK.md
@@ -442,10 +442,11 @@ func (pm *ProfileManager) CreateProfile(name string) error {
         return fmt.Errorf("failed to get bass: %w", err)
     }
 
+    // Balance exists only on a stereo pair; an unpaired speaker answers
+    // Available=false rather than failing, so check the flag, not just err.
     balance, err := pm.client.GetBalance()
-    if err != nil {
-        // Balance might not be supported, use default
-        balance = &models.Balance{TargetBalance: 0}
+    if err != nil || !balance.Available {
+        balance = &models.Balance{}
     }
 
     nowPlaying, err := pm.client.GetNowPlaying()
@@ -458,7 +459,7 @@ func (pm *ProfileManager) CreateProfile(name string) error {
         Name:    name,
         Volume:  volume.TargetVolume,
         Bass:    bass.TargetBass,
-        Balance: balance.TargetBalance,
+        Balance: balance.Target,
         Source:  source,
     }
 
@@ -486,7 +487,9 @@ func (pm *ProfileManager) ApplyProfile(name string) error {
         log.Printf("Warning: failed to set bass: %v", err)
     }
 
-    if err := pm.client.SetBalanceSafe(profile.Balance); err != nil {
+    // Balance is the odd one out: POST /balance hangs, so the write goes over
+    // the WebSocket. See applyBalance below.
+    if err := pm.applyBalance(profile.Balance); err != nil {
         log.Printf("Warning: failed to set balance: %v", err)
     }
 
@@ -497,6 +500,42 @@ func (pm *ProfileManager) ApplyProfile(name string) error {
     }
 
     fmt.Printf("✅ Profile '%s' applied successfully\n", name)
+    return nil
+}
+
+// applyBalance writes the balance over the WebSocket, which is the only
+// transport the speakers accept it on.
+//
+// The speaker echoes the whole balance document in its reply, so the returned
+// value is the confirmation — do not read back over HTTP to check, that
+// endpoint lags a write by about a second.
+func (pm *ProfileManager) applyBalance(level int) error {
+    ws := pm.client.NewWebSocketClient(nil)
+    if err := ws.Connect(); err != nil {
+        return fmt.Errorf("open websocket: %w", err)
+    }
+    defer func() { _ = ws.Disconnect() }()
+
+    ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+    defer cancel()
+
+    current, err := ws.GetBalance(ctx)
+    if err != nil {
+        return fmt.Errorf("read balance: %w", err)
+    }
+
+    if !current.Available {
+        return fmt.Errorf("balance needs a stereo pair; this speaker has none")
+    }
+
+    // Clamp to the range the device reports rather than an assumed one.
+    updated, err := ws.SetBalanceWithBounds(ctx, current.Clamp(level), current)
+    if err != nil {
+        return err
+    }
+
+    fmt.Printf("   Balance now %d\n", updated.Target)
+
     return nil
 }
 

--- a/docs/content/docs/reference/API-ENDPOINTS.md
+++ b/docs/content/docs/reference/API-ENDPOINTS.md
@@ -280,11 +280,14 @@ Retrieves multiroom zone information.
 Configures multiroom zones.
 
 ### GET /balance ✅ **Implemented**
-Retrieves balance settings (stereo devices). Only works if device is configured as part of a stereo pair.
+Retrieves balance settings. Balance belongs to a stereo **pair** (two SoundTouch
+10s taking the LEFT and RIGHT channel), not to a multiroom zone and not to one
+speaker. Either member answers, with the same document; an unpaired speaker
+answers `balanceAvailable=false` rather than failing.
 
 **Response XML:**
 ```xml
-<balance deviceID="...">
+<balance deviceID="DEVICEID01">
   <balanceAvailable>true</balanceAvailable>
   <balanceMin>-7</balanceMin>
   <balanceMax>7</balanceMax>
@@ -294,20 +297,58 @@ Retrieves balance settings (stereo devices). Only works if device is configured 
 </balance>
 ```
 
-### POST /balance ✅ **Implemented**
-Sets balance settings. Value must be within the range specified by `balanceMin` and `balanceMax`.
+Take the range from `balanceMin`/`balanceMax`; do not hardcode it. On a
+SoundTouch 10 it is `-7..7`, default `0`, negative = left.
 
-**Request XML:**
+⚠️ This endpoint **blocks rather than refusing** on a speaker in deep standby
+(12 s and counting, measured). Give it its own short timeout and keep it off any
+polled path.
+
+### POST /balance ❌ **Does not work — write over the WebSocket instead**
+`POST /balance` **hangs** rather than returning or refusing. The app Bose ships
+on the speaker never writes balance over HTTP either; it writes exclusively over
+the WebSocket. `Client.SetBalance` therefore returns an error pointing at
+`WebSocketClient.SetBalance` / `SetBalanceWithBounds` instead of issuing a
+request (GH-699).
+
+The write is a normal `<msg>` envelope on the event socket (port 8080), with
+`mainNode="balanceSet"`:
+
 ```xml
-<balance>
-  <targetBalance>0</targetBalance>
-</balance>
+<msg><header deviceID="DEVICEID01" url="balance" method="POST">
+  <request requestID="3"><info mainNode="balanceSet" type="new"/></request>
+</header><body><balance><targetBalance>-3</targetBalance></balance></body></msg>
 ```
+
+The speaker answers on the same socket, 25-55 ms later, with the `requestID`
+echoed, `msgType="RESPONSE"`, and the **whole balance document including the new
+value**:
+
+```xml
+<msg><header deviceID="DEVICEID01" url="balance" method="POST">
+  <request requestID="3" msgType="RESPONSE"><info mainNode="balanceSet" type="new" /></request>
+</header><body>
+  <balance deviceID="DEVICEID01"><balanceAvailable>true</balanceAvailable>
+    <balanceMin>-7</balanceMin><balanceMax>7</balanceMax><balanceDefault>0</balanceDefault>
+    <targetBalance>-3</targetBalance><actualBalance>-3</actualBalance></balance>
+</body></msg>
+```
+
+So the write is self-confirming: parse that response and **do not read back**.
+`GET /balance` lags a write by about a second, so a read-back to confirm can
+report the old value.
+
+Either member of the pair accepts the write and both reflect it; addressing the
+master is a convention, not a requirement. The write leaves the pairing
+untouched (`/getGroup` is byte-identical before and after).
 
 **Range Examples:**
 - `-7` = left speaker
 - `0` = centered
 - `7` = right speaker
+
+The `balanceUpdated` WebSocket event that follows a change is **empty** and is
+broadcast to every connected client. It is a signal to re-read, not a value.
 
 ### GET /clockTime ✅ **Implemented**
 Retrieves the device time.
@@ -608,7 +649,9 @@ These endpoints work with real hardware but are NOT in official API v1.0:
 - `GET /networkInfo` ✅ **Implemented** - Network information
 
 ### Balance Control 🔍 **Extra**
-- `GET/POST /balance` ✅ **Implemented** - Stereo balance adjustment
+- `GET /balance` ✅ **Implemented** - Stereo pair balance, read over HTTP
+- `POST /balance` ❌ **Hangs** - the write goes over the WebSocket
+  (`mainNode="balanceSet"`), never over HTTP
 
 **Note**: Not documented in official API v1.0 but works with real devices.
 

--- a/docs/content/docs/reference/FEATURE-MAPPING.md
+++ b/docs/content/docs/reference/FEATURE-MAPPING.md
@@ -40,7 +40,7 @@ Basic device functionality required for operation:
 ### 🔊 Audio Features
 Sound quality and audio processing:
 - **Bass Control** - Bass level adjustment (-9 to +9)
-- **Balance Control** - Left/right audio balance (-50 to +50)
+- **Balance Control** - Left/right balance of a stereo pair, in the range the device reports (-7 to +7 on a SoundTouch 10)
 - **Advanced Audio Controls** - DSP controls, tone controls, audio processing
 
 ### ▶️ Playback Features

--- a/examples/advanced-audio-controls/main.go
+++ b/examples/advanced-audio-controls/main.go
@@ -252,16 +252,20 @@ func demonstrateBasicControls(soundtouchClient *client.Client) {
 		fmt.Printf("   Volume: %d%%\n", volume.TargetVolume)
 	}
 
-	// Balance control. Only the master of a stereo pair reports it; anything
-	// else answers balanceAvailable=false rather than failing, and the range
-	// comes from the device rather than being assumed.
+	// Balance control. Balance belongs to a stereo PAIR, and either member
+	// reports it with the same value; an unpaired speaker answers
+	// balanceAvailable=false rather than failing. The range comes from the
+	// device rather than being assumed.
+	//
+	// Reading is HTTP. Writing is not: POST /balance hangs, so a write goes
+	// over the WebSocket (see WebSocketClient.SetBalance).
 	balance, err := soundtouchClient.GetBalance()
 
 	switch {
 	case err != nil:
 		log.Printf("   Balance: read failed: %v", err)
 	case !balance.Available:
-		fmt.Println("   Balance: not available (only the master of a stereo pair has it)")
+		fmt.Println("   Balance: not available (this speaker is not in a stereo pair)")
 	default:
 		fmt.Printf("   Balance: %d (range: %d to %d)\n", balance.Target, balance.Min, balance.Max)
 	}
@@ -321,7 +325,7 @@ func printNotes() {
 // Consumer Devices (SoundTouch 10, 20, 30):
 // - Basic bass control: ✅ Available
 // - Basic volume control: ✅ Available
-// - Basic balance control: ✅ Available (some models)
+// - Basic balance control: ✅ Available (stereo pairs only)
 // - Advanced DSP controls: ❌ Not available
 // - Advanced tone controls: ❌ Not available
 // - Speaker level controls: ❌ Not available
@@ -341,4 +345,5 @@ func printNotes() {
 // These complement the existing basic audio controls:
 // - GET/POST /bass - Basic bass control (-9 to +9)
 // - GET/POST /volume - Volume and mute control
-// - GET/POST /balance - Stereo balance control (-50 to +50)
+// - GET /balance - Stereo pair balance, range reported by the device (-7..7 on
+//   a SoundTouch 10). The write is WebSocket-only; POST /balance hangs.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -57,7 +57,15 @@
 //		log.Fatal(err)
 //	}
 //
-//	err = client.SetBalance(-10)  // Range: -50 (left) to +50 (right)
+//	// Balance is the exception: POST /balance hangs, so the write goes over
+//	// the WebSocket, and the range comes from the device (-7..7 on an ST-10).
+//	ws := client.NewWebSocketClient(nil)
+//	if err = ws.Connect(); err != nil {
+//		log.Fatal(err)
+//	}
+//	defer func() { _ = ws.Disconnect() }()
+//
+//	updated, err := ws.SetBalance(context.Background(), -3)
 //	if err != nil {
 //		log.Fatal(err)
 //	}
@@ -132,7 +140,8 @@
 //   - Playback Control (Play/Pause/Stop/Next/Previous/Key commands)
 //   - Volume Control (Get/Set/Increment/Decrement)
 //   - Bass Control (-9 to +9 range)
-//   - Balance Control (-50 to +50 range)
+//   - Balance Control (stereo pairs; device-reported range, -7..7 on an ST-10;
+//     read over HTTP, written over the WebSocket)
 //   - Source Selection (Spotify, Bluetooth, AUX, Radio, etc.)
 //   - Preset Management (Get configured presets)
 //   - Clock/Time Management

--- a/pkg/models/doc.go
+++ b/pkg/models/doc.go
@@ -12,7 +12,7 @@
 //   - NowPlaying: Current playback status and track information
 //   - Volume: Volume levels and mute status
 //   - Bass: Bass control settings (-9 to +9)
-//   - Balance: Balance control settings (-50 to +50)
+//   - Balance: Stereo pair balance; range reported by the device (-7..7)
 //   - Sources: Available audio sources (Spotify, Bluetooth, etc.)
 //   - Presets: Configured preset buttons
 //   - Zone: Multiroom zone configuration
@@ -101,7 +101,8 @@
 //
 //   - Volume: 0-100 range with mute support
 //   - Bass: -9 to +9 range
-//   - Balance: -50 (left) to +50 (right)
+//   - Balance: device-reported range, negative = left (-7..7 on an ST-10);
+//     validate with Balance.Validate or Balance.Clamp, never a constant
 //   - Keys: Predefined key constants (PLAY, PAUSE, etc.)
 //
 // # Thread Safety


### PR DESCRIPTION
[PR #706](https://github.com/gesellix/Bose-SoundTouch/pull/706) corrected the `/balance` model against hardware, but the prose never followed. The `docs/` tree, `examples/advanced-audio-controls`, the CLI's own `--help` strings and the `pkg/client` / `pkg/models` package godoc were all still describing what we believed beforehand: a `-50..+50` range copied from `/bass` with the range widened, and `POST /balance` as a working HTTP endpoint.

## What prompted it

JRpersonal reproduced our WebSocket balance write on their own two paired SoundTouch 10s and [reported back](https://github.com/JRpersonal/streborn/issues/70#issuecomment-5629581258) confirming all three of the findings in [issue #699](https://github.com/gesellix/Bose-SoundTouch/issues/699): the `msgType="RESPONSE"` frame echoes the whole balance document so no read-back is needed, the right-hand member is not passive (retracting their own earlier note), and `-7..+7` held.

All three already match the shipped implementation, so there is no code change here. What the exchange surfaced is that the documentation still teaches the refuted shape.

## Corrected consistently

- Balance belongs to a stereo **pair**. Either member reports it with the same value and either accepts a write; an unpaired speaker reports `balanceAvailable=false`. The "only the master has it" claim is refuted by our own hardware run and now independently by a second pair.
- The range comes from the device: `-7..7`, default `0`, on a SoundTouch 10. Never hardcode it.
- Reads work over HTTP, but `GET /balance` blocks (12 s and counting) on a speaker in deep standby, so it must stay off polled paths.
- Writes are WebSocket-only. `POST /balance` hangs rather than refusing. `API-ENDPOINTS.md` now carries the real `<msg>` envelope with `mainNode="balanceSet"` and the echoed `msgType="RESPONSE"` reply.
- The write response carries the whole balance document, so it is self-confirming. Never read back over HTTP to verify: that endpoint lags a write by about a second, and in a UI a read-back can snap the slider back to the old value.

## Two snippets that would not compile

`API-COOKBOOK.md` used `models.Balance{TargetBalance: 0}` (the field is `Target`) and `client.SetBalanceSafe` (never existed). The recipe now writes over the WebSocket via `WebSocketClient.SetBalanceWithBounds`, clamped to the device-reported range. `TROUBLESHOOTING.md` says why there is no safe variant for balance, and its device table no longer has the ST-10/ST-20 support backwards.

## Deliberately untouched

`docs/content/docs/appendix/FEATURE_HISTORY.md` and `docs/archive/`. Those are dated records of what was believed at the time; retrofitting them to a later convention is not what they are for.

## Verification

- `make lint` clean, `make test` passing, `go build ./...` OK.
- `soundtouch-cli balance set --help` and `balance left --help` no longer mention `-50 to 50`.
- `make check`'s docker-backed http-client leg was not run locally (daemon down); nothing here can affect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)