### PR TITLE
feat: DLNA container art and durations, nowSelectionUpdated, recents artwork

### DIFF
--- a/cmd/example-dlna-server/audioprobe.go
+++ b/cmd/example-dlna-server/audioprobe.go
@@ -1,0 +1,236 @@
+package main
+
+import (
+	"encoding/binary"
+)
+
+// A DLNA server is expected to report how long a track is. Ours reported
+// duration="0:00:00.000" for every file, because nothing ever measured one,
+// and a speaker given that reports <time total="0"> in turn: no progress bar
+// in any client, including our own player.
+//
+// Measuring properly means reading the audio itself. These probes read only
+// the header (plus, for VBR MP3, the Xing/Info frame), which is enough for the
+// duration, bit rate, sample rate and channel count that DIDL-Lite wants, and
+// costs nothing compared with decoding. Formats we cannot parse report zero
+// and fall back to the placeholders, exactly as before.
+
+// audioParams is what a probe can tell about a track.
+type audioParams struct {
+	DurSec     float64
+	Bitrate    int // bits per second
+	SampleRate int // Hz
+	Channels   int
+}
+
+// probeAudio measures what it can from a file's bytes, by MIME type.
+func probeAudio(mime string, payload []byte) audioParams {
+	switch mime {
+	case "audio/mpeg":
+		return probeMP3(payload)
+	case "audio/x-wav", "audio/wav":
+		return probeWAV(payload)
+	default:
+		return audioParams{}
+	}
+}
+
+// --- WAV ---------------------------------------------------------------------
+
+// probeWAV reads the RIFF header: the fmt chunk carries the sample rate,
+// channel count and byte rate, and the data chunk's length divided by the byte
+// rate is the duration.
+func probeWAV(b []byte) audioParams {
+	if len(b) < 12 || string(b[0:4]) != "RIFF" || string(b[8:12]) != "WAVE" {
+		return audioParams{}
+	}
+
+	var params audioParams
+
+	var byteRate uint32
+
+	for pos := 12; pos+8 <= len(b); {
+		id := string(b[pos : pos+4])
+		size := int(binary.LittleEndian.Uint32(b[pos+4 : pos+8]))
+		body := pos + 8
+
+		if size < 0 || body+size > len(b) {
+			size = len(b) - body // tolerate a truncated final chunk
+		}
+
+		switch {
+		case id == "fmt " && size >= 16:
+			params.Channels = int(binary.LittleEndian.Uint16(b[body+2 : body+4]))
+			params.SampleRate = int(binary.LittleEndian.Uint32(b[body+4 : body+8]))
+			byteRate = binary.LittleEndian.Uint32(b[body+8 : body+12])
+			params.Bitrate = int(byteRate) * 8
+		case id == "data" && byteRate > 0:
+			params.DurSec = float64(size) / float64(byteRate)
+
+			return params
+		}
+
+		pos = body + size
+		if size%2 == 1 {
+			pos++ // chunks are word-aligned
+		}
+	}
+
+	return params
+}
+
+// --- MP3 ---------------------------------------------------------------------
+
+// MPEG audio bit rates in kbit/s, indexed by the header's bitrate_index, for
+// the version/layer combinations we care about.
+var mp3BitrateKbps = map[int][16]int{
+	// MPEG 1 Layer III
+	1: {0, 32, 40, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 0},
+	// MPEG 2 / 2.5 Layer III
+	2: {0, 8, 16, 24, 32, 40, 48, 56, 64, 80, 96, 112, 128, 144, 160, 0},
+}
+
+var mp3SampleRates = map[int][4]int{
+	3: {44100, 48000, 32000, 0}, // MPEG 1
+	2: {22050, 24000, 16000, 0}, // MPEG 2
+	0: {11025, 12000, 8000, 0},  // MPEG 2.5
+}
+
+// probeMP3 finds the first audio frame and reads its header. A Xing or Info
+// frame, written by VBR encoders, carries the total frame count, which gives
+// an exact duration; without one the file is assumed constant-bitrate and the
+// duration comes from the remaining byte count.
+func probeMP3(b []byte) audioParams {
+	start := skipID3v2(b)
+
+	offset, header, ok := findMP3Frame(b, start)
+	if !ok {
+		return audioParams{}
+	}
+
+	versionBits := int(header[1]>>3) & 0x03
+	bitrateIndex := int(header[2]>>4) & 0x0f
+	sampleIndex := int(header[2]>>2) & 0x03
+	channelMode := int(header[3]>>6) & 0x03
+
+	sampleRates, known := mp3SampleRates[versionBits]
+	if !known {
+		return audioParams{}
+	}
+
+	sampleRate := sampleRates[sampleIndex]
+
+	table := 2
+	if versionBits == 3 {
+		table = 1
+	}
+
+	bitrate := mp3BitrateKbps[table][bitrateIndex] * 1000
+
+	channels := 2
+	if channelMode == 3 {
+		channels = 1
+	}
+
+	if sampleRate == 0 || bitrate == 0 {
+		return audioParams{}
+	}
+
+	params := audioParams{Bitrate: bitrate, SampleRate: sampleRate, Channels: channels}
+
+	// Samples per frame: 1152 for MPEG 1 Layer III, 576 for MPEG 2/2.5.
+	samplesPerFrame := 576
+	if versionBits == 3 {
+		samplesPerFrame = 1152
+	}
+
+	if frames, found := xingFrameCount(b, offset, versionBits, channelMode); found {
+		params.DurSec = float64(frames) * float64(samplesPerFrame) / float64(sampleRate)
+
+		return params
+	}
+
+	params.DurSec = float64(len(b)-offset) * 8 / float64(bitrate)
+
+	return params
+}
+
+// skipID3v2 returns the offset just past an ID3v2 tag, if the file opens with
+// one. Its size is stored as four 7-bit bytes.
+func skipID3v2(b []byte) int {
+	if len(b) < 10 || string(b[0:3]) != "ID3" {
+		return 0
+	}
+
+	size := int(b[6]&0x7f)<<21 | int(b[7]&0x7f)<<14 | int(b[8]&0x7f)<<7 | int(b[9]&0x7f)
+	end := 10 + size
+
+	if end > len(b) {
+		return 0
+	}
+
+	return end
+}
+
+// findMP3Frame scans for the first frame sync, the 11 set bits that open every
+// MPEG audio frame, skipping anything the tag parser left behind.
+func findMP3Frame(b []byte, start int) (int, []byte, bool) {
+	const maxScan = 1 << 16 // a sync this far in means it is not an MP3 we can read
+
+	limit := start + maxScan
+	if limit > len(b)-4 {
+		limit = len(b) - 4
+	}
+
+	for i := start; i <= limit; i++ {
+		if b[i] != 0xff || b[i+1]&0xe0 != 0xe0 {
+			continue
+		}
+
+		// Reject the reserved version and layer encodings, so a random 0xff
+		// byte inside metadata is not mistaken for a frame.
+		if int(b[i+1]>>3)&0x03 == 1 || int(b[i+1]>>1)&0x03 == 0 {
+			continue
+		}
+
+		return i, b[i : i+4], true
+	}
+
+	return 0, nil, false
+}
+
+// xingFrameCount reads the frame count from a Xing or Info header, which VBR
+// encoders place in the first frame's side-information area.
+func xingFrameCount(b []byte, frameOffset, versionBits, channelMode int) (int, bool) {
+	// The tag sits after the side information, whose size depends on the MPEG
+	// version and whether the stream is mono.
+	var sideInfo int
+
+	switch {
+	case versionBits == 3 && channelMode == 3:
+		sideInfo = 17
+	case versionBits == 3:
+		sideInfo = 32
+	case channelMode == 3:
+		sideInfo = 9
+	default:
+		sideInfo = 17
+	}
+
+	pos := frameOffset + 4 + sideInfo
+	if pos+12 > len(b) {
+		return 0, false
+	}
+
+	tag := string(b[pos : pos+4])
+	if tag != "Xing" && tag != "Info" {
+		return 0, false
+	}
+
+	flags := binary.BigEndian.Uint32(b[pos+4 : pos+8])
+	if flags&0x0001 == 0 {
+		return 0, false // no frame count present
+	}
+
+	return int(binary.BigEndian.Uint32(b[pos+8 : pos+12])), true
+}

--- a/cmd/example-dlna-server/audioprobe_test.go
+++ b/cmd/example-dlna-server/audioprobe_test.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"testing"
+)
+
+// wavBytes builds a minimal RIFF/WAVE file with the given parameters and
+// dataBytes of (silent) payload.
+func wavBytes(sampleRate, channels, bitsPerSample, dataBytes int) []byte {
+	byteRate := sampleRate * channels * bitsPerSample / 8
+
+	var b bytes.Buffer
+
+	b.WriteString("RIFF")
+	_ = binary.Write(&b, binary.LittleEndian, uint32(36+dataBytes))
+	b.WriteString("WAVE")
+
+	b.WriteString("fmt ")
+	_ = binary.Write(&b, binary.LittleEndian, uint32(16))
+	_ = binary.Write(&b, binary.LittleEndian, uint16(1)) // PCM
+	_ = binary.Write(&b, binary.LittleEndian, uint16(channels))
+	_ = binary.Write(&b, binary.LittleEndian, uint32(sampleRate))
+	_ = binary.Write(&b, binary.LittleEndian, uint32(byteRate))
+	_ = binary.Write(&b, binary.LittleEndian, uint16(channels*bitsPerSample/8))
+	_ = binary.Write(&b, binary.LittleEndian, uint16(bitsPerSample))
+
+	b.WriteString("data")
+	_ = binary.Write(&b, binary.LittleEndian, uint32(dataBytes))
+	b.Write(make([]byte, dataBytes))
+
+	return b.Bytes()
+}
+
+// mp3Bytes builds bytes that open with one MPEG 1 Layer III frame header
+// (128 kbit/s, 44100 Hz, stereo) followed by total-4 bytes of filler.
+func mp3Bytes(total int) []byte {
+	b := make([]byte, total)
+	copy(b, []byte{0xff, 0xfb, 0x90, 0x00})
+
+	return b
+}
+
+func TestProbeWAVMeasuresDuration(t *testing.T) {
+	// 44100 Hz, stereo, 16-bit: one second is 176400 bytes.
+	params := probeAudio("audio/x-wav", wavBytes(44100, 2, 16, 176400*3))
+
+	if params.SampleRate != 44100 || params.Channels != 2 {
+		t.Errorf("sampleRate=%d channels=%d, want 44100 and 2", params.SampleRate, params.Channels)
+	}
+
+	if params.Bitrate != 44100*2*16 {
+		t.Errorf("bitrate = %d, want %d", params.Bitrate, 44100*2*16)
+	}
+
+	if math.Abs(params.DurSec-3) > 0.001 {
+		t.Errorf("duration = %v, want 3", params.DurSec)
+	}
+}
+
+func TestProbeMP3ReadsTheFrameHeader(t *testing.T) {
+	// At 128 kbit/s, 32000 bytes is exactly two seconds.
+	params := probeAudio("audio/mpeg", mp3Bytes(32000))
+
+	if params.Bitrate != 128000 || params.SampleRate != 44100 || params.Channels != 2 {
+		t.Errorf("bitrate=%d sampleRate=%d channels=%d, want 128000, 44100 and 2",
+			params.Bitrate, params.SampleRate, params.Channels)
+	}
+
+	if math.Abs(params.DurSec-2) > 0.01 {
+		t.Errorf("duration = %v, want 2", params.DurSec)
+	}
+}
+
+// A VBR file's byte count says nothing about its length, so the Xing frame
+// count is what has to be believed when one is present.
+func TestProbeMP3PrefersTheXingFrameCount(t *testing.T) {
+	const frames = 100
+
+	b := mp3Bytes(32000)
+
+	// Side information for MPEG 1 stereo is 32 bytes, so the tag starts there.
+	pos := 4 + 32
+	copy(b[pos:], []byte("Xing"))
+	binary.BigEndian.PutUint32(b[pos+4:], 0x0001) // frame count present
+	binary.BigEndian.PutUint32(b[pos+8:], frames)
+
+	params := probeAudio("audio/mpeg", b)
+
+	want := float64(frames) * 1152 / 44100
+	if math.Abs(params.DurSec-want) > 0.001 {
+		t.Errorf("duration = %v, want %v from the Xing frame count", params.DurSec, want)
+	}
+}
+
+func TestProbeMP3SkipsAnID3Tag(t *testing.T) {
+	const tagBody = 40
+
+	tag := make([]byte, 10+tagBody)
+	copy(tag, []byte("ID3"))
+	tag[3] = 3               // version 2.3
+	tag[9] = byte(tagBody)   // syncsafe size, small enough to fit one byte
+	audio := mp3Bytes(32000) //nolint:mnd // exactly two seconds at 128 kbit/s
+	b := append(tag, audio...)
+
+	params := probeAudio("audio/mpeg", b)
+
+	if params.Bitrate != 128000 {
+		t.Errorf("bitrate = %d, want the frame past the ID3 tag to be read", params.Bitrate)
+	}
+}
+
+// Anything we cannot parse must report nothing rather than guess, so the DIDL
+// falls back to its placeholders.
+func TestProbeUnknownFormatsReportNothing(t *testing.T) {
+	for _, mime := range []string{"audio/flac", "audio/mp4", "audio/ogg", ""} {
+		if got := probeAudio(mime, []byte("not audio")); got != (audioParams{}) {
+			t.Errorf("probeAudio(%q) = %+v, want the zero value", mime, got)
+		}
+	}
+}

--- a/cmd/example-dlna-server/main.go
+++ b/cmd/example-dlna-server/main.go
@@ -508,6 +508,8 @@ func loadTreeFromDir(dir, fallbackName string) (*dlnatest.Tree, int, error) {
 			order = append(order, trackDir)
 		}
 
+		params := probeAudio(mime, payload)
+
 		g.items = append(g.items, &dlnatest.Item{
 			Title:      base,
 			Class:      "object.item.audioItem.musicTrack",
@@ -515,6 +517,10 @@ func loadTreeFromDir(dir, fallbackName string) (*dlnatest.Tree, int, error) {
 			Album:      albumTitle(trackDir, rootClean, fallbackName),
 			MimeType:   mime,
 			Payload:    payload,
+			DurSec:     params.DurSec,
+			Bitrate:    params.Bitrate,
+			SampleRate: params.SampleRate,
+			Channels:   params.Channels,
 			ArtPayload: art,
 			ArtMime:    artMime,
 		})
@@ -541,12 +547,18 @@ func loadTreeFromDir(dir, fallbackName string) (*dlnatest.Tree, int, error) {
 			it.ParentID = cid
 		}
 
+		// The album folder's own cover, so the container advertises album art
+		// rather than leaving a client to fall back on a track's.
+		cover, coverMime := dirCover(d)
+
 		containers = append(containers, &dlnatest.Container{
-			ID:       cid,
-			ParentID: "0",
-			Title:    albumTitle(d, rootClean, fallbackName),
-			Class:    "object.container.storageFolder",
-			Children: g.items,
+			ID:         cid,
+			ParentID:   "0",
+			Title:      albumTitle(d, rootClean, fallbackName),
+			Class:      "object.container.storageFolder",
+			Children:   g.items,
+			ArtPayload: cover,
+			ArtMime:    coverMime,
 		})
 	}
 

--- a/cmd/soundtouch-cli/cmd_events.go
+++ b/cmd/soundtouch-cli/cmd_events.go
@@ -210,7 +210,7 @@ func parseEventFilters(eventFilter string) map[string]bool {
 		"nowPlaying": true, "volume": true, "connection": true,
 		"preset": true, "zone": true, "group": true, "bass": true,
 		"sdkInfo": true, "userActivity": true, "userInactivity": true,
-		"errors": true, "balance": true,
+		"errors": true, "balance": true, "nowSelection": true,
 	}
 
 	if eventFilter == "" {
@@ -293,6 +293,13 @@ func setupEventHandlers(wsClient *client.WebSocketClient, filters map[string]boo
 	if filters == nil || filters["preset"] {
 		wsClient.OnPresetUpdated(func(event *models.PresetUpdatedEvent) {
 			handlePresetEvent(event, verbose)
+		})
+	}
+
+	// Now-selection events
+	if filters == nil || filters["nowSelection"] {
+		wsClient.OnNowSelection(func(event *models.NowSelectionUpdatedEvent) {
+			handleNowSelectionEvent(event, verbose)
 		})
 	}
 
@@ -608,6 +615,44 @@ func handleBalanceEvent(_ *models.BalanceUpdatedEvent, verbose bool) {
 
 	if verbose {
 		fmt.Printf("  ⏰ Timestamp: %s\n", time.Now().Format("15:04:05"))
+	}
+}
+
+// handleNowSelectionEvent prints what the speaker now considers selected. It
+// arrives alongside nowPlayingUpdated and names the ContentItem the speaker
+// acted on, which is the identity a selection can be checked against.
+func handleNowSelectionEvent(event *models.NowSelectionUpdatedEvent, verbose bool) {
+	fmt.Printf("\n🎯 Now Selection Updated [%s]:\n", event.DeviceID)
+
+	item := event.SelectedContentItem()
+	if item == nil {
+		fmt.Printf("  ⏹️  No selection reported\n")
+
+		return
+	}
+
+	if item.ItemName != "" {
+		fmt.Printf("  🎵 %s\n", item.ItemName)
+	}
+
+	fmt.Printf("  📻 Source: %s\n", item.Source)
+
+	if item.SourceAccount != "" {
+		fmt.Printf("  👤 Account: %s\n", item.SourceAccount)
+	}
+
+	if id, ok := event.PresetID(); ok {
+		fmt.Printf("  ⭐ Preset: %d\n", id)
+	}
+
+	if verbose {
+		if item.Type != "" {
+			fmt.Printf("  🏷️  Type: %s\n", item.Type)
+		}
+
+		if item.Location != "" {
+			fmt.Printf("  📍 Location: %s\n", item.Location)
+		}
 	}
 }
 

--- a/cmd/soundtouch-cli/cmd_events_test.go
+++ b/cmd/soundtouch-cli/cmd_events_test.go
@@ -377,12 +377,9 @@ func TestWebSocketConfigReconnectToggle(t *testing.T) {
 // registering an OnUnknownEvent handler opts out of the client's own fallback
 // log, which was the only other caller.
 func TestHandleUnknownEventNamesTheElement(t *testing.T) {
-	// Captured from a SoundTouch 10 (FW 27.0.6) when a STORED_MUSIC folder is
-	// selected. nowSelectionUpdated is not modelled yet.
-	raw := []byte(`<updates deviceID="DEVICEID01"><nowSelectionUpdated>` +
-		`<preset id="0"><ContentItem source="STORED_MUSIC" type="dir" location="4:cont2:615:part12:39"` +
-		` isPresetable="true"><itemName>Swissgroove</itemName></ContentItem></preset>` +
-		`</nowSelectionUpdated></updates>`)
+	// Any <updates> child we do not model yet. nowSelectionUpdated used to
+	// stand in here and is modelled now, so this uses a name that is not.
+	raw := []byte(`<updates deviceID="DEVICEID01"><someFutureUpdated><whatever/></someFutureUpdated></updates>`)
 
 	event, err := models.ParseWebSocketEvent(raw)
 	if err != nil {
@@ -391,7 +388,39 @@ func TestHandleUnknownEventNamesTheElement(t *testing.T) {
 
 	out := captureStdout(t, func() { handleUnknownEvent(event, true) })
 
-	if !strings.Contains(out, "nowSelectionUpdated") {
+	if !strings.Contains(out, "someFutureUpdated") {
 		t.Errorf("unknown-event output does not name the element:\n%s", out)
+	}
+}
+
+// TestHandleNowSelectionEventPrintsTheSelection: the frame that used to print
+// as "Unmodelled element" now names what the speaker selected.
+func TestHandleNowSelectionEventPrintsTheSelection(t *testing.T) {
+	// Captured from a SoundTouch 10 when a STORED_MUSIC folder is selected.
+	raw := []byte(`<updates deviceID="DEVICEID01"><nowSelectionUpdated>` +
+		`<preset id="0"><ContentItem source="STORED_MUSIC" type="dir" location="4:cont2:615:part12:39"` +
+		` isPresetable="true"><itemName>A Folder</itemName></ContentItem></preset>` +
+		`</nowSelectionUpdated></updates>`)
+
+	event, err := models.ParseWebSocketEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent: %v", err)
+	}
+
+	if len(event.UnknownEventNames()) != 0 {
+		t.Errorf("still reported as unmodelled: %v", event.UnknownEventNames())
+	}
+
+	out := captureStdout(t, func() { handleNowSelectionEvent(event.NowSelectionUpdated, true) })
+
+	for _, want := range []string{"DEVICEID01", "A Folder", "STORED_MUSIC", "4:cont2:615:part12:39"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("now-selection output does not contain %q:\n%s", want, out)
+		}
+	}
+
+	// Preset id 0 means "not a stored preset", so no slot should be claimed.
+	if strings.Contains(out, "Preset:") {
+		t.Errorf("output claims a preset slot for id 0:\n%s", out)
 	}
 }

--- a/pkg/client/websocket.go
+++ b/pkg/client/websocket.go
@@ -153,6 +153,15 @@ func (ws *WebSocketClient) OnPresetUpdated(handler models.TypedEventHandler[*mod
 	ws.handlers.OnPresetUpdated = handler
 }
 
+// OnNowSelection sets a handler for now-selection update events, which report
+// the ContentItem the speaker considers selected.
+func (ws *WebSocketClient) OnNowSelection(handler models.TypedEventHandler[*models.NowSelectionUpdatedEvent]) {
+	ws.mu.Lock()
+	defer ws.mu.Unlock()
+
+	ws.handlers.OnNowSelection = handler
+}
+
 // OnZoneUpdated sets a handler for zone update events
 func (ws *WebSocketClient) OnZoneUpdated(handler models.TypedEventHandler[*models.ZoneUpdatedEvent]) {
 	ws.mu.Lock()
@@ -769,6 +778,23 @@ func (ws *WebSocketClient) dispatchTypedEventContinued(handlers *models.WebSocke
 		return true
 
 	case models.EventTypeLanguageUpdated:
+		return true
+
+	default:
+		return ws.dispatchTypedEventTail(handlers, eventType, event)
+	}
+}
+
+// dispatchTypedEventTail carries the events added after the switch above
+// reached the complexity limit. Splitting the chain keeps each switch within
+// it rather than suppressing the check.
+func (ws *WebSocketClient) dispatchTypedEventTail(handlers *models.WebSocketEventHandlers, eventType models.WebSocketEventType, event *models.WebSocketEvent) bool {
+	switch eventType {
+	case models.EventTypeNowSelectionUpdated:
+		if handlers.OnNowSelection != nil && event.NowSelectionUpdated != nil {
+			handlers.OnNowSelection(event.NowSelectionUpdated)
+		}
+
 		return true
 
 	default:

--- a/pkg/dlna/dlnatest/dlnatest.go
+++ b/pkg/dlna/dlnatest/dlnatest.go
@@ -38,6 +38,17 @@ type Container struct {
 	Title    string
 	Class    string // upnp:class value, e.g. "object.container.storageFolder"
 	Children []*Item
+
+	// ArtPayload, when non-empty, is album-art image bytes served at
+	// /AlbumArt/<ID>.<ext> and advertised on the container itself, with
+	// ArtMime as the image MIME type.
+	//
+	// A container that advertises none leaves a speaker nothing to store when
+	// it saves a preset for the whole album: measured on a SoundTouch 10, it
+	// then stores the art URL of whatever track was playing, so the preset for
+	// an album carries a track's artwork.
+	ArtPayload []byte
+	ArtMime    string
 }
 
 // Item represents a DLNA object.item.audioItem node.
@@ -51,6 +62,13 @@ type Item struct {
 	MimeType string
 	DurSec   float64 // duration in seconds
 	Payload  []byte  // raw audio bytes served at /MediaItems/<ID>.<ext>
+
+	// Bitrate (bits per second), SampleRate (Hz) and Channels describe the
+	// audio in Payload. Each falls back to a placeholder in the DIDL <res>
+	// when left zero, which is what the built-in synthetic tracks rely on.
+	Bitrate    int
+	SampleRate int
+	Channels   int
 
 	// ArtPayload, when non-empty, is album-art image bytes served at
 	// /AlbumArt/<ID>.<ext> and advertised in DIDL-Lite via <upnp:albumArtURI>.
@@ -75,6 +93,15 @@ func (it *Item) mediaExt() string {
 	default:
 		return "bin"
 	}
+}
+
+// orDefault keeps the historical placeholder for a field nothing measured.
+func orDefault(value, fallback int) int {
+	if value > 0 {
+		return value
+	}
+
+	return fallback
 }
 
 // artExt returns the file extension for an album-art MIME type.
@@ -151,6 +178,20 @@ func (t *Tree) containerByID(id string) *Container {
 	}
 
 	return nil
+}
+
+// artByID returns the album art for an item or a container ID, since both
+// advertise art under /AlbumArt/<ID>.
+func (t *Tree) artByID(id string) ([]byte, string) {
+	if it := t.itemByID(id); it != nil && len(it.ArtPayload) > 0 {
+		return it.ArtPayload, it.ArtMime
+	}
+
+	if c := t.containerByID(id); c != nil && len(c.ArtPayload) > 0 {
+		return c.ArtPayload, c.ArtMime
+	}
+
+	return nil, ""
 }
 
 // itemByID returns the first item in any container whose ID matches.
@@ -371,7 +412,7 @@ func (s *Server) serveContentDir(w http.ResponseWriter, r *http.Request) {
 		switch objectID {
 		case "0":
 			// Root: return containers.
-			didl, total = s.browseRoot(startIndex, reqCount)
+			didl, total = s.browseRoot(startIndex, reqCount, base)
 		default:
 			// Try as a container ID.
 			if c := s.tree.containerByID(objectID); c != nil {
@@ -410,7 +451,7 @@ func baseURL(r *http.Request) string {
 }
 
 // browseRoot returns DIDL-Lite for the root container (ObjectID "0").
-func (s *Server) browseRoot(start, count int) (string, int) {
+func (s *Server) browseRoot(start, count int, base string) (string, int) {
 	containers := s.tree.Containers
 	total := len(containers)
 	page := page(containers, start, count)
@@ -430,12 +471,25 @@ func (s *Server) browseRoot(start, count int) (string, int) {
 		)
 		b.WriteString(`<dc:title>` + xmlEsc(c.Title) + `</dc:title>`)
 		b.WriteString(`<upnp:class>` + xmlEsc(c.Class) + `</upnp:class>`)
+		writeContainerArtDIDL(&b, c, base)
 		b.WriteString(`</container>`)
 	}
 
 	b.WriteString(`</DIDL-Lite>`)
 
 	return b.String(), total
+}
+
+// writeContainerArtDIDL advertises a container's own album art, so a client
+// that saves the container (a speaker storing a preset for an album, say) has
+// album art to save rather than the art of whichever track is playing.
+func writeContainerArtDIDL(b *strings.Builder, c *Container, base string) {
+	if len(c.ArtPayload) == 0 {
+		return
+	}
+
+	artURL := fmt.Sprintf("%s/AlbumArt/%s.%s", base, urlPathEsc(c.ID), artExt(c.ArtMime))
+	b.WriteString(`<upnp:albumArtURI>` + xmlEsc(artURL) + `</upnp:albumArtURI>`)
 }
 
 // didlOpen is the opening tag (with namespaces) shared by all DIDL-Lite results.
@@ -470,8 +524,9 @@ func writeItemDIDL(b *strings.Builder, it *Item, base string) {
 	}
 
 	_, _ = fmt.Fprintf(b,
-		`<res size="%d" duration="%s" bitrate="128000" sampleFrequency="8000" nrAudioChannels="1" protocolInfo="http-get:*:%s:*">%s</res>`,
-		size, dur, xmlEsc(it.MimeType), xmlEsc(resURL),
+		`<res size="%d" duration="%s" bitrate="%d" sampleFrequency="%d" nrAudioChannels="%d" protocolInfo="http-get:*:%s:*">%s</res>`,
+		size, dur, orDefault(it.Bitrate, 128000), orDefault(it.SampleRate, 8000),
+		orDefault(it.Channels, 1), xmlEsc(it.MimeType), xmlEsc(resURL),
 	)
 	b.WriteString(`</item>`)
 }
@@ -518,6 +573,7 @@ func (s *Server) browseMetadata(objectID, base string) (string, int) {
 		)
 		b.WriteString(`<dc:title>` + xmlEsc(c.Title) + `</dc:title>`)
 		b.WriteString(`<upnp:class>` + xmlEsc(c.Class) + `</upnp:class>`)
+		writeContainerArtDIDL(&b, c, base)
 		b.WriteString(`</container>`)
 	case s.tree.itemByID(objectID) != nil:
 		writeItemDIDL(&b, s.tree.itemByID(objectID), base)
@@ -608,18 +664,18 @@ func (s *Server) serveAlbumArt(w http.ResponseWriter, r *http.Request) {
 		id = rel[:dot]
 	}
 
-	item := s.tree.itemByID(id)
-	if item == nil || len(item.ArtPayload) == 0 {
+	payload, mime := s.tree.artByID(id)
+	if len(payload) == 0 {
 		http.NotFound(w, r)
 
 		return
 	}
 
-	if item.ArtMime != "" {
-		w.Header().Set("Content-Type", item.ArtMime)
+	if mime != "" {
+		w.Header().Set("Content-Type", mime)
 	}
 
-	http.ServeContent(w, r, "art."+artExt(item.ArtMime), serveModTime, bytes.NewReader(item.ArtPayload))
+	http.ServeContent(w, r, "art."+artExt(mime), serveModTime, bytes.NewReader(payload))
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/dlna/dlnatest/dlnatest_test.go
+++ b/pkg/dlna/dlnatest/dlnatest_test.go
@@ -156,11 +156,12 @@ type didlLite struct {
 }
 
 type didlContainer struct {
-	ID         string `xml:"id,attr"`
-	ParentID   string `xml:"parentID,attr"`
-	ChildCount string `xml:"childCount,attr"`
-	Title      string `xml:"title"`
-	Class      string `xml:"class"`
+	ID          string `xml:"id,attr"`
+	ParentID    string `xml:"parentID,attr"`
+	ChildCount  string `xml:"childCount,attr"`
+	Title       string `xml:"title"`
+	Class       string `xml:"class"`
+	AlbumArtURI string `xml:"albumArtURI"`
 }
 
 type didlItem struct {
@@ -172,8 +173,12 @@ type didlItem struct {
 }
 
 type didlRes struct {
-	ProtocolInfo string `xml:"protocolInfo,attr"`
-	URL          string `xml:",chardata"`
+	ProtocolInfo    string `xml:"protocolInfo,attr"`
+	Duration        string `xml:"duration,attr"`
+	Bitrate         int    `xml:"bitrate,attr"`
+	SampleFrequency int    `xml:"sampleFrequency,attr"`
+	NrAudioChannels int    `xml:"nrAudioChannels,attr"`
+	URL             string `xml:",chardata"`
 }
 
 func TestBrowseRoot_ReturnsMusicContainer(t *testing.T) {
@@ -330,6 +335,128 @@ func min8(n int) int {
 // ----------------------------------------------------------------------------
 // Custom tree
 // ----------------------------------------------------------------------------
+
+// albumTree is a one-album library whose container carries its own art and
+// whose track carries measured audio parameters.
+func albumTree() *dlnatest.Tree {
+	cover := []byte("cover-bytes")
+
+	return &dlnatest.Tree{
+		Containers: []*dlnatest.Container{
+			{
+				ID:         "7",
+				ParentID:   "0",
+				Title:      "An Album",
+				Class:      "object.container.storageFolder",
+				ArtPayload: cover,
+				ArtMime:    "image/jpeg",
+				Children: []*dlnatest.Item{
+					{
+						ID:         "7$0",
+						ParentID:   "7",
+						Title:      "01 - A Track",
+						Class:      "object.item.audioItem.musicTrack",
+						MimeType:   "audio/mpeg",
+						DurSec:     212.5,
+						Bitrate:    320000,
+						SampleRate: 44100,
+						Channels:   2,
+						Payload:    []byte("audio"),
+						ArtPayload: cover,
+						ArtMime:    "image/jpeg",
+					},
+				},
+			},
+		},
+	}
+}
+
+// A container that advertises no art leaves a speaker saving a preset for the
+// whole album with nothing to store but the art of whichever track happened to
+// be playing, which is what a SoundTouch 10 was measured doing.
+func TestBrowseRootAdvertisesContainerAlbumArt(t *testing.T) {
+	ts, _ := dlnatest.NewHTTPTest(dlnatest.WithTree(albumTree()))
+	defer ts.Close()
+
+	_, didl := soapBrowse(t, ts.URL, "0")
+
+	if len(didl.Containers) != 1 {
+		t.Fatalf("root browse returned %d containers, want 1", len(didl.Containers))
+	}
+
+	artURL := didl.Containers[0].AlbumArtURI
+	if artURL == "" {
+		t.Fatal("container advertises no albumArtURI")
+	}
+
+	if want := ts.URL + "/AlbumArt/7.jpg"; artURL != want {
+		t.Errorf("albumArtURI = %q, want %q", artURL, want)
+	}
+
+	resp, err := http.Get(artURL)
+	if err != nil {
+		t.Fatalf("GET %s: %v", artURL, err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d", artURL, resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading art: %v", err)
+	}
+
+	if string(body) != "cover-bytes" {
+		t.Errorf("container art body = %q, want the container's own art", body)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != "image/jpeg" {
+		t.Errorf("container art Content-Type = %q, want image/jpeg", got)
+	}
+}
+
+// A container with no art of its own must not advertise one, rather than
+// pointing at a URL that 404s.
+func TestBrowseRootOmitsAlbumArtWhenTheContainerHasNone(t *testing.T) {
+	ts, _ := dlnatest.NewHTTPTest()
+	defer ts.Close()
+
+	_, didl := soapBrowse(t, ts.URL, "0")
+
+	for _, c := range didl.Containers {
+		if c.AlbumArtURI != "" {
+			t.Errorf("container %q advertises albumArtURI %q with no art set", c.Title, c.AlbumArtURI)
+		}
+	}
+}
+
+// Durations and audio parameters are what a client draws a progress bar from.
+// Reporting zero for everything, as this server used to, leaves the speaker
+// reporting <time total="0"> in turn.
+func TestItemResCarriesMeasuredAudioParameters(t *testing.T) {
+	ts, _ := dlnatest.NewHTTPTest(dlnatest.WithTree(albumTree()))
+	defer ts.Close()
+
+	_, didl := soapBrowse(t, ts.URL, "7")
+
+	if len(didl.Items) != 1 || len(didl.Items[0].Res) != 1 {
+		t.Fatalf("container browse returned %d items, want 1 with one <res>", len(didl.Items))
+	}
+
+	res := didl.Items[0].Res[0]
+
+	if res.Duration != "0:03:32.500" {
+		t.Errorf("duration = %q, want %q", res.Duration, "0:03:32.500")
+	}
+
+	if res.Bitrate != 320000 || res.SampleFrequency != 44100 || res.NrAudioChannels != 2 {
+		t.Errorf("res bitrate=%d sampleFrequency=%d channels=%d, want 320000, 44100 and 2",
+			res.Bitrate, res.SampleFrequency, res.NrAudioChannels)
+	}
+}
 
 func TestCustomTree(t *testing.T) {
 	customTree := &dlnatest.Tree{

--- a/pkg/models/websocket.go
+++ b/pkg/models/websocket.go
@@ -42,6 +42,9 @@ const (
 	EventTypeRecentsUpdated WebSocketEventType = "recentsUpdated"
 	// EventTypeLanguageUpdated indicates a language setting change
 	EventTypeLanguageUpdated WebSocketEventType = "languageUpdated"
+	// EventTypeNowSelectionUpdated reports what the speaker now considers
+	// selected, as a preset slot wrapping the ContentItem.
+	EventTypeNowSelectionUpdated WebSocketEventType = "nowSelectionUpdated"
 	// EventTypePairDeviceWithAccount indicates a device pairing request
 	EventTypePairDeviceWithAccount WebSocketEventType = "PairDeviceWithAccount"
 	// EventTypeUnPairDeviceWithAccount indicates a device unpairing request
@@ -85,6 +88,8 @@ func (e WebSocketEventType) String() string {
 		return "Pair Device With Account"
 	case EventTypeUnPairDeviceWithAccount:
 		return "UnPair Device With Account"
+	case EventTypeNowSelectionUpdated:
+		return "Now Selection Updated"
 	default:
 		return "Unknown Event"
 	}
@@ -108,6 +113,7 @@ type WebSocketEvent struct {
 	ErrorUpdated           *ErrorUpdatedEvent           `xml:"errorUpdated,omitempty"`
 	RecentsUpdated         *RecentsUpdatedEvent         `xml:"recentsUpdated,omitempty"`
 	LanguageUpdated        *LanguageUpdatedEvent        `xml:"languageUpdated,omitempty"`
+	NowSelectionUpdated    *NowSelectionUpdatedEvent    `xml:"nowSelectionUpdated,omitempty"`
 	// UnknownElements captures <updates> children we don't model yet (e.g.
 	// nowSelectionUpdated), so callers can log them by name instead of an
 	// empty list when no known event matched.
@@ -150,6 +156,10 @@ func (e *WebSocketEvent) GetEvents() []interface{} {
 
 	if e.PresetUpdated != nil {
 		events = append(events, e.PresetUpdated)
+	}
+
+	if e.NowSelectionUpdated != nil {
+		events = append(events, e.NowSelectionUpdated)
 	}
 
 	if e.ZoneUpdated != nil {
@@ -400,7 +410,46 @@ type Error struct {
 	Text     string   `xml:",chardata"`
 }
 
-// RecentsUpdatedEvent represents a recent items update event
+// NowSelectionUpdatedEvent reports what the speaker now considers selected.
+// It arrives alongside nowPlayingUpdated after a selection, and carries the
+// ContentItem the speaker actually acted on, wrapped in a preset element.
+//
+// Observed on SoundTouch 10 firmware for TUNEIN (a station) and STORED_MUSIC
+// (a container). The preset id is 0 for a selection that is not a stored
+// preset, so it identifies a slot only when non-zero.
+type NowSelectionUpdatedEvent struct {
+	XMLName  xml.Name            `xml:"nowSelectionUpdated"`
+	DeviceID string              `xml:"deviceID,attr"`
+	Preset   *NowSelectionPreset `xml:"preset"`
+}
+
+// NowSelectionPreset is the preset wrapper inside a nowSelectionUpdated event.
+type NowSelectionPreset struct {
+	ID          int          `xml:"id,attr"`
+	ContentItem *ContentItem `xml:"ContentItem"`
+}
+
+// SelectedContentItem returns the ContentItem this selection names, or nil
+// when the frame carried none.
+func (e *NowSelectionUpdatedEvent) SelectedContentItem() *ContentItem {
+	if e == nil || e.Preset == nil {
+		return nil
+	}
+
+	return e.Preset.ContentItem
+}
+
+// PresetID returns the preset slot this selection came from, and false when
+// the selection is not a stored preset.
+func (e *NowSelectionUpdatedEvent) PresetID() (int, bool) {
+	if e == nil || e.Preset == nil || e.Preset.ID <= 0 {
+		return 0, false
+	}
+
+	return e.Preset.ID, true
+}
+
+// RecentsUpdatedEvent represents a recents update event
 type RecentsUpdatedEvent struct {
 	XMLName  xml.Name `xml:"recentsUpdated"`
 	DeviceID string   `xml:"deviceID,attr"`
@@ -531,6 +580,7 @@ type WebSocketEventHandlers struct {
 	OnNameUpdated         TypedEventHandler[*NameUpdatedEvent]
 	OnErrorUpdated        TypedEventHandler[*ErrorUpdatedEvent]
 	OnRecentsUpdated      TypedEventHandler[*RecentsUpdatedEvent]
+	OnNowSelection        TypedEventHandler[*NowSelectionUpdatedEvent]
 	OnLanguageUpdated     TypedEventHandler[*LanguageUpdatedEvent]
 	OnUnknownEvent        EventHandler
 	// OnDeviceError fires for root-level <errorUpdate> frames — the
@@ -637,6 +687,10 @@ func (e *WebSocketEvent) propagateDeviceID() {
 
 	if e.LanguageUpdated != nil {
 		targets = append(targets, &e.LanguageUpdated.DeviceID)
+	}
+
+	if e.NowSelectionUpdated != nil {
+		targets = append(targets, &e.NowSelectionUpdated.DeviceID)
 	}
 
 	for _, target := range targets {
@@ -859,6 +913,10 @@ func (e *WebSocketEvent) GetEventTypes() []WebSocketEventType {
 
 	if e.LanguageUpdated != nil {
 		types = append(types, EventTypeLanguageUpdated)
+	}
+
+	if e.NowSelectionUpdated != nil {
+		types = append(types, EventTypeNowSelectionUpdated)
 	}
 
 	return types

--- a/pkg/models/websocket_test.go
+++ b/pkg/models/websocket_test.go
@@ -593,12 +593,11 @@ func TestCreateMockWebSocketEvent(t *testing.T) {
 }
 
 // TestParseWebSocketEvent_UnknownElements verifies that an <updates> envelope
-// whose only child is an unmodeled element (e.g. nowSelectionUpdated, observed
-// on real SoundTouch 10 firmware) parses with no known event types but with
-// the element captured by name, so callers can log something useful instead
-// of an empty list.
+// whose only child is an unmodeled element parses with no known event types
+// but with the element captured by name, so callers can log something useful
+// instead of an empty list.
 func TestParseWebSocketEvent_UnknownElements(t *testing.T) {
-	raw := []byte(`<updates deviceID="A81B6A536A98"><nowSelectionUpdated><preset id="0"><ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s308770" sourceAccount="" isPresetable="true"><itemName>Willy</itemName></ContentItem></preset></nowSelectionUpdated></updates>`)
+	raw := []byte(`<updates deviceID="DEVICEID01"><someFutureUpdated><whatever/></someFutureUpdated></updates>`)
 
 	event, err := ParseWebSocketEvent(raw)
 	if err != nil {
@@ -610,8 +609,115 @@ func TestParseWebSocketEvent_UnknownElements(t *testing.T) {
 	}
 
 	names := event.UnknownEventNames()
-	if len(names) != 1 || names[0] != "nowSelectionUpdated" {
-		t.Errorf("expected [nowSelectionUpdated], got %v", names)
+	if len(names) != 1 || names[0] != "someFutureUpdated" {
+		t.Errorf("expected [someFutureUpdated], got %v", names)
+	}
+}
+
+// TestParseWebSocketEvent_NowSelectionUpdated pins the two shapes captured on
+// SoundTouch 10 firmware: a TuneIn station and a stored-music container. The
+// preset id is 0 in both, because neither selection came from a preset slot.
+func TestParseWebSocketEvent_NowSelectionUpdated(t *testing.T) {
+	tests := []struct {
+		name         string
+		raw          string
+		wantSource   string
+		wantType     string
+		wantLocation string
+		wantItemName string
+	}{
+		{
+			name:         "tunein station",
+			raw:          `<updates deviceID="DEVICEID01"><nowSelectionUpdated><preset id="0"><ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s308770" sourceAccount="" isPresetable="true"><itemName>A Station</itemName></ContentItem></preset></nowSelectionUpdated></updates>`,
+			wantSource:   "TUNEIN",
+			wantType:     "stationurl",
+			wantLocation: "/v1/playback/station/s308770",
+			wantItemName: "A Station",
+		},
+		{
+			name:         "stored music container",
+			raw:          `<updates deviceID="DEVICEID01"><nowSelectionUpdated><preset id="0"><ContentItem source="STORED_MUSIC" type="dir" location="4:cont2:615:part12:39" isPresetable="true"><itemName>A Folder</itemName></ContentItem></preset></nowSelectionUpdated></updates>`,
+			wantSource:   "STORED_MUSIC",
+			wantType:     "dir",
+			wantLocation: "4:cont2:615:part12:39",
+			wantItemName: "A Folder",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, err := ParseWebSocketEvent([]byte(test.raw))
+			if err != nil {
+				t.Fatalf("ParseWebSocketEvent: %v", err)
+			}
+
+			if names := event.UnknownEventNames(); len(names) != 0 {
+				t.Errorf("modeled event still reported as unknown: %v", names)
+			}
+
+			types := event.GetEventTypes()
+			if len(types) != 1 || types[0] != EventTypeNowSelectionUpdated {
+				t.Fatalf("event types = %v, want [%s]", types, EventTypeNowSelectionUpdated)
+			}
+
+			selection := event.NowSelectionUpdated
+			if selection == nil {
+				t.Fatal("NowSelectionUpdated is nil")
+			}
+
+			// The device ID lives on <updates> and is copied down to children.
+			if selection.DeviceID != "DEVICEID01" {
+				t.Errorf("deviceID = %q, want DEVICEID01", selection.DeviceID)
+			}
+
+			if _, ok := selection.PresetID(); ok {
+				t.Error("preset id 0 reported as a stored preset")
+			}
+
+			item := selection.SelectedContentItem()
+			if item == nil {
+				t.Fatal("SelectedContentItem is nil")
+			}
+
+			if item.Source != test.wantSource || item.Type != test.wantType ||
+				item.Location != test.wantLocation || item.ItemName != test.wantItemName {
+				t.Errorf("content item = %+v, want source=%q type=%q location=%q itemName=%q",
+					item, test.wantSource, test.wantType, test.wantLocation, test.wantItemName)
+			}
+		})
+	}
+}
+
+// A non-zero preset id names the slot the selection came from.
+func TestNowSelectionUpdatedReportsAPresetSlot(t *testing.T) {
+	raw := []byte(`<updates deviceID="DEVICEID01"><nowSelectionUpdated><preset id="4"><ContentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s1" isPresetable="true"><itemName>A Station</itemName></ContentItem></preset></nowSelectionUpdated></updates>`)
+
+	event, err := ParseWebSocketEvent(raw)
+	if err != nil {
+		t.Fatalf("ParseWebSocketEvent: %v", err)
+	}
+
+	id, ok := event.NowSelectionUpdated.PresetID()
+	if !ok || id != 4 {
+		t.Errorf("PresetID() = (%d, %t), want (4, true)", id, ok)
+	}
+}
+
+// The accessors are nil-safe, since a frame may carry no preset at all.
+func TestNowSelectionUpdatedAccessorsTolerateEmptyFrames(t *testing.T) {
+	var nilEvent *NowSelectionUpdatedEvent
+
+	if nilEvent.SelectedContentItem() != nil {
+		t.Error("SelectedContentItem on a nil event is not nil")
+	}
+
+	if _, ok := nilEvent.PresetID(); ok {
+		t.Error("PresetID on a nil event reported a slot")
+	}
+
+	empty := &NowSelectionUpdatedEvent{}
+	if empty.SelectedContentItem() != nil {
+		t.Error("SelectedContentItem without a preset is not nil")
 	}
 }
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -1175,6 +1175,84 @@ render(h(Fixture), document.getElementById('fixture'));
 	}
 }
 
+// TestRecentsBorrowArtworkFromAMatchingPreset: the speaker sends no artwork
+// with /recents (measured on a SoundTouch 10: every preset carried
+// containerArt and not one of ten recents did), so the player borrows it from
+// a preset for the same content. The recents entry here also carries the
+// echoed source-name account the speaker writes there, which is what a naive
+// comparison against the preset's empty account would miss.
+func TestRecentsBorrowArtworkFromAMatchingPreset(t *testing.T) {
+	const art = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+
+	fixture := `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { DeviceDetail } from '/app/static/js/app.js';
+const initialStatus = {
+  revision: 1,
+  nowPlayingRevision: 1,
+  nowPlaying: { Source: 'TUNEIN', PlayStatus: 'PLAY_STATE' },
+  volume: { ActualVolume: 20, MuteEnabled: false },
+  presets: { Preset: [{ ID: 1, ContentItem: {
+    Source: 'TUNEIN', SourceAccount: '', Location: '/v1/playback/station/s6634',
+    ItemName: 'A Station', ContainerArt: '` + art + `',
+  } }] },
+  sources: { SourceItem: [] },
+};
+function Fixture() {
+  const [devices] = useState({ speaker: { info: { name: 'Speaker' }, status: initialStatus } });
+  return h(DeviceDetail, { deviceId: 'speaker', devices, onBack: () => {}, commandReadbackDelays: [100, 250, 500] });
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/recents", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{"Items": []any{
+				// No ContainerArt, and the account the speaker echoes back.
+				map[string]any{"ID": "recent-1", "ContentItem": map[string]any{
+					"Source": "TUNEIN", "SourceAccount": "TUNEIN",
+					"Location": "/v1/playback/station/s6634", "ItemName": "A Station",
+				}},
+				map[string]any{"ID": "recent-2", "ContentItem": map[string]any{
+					"Source": "TUNEIN", "SourceAccount": "TUNEIN",
+					"Location": "/v1/playback/station/s999999", "ItemName": "Not A Preset",
+				}},
+			}}})
+		})
+		r.Get("/api/control/devices/speaker/zone", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+		r.Get("/api/control/devices/speaker/zone/candidates", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+
+	var borrowed string
+
+	var fallbacks int
+
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.recent-item`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.recent-item img.recent-art')?.getAttribute('src') || ''`, &borrowed),
+		// The entry with no matching preset keeps the source-icon placeholder.
+		chromedp.Evaluate(`document.querySelectorAll('.recent-art-empty').length`, &fallbacks),
+	); err != nil {
+		t.Fatalf("exercise recents artwork borrowing: %v", err)
+	}
+
+	if borrowed != art {
+		t.Errorf("recents artwork = %q, want the matching preset's art", borrowed)
+	}
+
+	if fallbacks != 1 {
+		t.Errorf("source-icon fallbacks = %d, want 1 for the entry with no matching preset", fallbacks)
+	}
+}
+
 // TestEmptyPresetSlotStaysSavableWhileACommandIsPending: an empty slot's
 // tile is a save gesture, not a playback command, so an in-flight command
 // has no reason to disable it -- and the sibling star button, which saves the

--- a/pkg/service/soundtouchweb/frontend_test/recentsArt.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/recentsArt.test.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import { artworkFor, identityOf, presetArtIndex } from '../static/js/recentsArt.mjs';
+
+// Shapes taken from a SoundTouch 10: presets carry containerArt, recents do
+// not, and recents echo the source name back as the account.
+const presets = {
+    Preset: [
+        {
+            ID: 1,
+            ContentItem: {
+                Source: 'TUNEIN',
+                SourceAccount: '',
+                Location: '/v1/playback/station/s6634',
+                ItemName: 'A Station',
+                ContainerArt: 'http://example.invalid/station.png',
+            },
+        },
+        {
+            ID: 2,
+            ContentItem: {
+                Source: 'SPOTIFY',
+                SourceAccount: 'listener',
+                Location: '/playback/container/abc',
+                ItemName: 'An Album',
+                ContainerArt: 'http://example.invalid/album.jpg',
+            },
+        },
+        {
+            ID: 3,
+            ContentItem: {
+                Source: 'RADIO_BROWSER',
+                SourceAccount: '',
+                Location: '/stations/byuuid/1234',
+                ItemName: 'Another Station',
+                ContainerArt: '',
+            },
+        },
+    ],
+};
+
+test('a recents entry borrows the artwork of the preset for the same content', () => {
+    const index = presetArtIndex(presets);
+    const recent = {
+        Source: 'SPOTIFY',
+        SourceAccount: 'listener',
+        Location: '/playback/container/abc',
+        ItemName: 'An Album',
+    };
+
+    assert.equal(artworkFor(recent, index), 'http://example.invalid/album.jpg');
+});
+
+// The speaker writes sourceAccount="TUNEIN" in recents and "" in presets for
+// the same station. Comparing raw accounts misses every station this way.
+test('the echoed source-name account matches an empty one', () => {
+    const index = presetArtIndex(presets);
+    const recent = {
+        Source: 'TUNEIN',
+        SourceAccount: 'TUNEIN',
+        Location: '/v1/playback/station/s6634',
+        ItemName: 'A Station',
+    };
+
+    assert.equal(artworkFor(recent, index), 'http://example.invalid/station.png');
+});
+
+test('a different location borrows nothing, even with the same name', () => {
+    const index = presetArtIndex(presets);
+    const recent = {
+        Source: 'TUNEIN',
+        SourceAccount: 'TUNEIN',
+        Location: '/v1/playback/station/s213886',
+        ItemName: 'A Station',
+    };
+
+    assert.equal(artworkFor(recent, index), '');
+});
+
+test('a different source borrows nothing', () => {
+    const index = presetArtIndex(presets);
+    const recent = {
+        Source: 'RADIO_BROWSER',
+        SourceAccount: 'RADIO_BROWSER',
+        Location: '/v1/playback/station/s6634',
+        ItemName: 'A Station',
+    };
+
+    assert.equal(artworkFor(recent, index), '');
+});
+
+test("an entry's own artwork always wins", () => {
+    const index = presetArtIndex(presets);
+    const recent = {
+        Source: 'SPOTIFY',
+        SourceAccount: 'listener',
+        Location: '/playback/container/abc',
+        ContainerArt: 'http://example.invalid/own.jpg',
+    };
+
+    assert.equal(artworkFor(recent, index), 'http://example.invalid/own.jpg');
+});
+
+test('presets without artwork are not indexed as empty', () => {
+    const index = presetArtIndex(presets);
+
+    assert.equal(index.size, 2);
+    assert.equal(artworkFor({
+        Source: 'RADIO_BROWSER',
+        SourceAccount: '',
+        Location: '/stations/byuuid/1234',
+    }, index), '');
+});
+
+// Nothing here may throw: the list still has to render when a device has no
+// presets, no recents content, or a half-filled entry.
+test('missing and malformed input yields no artwork rather than an error', () => {
+    assert.equal(presetArtIndex(undefined).size, 0);
+    assert.equal(presetArtIndex({}).size, 0);
+    assert.equal(presetArtIndex({ Preset: [null, {}, { ContentItem: {} }] }).size, 0);
+
+    const index = presetArtIndex(presets);
+
+    assert.equal(artworkFor(undefined, index), '');
+    assert.equal(artworkFor({}, index), '');
+    assert.equal(artworkFor({ Source: 'SPOTIFY' }, index), '');
+    assert.equal(artworkFor({ Source: 'SPOTIFY', Location: '/x' }, undefined), '');
+});
+
+test('identity ignores nothing that distinguishes content', () => {
+    const base = { Source: 'SPOTIFY', SourceAccount: 'listener', Location: '/a' };
+
+    assert.notEqual(identityOf(base), identityOf({ ...base, Location: '/b' }));
+    assert.notEqual(identityOf(base), identityOf({ ...base, Source: 'AMAZON' }));
+    assert.notEqual(identityOf(base), identityOf({ ...base, SourceAccount: 'other' }));
+});
+
+// The panel must actually use the join, not just ship the helper.
+test('the Recents panel resolves artwork through the preset index', async () => {
+    const source = await readFile(new URL('../static/js/components/Recents.js', import.meta.url), 'utf8');
+
+    assert.match(source, /presetArtIndex/);
+    assert.match(source, /artworkFor/);
+});

--- a/pkg/service/soundtouchweb/static/js/app.js
+++ b/pkg/service/soundtouchweb/static/js/app.js
@@ -297,6 +297,7 @@ export function DeviceDetail({
             <${Zone} deviceId=${deviceId} devices=${devices} />
             <${Recents}
                 deviceId=${deviceId}
+                presets=${device.status?.presets}
                 command=${command}
                 commandBusy=${commandBusy}
                 onPlay=${playRecent}

--- a/pkg/service/soundtouchweb/static/js/components/Recents.js
+++ b/pkg/service/soundtouchweb/static/js/components/Recents.js
@@ -3,10 +3,11 @@ import { useState, useEffect } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
 import { SourceIcon } from '../sourceIcons.js';
+import { artworkFor, presetArtIndex } from '../recentsArt.mjs';
 
 const html = htm.bind(h);
 
-export function Recents({ deviceId, command, commandBusy = false, onPlay }) {
+export function Recents({ deviceId, presets, command, commandBusy = false, onPlay }) {
     const [items, setItems] = useState(null);
     const [loading, setLoading] = useState(true);
 
@@ -46,6 +47,10 @@ export function Recents({ deviceId, command, commandBusy = false, onPlay }) {
         });
     }
 
+    // The speaker sends no artwork with recents; a preset for the same content
+    // is the one place the player can borrow it from. See recentsArt.mjs.
+    const artIndex = presetArtIndex(presets);
+
     return html`
         <div class="recents-section">
             <div class="section-title">Recents</div>
@@ -53,6 +58,7 @@ export function Recents({ deviceId, command, commandBusy = false, onPlay }) {
                 ${items.map(item => {
                     const ci = item.ContentItem;
                     if (!ci) return null;
+                    const art = artworkFor(ci, artIndex);
                     return html`
                         <button
                             class="recent-item"
@@ -63,8 +69,8 @@ export function Recents({ deviceId, command, commandBusy = false, onPlay }) {
                                 command?.expected?.targetId === String(item.ID || item.UTCTime || ci.Location)
                                 ? 'true' : null}
                         >
-                            ${ci.ContainerArt
-                                ? html`<img class="recent-art" src=${ci.ContainerArt} alt="" />`
+                            ${art
+                                ? html`<img class="recent-art" src=${art} alt="" />`
                                 : html`<div class="recent-art recent-art-empty"><${SourceIcon} source=${ci.Source} className="recent-source-icon" /></div>`
                             }
                             <div class="recent-info">

--- a/pkg/service/soundtouchweb/static/js/recentsArt.mjs
+++ b/pkg/service/soundtouchweb/static/js/recentsArt.mjs
@@ -1,0 +1,63 @@
+// The speaker's /recents omits container art. Measured on a SoundTouch 10:
+// all six presets carried a containerArt URL and not one of ten recents did,
+// which matches what the captures under _/ have shown for other reporters
+// (Spotify recents never carry art; TuneIn sometimes do). It is the speaker's
+// doing: /presets, /recents and /now_playing all read artwork back from what
+// the speaker was handed at /select time, and nothing hands it to recents.
+//
+// The player can still show something, because the same content is often a
+// preset, and presets do carry art. This joins the two by content identity.
+// It is best-effort by construction: an entry with no match keeps the source
+// icon it has today, and nothing here can fail in a way that costs the list.
+
+// identityOf keys a ContentItem by what actually identifies the content.
+//
+// The account needs normalising first: the speaker echoes the source name back
+// as sourceAccount in recents ("TUNEIN", "RADIO_BROWSER") while writing an
+// empty one in presets, so comparing the raw values misses every station. That
+// placeholder pattern is the same one Sources.js normalises for source
+// selection. On the measured speaker it is the difference between matching 4
+// of 10 recents and matching 6.
+//
+// Item names are deliberately not part of the identity, and are not a
+// fallback: the same speaker had "WDR 2 Rheinland" as both a RADIO_BROWSER
+// preset and a TUNEIN recent, pointing at different stations. Borrowing art
+// across those would show the wrong logo.
+export function identityOf(item) {
+    const source = item?.Source || '';
+    const account = item?.SourceAccount && item.SourceAccount !== source
+        ? item.SourceAccount
+        : '';
+
+    return JSON.stringify([source, account, item?.Location || '']);
+}
+
+// presetArtIndex maps content identity to artwork, for every preset that has
+// both. Presets without art, or without a location to identify them by, are
+// skipped rather than indexed as empty.
+export function presetArtIndex(presets) {
+    const index = new Map();
+
+    for (const preset of presets?.Preset ?? []) {
+        const item = preset?.ContentItem;
+
+        if (!item?.ContainerArt || !item?.Location) continue;
+
+        const key = identityOf(item);
+
+        if (!index.has(key)) index.set(key, item.ContainerArt);
+    }
+
+    return index;
+}
+
+// artworkFor returns the artwork to show for a recents entry: its own if the
+// speaker sent one, otherwise a preset's for the same content, otherwise an
+// empty string so the caller falls back to its source icon.
+export function artworkFor(item, index) {
+    if (item?.ContainerArt) return item.ContainerArt;
+
+    if (!item?.Location || !index?.size) return '';
+
+    return index.get(identityOf(item)) || '';
+}


### PR DESCRIPTION
## Summary

Three things found while diagnosing why a preset saved for an album appeared to point at its eighth track, each measured against a real SoundTouch 10 rather than reasoned about.

**`example-dlna-server`: containers advertise their own artwork, and tracks report a real duration.** `writeItemDIDL` put `upnp:albumArtURI` on every item, while containers were written with only a title and a class. An album therefore had no art of its own, so a speaker saving a preset for that album had nothing to store but the art URL of whichever track was playing: the preset's location was the album container, its `containerArt` the eighth track's image. Separately, `DurSec` was only ever set for the two built-in synthetic tracks, so every file loaded from `--media-dir` advertised `duration="0:00:00.000"` next to a hardcoded 128 kbit/s, 8 kHz, mono, and the speaker reported `<time total="0">` in turn: no progress bar in any client, ours included. A new probe reads the MP3 frame header (with the Xing/Info frame count where a VBR encoder wrote one) or the WAV `fmt`/`data` chunks. Formats it cannot read report nothing and keep the previous placeholders.

**`nowSelectionUpdated` is modelled.** It was the last `<updates>` child reaching callers only through the `xml:",any"` catch-all, so `events subscribe` could say no more than "Unmodelled element". It carries the ContentItem the speaker acted on, wrapped in a `preset` element whose id is 0 unless the selection came from a stored preset. Both captured shapes are pinned in tests: a TuneIn station and a `STORED_MUSIC` container. The event now has its type, nil-safe accessors, its device id copied down from `<updates>` like every other child, an `OnNowSelection` handler, and a printer plus a `nowSelection` filter in the CLI.

**The player shows preset artwork for matching recents entries.** The speaker sends none with `/recents`: all six presets on the test speaker carried a `containerArt` URL and not one of ten recents did. The same content is often a preset though, so the list borrows it, matched on source, account and location. Normalising the account is what makes it work, since recents echo the source name back as `sourceAccount` while presets write an empty one: without that step the measured speaker matched 4 of 10 entries, with it 6. Item names are deliberately not a fallback, because the same speaker had "WDR 2 Rheinland" as both a `RADIO_BROWSER` preset and a `TUNEIN` recent pointing at different stations. Borrowed artwork is display-only; the play path still sends the entry's own art, so nothing inferred is written back to the speaker.

## Linked issue

None.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `node --test pkg/service/soundtouchweb/frontend_test/*.test.mjs` (37 tests)
- [x] `go test -tags browsertest ./pkg/service/soundtouchweb`
- [x] Measured against a real SoundTouch 10 for the findings above
- [ ] `make check`'s Docker-based HTTP integration leg was not run (daemon down)

The DLNA probe is covered by unit tests for WAV, CBR MP3, VBR MP3 via the Xing frame count, an ID3-prefixed file, and formats it cannot parse. Container artwork is asserted end to end: advertised in DIDL-Lite, served from `/AlbumArt/<container id>`, and absent when a container has no art. The recents join has node tests for the identity rules and a browser test that checks the rendered `<img>` src, including that an entry with no matching preset keeps its source icon.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] Documentation updated where behaviour changed (`PLAYER-SOURCE-BEHAVIOUR.md` carries the skip matrix and the measurements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
