### PR TITLE
fix(marge,player): STORED_MUSIC preset survival, folder replay type, library presetability

### DIFF
--- a/docs/content/docs/appendix/NAVIGATION-GUIDE.md
+++ b/docs/content/docs/appendix/NAVIGATION-GUIDE.md
@@ -36,7 +36,7 @@ package main
 import (
     "fmt"
     "log"
-    
+
     "github.com/gesellix/bose-soundtouch/pkg/client"
 )
 
@@ -47,7 +47,7 @@ func main() {
         Port: 8090,
     }
     soundtouch := client.NewClient(config)
-    
+
     // Your navigation code here...
 }
 ```
@@ -184,21 +184,21 @@ for {
     if err != nil {
         log.Fatal(err)
     }
-    
+
     if len(response.Items) == 0 {
         break // No more items
     }
-    
+
     fmt.Printf("Page starting at %d: %d items\n", startItem, len(response.Items))
-    
+
     // Process this page
     for _, item := range response.Items {
         fmt.Printf("  %s (%s)\n", item.GetDisplayName(), item.Type)
     }
-    
+
     // Move to next page
     startItem += pageSize
-    
+
     // Stop if we've seen all items
     if startItem > response.TotalItems {
         break
@@ -269,7 +269,7 @@ if err != nil {
 // Analyze all results
 for _, result := range results.GetAllResults() {
     fmt.Printf("Name: %s, Token: %s\n", result.GetDisplayName(), result.Token)
-    
+
     // Determine result type
     switch {
     case result.IsSong():
@@ -338,10 +338,10 @@ for i, station := range stations.Items {
 // Remove a specific station (example: remove the first one)
 if len(stations.Items) > 0 {
     stationToRemove := stations.Items[0]
-    
+
     if stationToRemove.ContentItem != nil {
         fmt.Printf("Removing: %s\n", stationToRemove.GetDisplayName())
-        
+
         err := soundtouch.RemoveStation(stationToRemove.ContentItem)
         if err != nil {
             log.Printf("Failed to remove station: %v", err)
@@ -373,17 +373,17 @@ if err != nil {
 artists := searchResults.GetArtists()
 for i, artist := range artists[:min(3, len(artists))] {
     stationName := fmt.Sprintf("%s Radio", artist.Name)
-    
+
     fmt.Printf("Adding station %d: %s\n", i+1, stationName)
-    
+
     err := soundtouch.AddStation("PANDORA", "your_account", artist.Token, stationName)
     if err != nil {
         log.Printf("Failed to add %s: %v", stationName, err)
         continue
     }
-    
+
     fmt.Printf("✓ Added: %s\n", stationName)
-    
+
     // Note: Each AddStation immediately starts playing that station
     // You might want to pause between additions in a real app
 }
@@ -398,25 +398,25 @@ fmt.Println("Station collection updated!")
 ```go
 func discoverAndPlayWorkflow(soundtouch *client.Client) {
     fmt.Println("=== Discover and Play Workflow ===")
-    
+
     // Step 1: Search for content
     searchTerm := "electronic music"
     fmt.Printf("🔍 Searching for '%s'...\n", searchTerm)
-    
+
     results, err := soundtouch.SearchTuneInStations(searchTerm)
     if err != nil {
         log.Fatal(err)
     }
-    
+
     if results.IsEmpty() {
         fmt.Println("❌ No results found")
         return
     }
-    
+
     // Step 2: Show options
     stations := results.GetStations()
     fmt.Printf("📻 Found %d stations:\n", len(stations))
-    
+
     for i, station := range stations[:min(5, len(stations))] {
         fmt.Printf("%d. %s", i+1, station.GetDisplayName())
         if station.Description != "" {
@@ -424,12 +424,12 @@ func discoverAndPlayWorkflow(soundtouch *client.Client) {
         }
         fmt.Println()
     }
-    
+
     // Step 3: Select and play (example: select first one)
     if len(stations) > 0 {
         selectedStation := stations[0]
         fmt.Printf("🎵 Playing: %s\n", selectedStation.GetDisplayName())
-        
+
         // For services that support it, add the station to play it
         if selectedStation.Token != "" {
             err := soundtouch.AddStation("TUNEIN", "", selectedStation.Token, selectedStation.Name)
@@ -448,38 +448,38 @@ func discoverAndPlayWorkflow(soundtouch *client.Client) {
 ```go
 func organizeLibraryWorkflow(soundtouch *client.Client, deviceAccount string) {
     fmt.Println("=== Library Organization Workflow ===")
-    
+
     // Step 1: Explore library structure
     fmt.Println("📂 Exploring music library...")
-    
+
     library, err := soundtouch.GetStoredMusicLibrary(deviceAccount)
     if err != nil {
         log.Fatal(err)
     }
-    
+
     directories := library.GetDirectories()
     tracks := library.GetTracks()
-    
-    fmt.Printf("📊 Library overview: %d directories, %d tracks\n", 
+
+    fmt.Printf("📊 Library overview: %d directories, %d tracks\n",
         len(directories), len(tracks))
-    
+
     // Step 2: Navigate into each directory
     for _, dir := range directories[:min(3, len(directories))] {
         fmt.Printf("\n📁 Exploring: %s\n", dir.GetDisplayName())
-        
+
         contents, err := soundtouch.NavigateContainer(
             "STORED_MUSIC", deviceAccount, 1, 20, dir.ContentItem)
         if err != nil {
             log.Printf("❌ Failed to explore %s: %v", dir.GetDisplayName(), err)
             continue
         }
-        
+
         subTracks := contents.GetTracks()
         subDirs := contents.GetDirectories()
-        
-        fmt.Printf("   Contains: %d tracks, %d subdirectories\n", 
+
+        fmt.Printf("   Contains: %d tracks, %d subdirectories\n",
             len(subTracks), len(subDirs))
-        
+
         // Show some tracks
         for i, track := range subTracks[:min(3, len(subTracks))] {
             fmt.Printf("   %d. %s", i+1, track.GetDisplayName())
@@ -489,7 +489,7 @@ func organizeLibraryWorkflow(soundtouch *client.Client, deviceAccount string) {
             fmt.Println()
         }
     }
-    
+
     fmt.Println("\n✓ Library exploration complete!")
 }
 ```
@@ -500,7 +500,7 @@ func organizeLibraryWorkflow(soundtouch *client.Client, deviceAccount string) {
 func multiServiceDiscovery(soundtouch *client.Client, accounts map[string]string) {
     searchTerm := "jazz"
     fmt.Printf("🔍 Searching '%s' across all services...\n", searchTerm)
-    
+
     // Search TuneIn (no account needed)
     fmt.Println("\n📻 TuneIn Results:")
     tuneInResults, err := soundtouch.SearchTuneInStations(searchTerm)
@@ -513,7 +513,7 @@ func multiServiceDiscovery(soundtouch *client.Client, accounts map[string]string
             fmt.Printf("  %d. %s\n", i+1, station.GetDisplayName())
         }
     }
-    
+
     // Search Pandora (if account available)
     if pandoraAccount, ok := accounts["PANDORA"]; ok {
         fmt.Println("\n🎵 Pandora Results:")
@@ -524,13 +524,13 @@ func multiServiceDiscovery(soundtouch *client.Client, accounts map[string]string
             artists := pandoraResults.GetArtists()
             stations := pandoraResults.GetStations()
             fmt.Printf("✓ Found %d artists, %d stations\n", len(artists), len(stations))
-            
+
             for i, artist := range artists[:min(2, len(artists))] {
                 fmt.Printf("  Artist: %s\n", artist.GetDisplayName())
             }
         }
     }
-    
+
     // Search Spotify (if account available)
     if spotifyAccount, ok := accounts["SPOTIFY"]; ok {
         fmt.Println("\n🎼 Spotify Results:")
@@ -540,13 +540,13 @@ func multiServiceDiscovery(soundtouch *client.Client, accounts map[string]string
         } else {
             songs := spotifyResults.GetSongs()
             fmt.Printf("✓ Found %d songs\n", len(songs))
-            
+
             for i, song := range songs[:min(2, len(songs))] {
                 fmt.Printf("  Song: %s\n", song.GetFullTitle())
             }
         }
     }
-    
+
     fmt.Println("\n✓ Multi-service discovery complete!")
 }
 ```
@@ -559,25 +559,25 @@ func multiServiceDiscovery(soundtouch *client.Client, accounts map[string]string
 func robustNavigation(soundtouch *client.Client) error {
     // Try multiple sources gracefully
     sources := []string{"TUNEIN", "SPOTIFY", "STORED_MUSIC"}
-    
+
     for _, source := range sources {
         fmt.Printf("Trying %s...\n", source)
-        
+
         response, err := soundtouch.Navigate(source, "", 1, 10)
         if err != nil {
             fmt.Printf("❌ %s failed: %v\n", source, err)
             continue
         }
-        
+
         if response.IsEmpty() {
             fmt.Printf("⚠️  %s has no content\n", source)
             continue
         }
-        
+
         fmt.Printf("✓ %s available with %d items\n", source, response.TotalItems)
         return nil
     }
-    
+
     return fmt.Errorf("no sources available")
 }
 ```
@@ -587,23 +587,23 @@ func robustNavigation(soundtouch *client.Client) error {
 ```go
 func searchWithRetry(soundtouch *client.Client, maxRetries int) (*models.SearchStationResponse, error) {
     var lastErr error
-    
+
     for attempt := 1; attempt <= maxRetries; attempt++ {
         fmt.Printf("Search attempt %d/%d...\n", attempt, maxRetries)
-        
+
         results, err := soundtouch.SearchTuneInStations("classical")
         if err == nil {
             return results, nil
         }
-        
+
         lastErr = err
         fmt.Printf("❌ Attempt %d failed: %v\n", attempt, err)
-        
+
         if attempt < maxRetries {
             time.Sleep(time.Duration(attempt) * time.Second)
         }
     }
-    
+
     return nil, fmt.Errorf("search failed after %d attempts: %w", maxRetries, lastErr)
 }
 ```
@@ -616,46 +616,46 @@ func safeStationManagement(soundtouch *client.Client, pandoraAccount string) {
     if pandoraAccount == "" {
         log.Fatal("Pandora account required")
     }
-    
+
     // Search safely
     results, err := soundtouch.SearchPandoraStations(pandoraAccount, "blues")
     if err != nil {
         log.Fatal(err)
     }
-    
+
     if results.IsEmpty() {
         fmt.Println("No results found")
         return
     }
-    
+
     // Check what we have before adding stations
     artists := results.GetArtists()
     if len(artists) == 0 {
         fmt.Println("No artists found to create stations from")
         return
     }
-    
+
     // Get current stations to avoid duplicates
     currentStations, err := soundtouch.GetPandoraStations(pandoraAccount)
     if err != nil {
         log.Printf("Warning: Could not get current stations: %v", err)
     }
-    
+
     // Create a map of existing station names
     existingStations := make(map[string]bool)
     for _, station := range currentStations.Items {
         existingStations[station.GetDisplayName()] = true
     }
-    
+
     // Add stations only if they don't exist
     for _, artist := range artists[:min(2, len(artists))] {
         stationName := artist.Name + " Radio"
-        
+
         if existingStations[stationName] {
             fmt.Printf("⚠️  Station already exists: %s\n", stationName)
             continue
         }
-        
+
         fmt.Printf("Adding new station: %s\n", stationName)
         err := soundtouch.AddStation("PANDORA", pandoraAccount, artist.Token, stationName)
         if err != nil {
@@ -695,23 +695,23 @@ const batchSize = 50
 
 func processLargeLibrary(soundtouch *client.Client, sourceAccount string) {
     startItem := 1
-    
+
     for {
         batch, err := soundtouch.Navigate("STORED_MUSIC", sourceAccount, startItem, batchSize)
         if err != nil {
             log.Printf("Error at position %d: %v", startItem, err)
             break
         }
-        
+
         if len(batch.Items) == 0 {
             break // No more items
         }
-        
+
         // Process this batch
         processBatch(batch.Items)
-        
+
         startItem += batchSize
-        
+
         // Prevent infinite loops
         if startItem > batch.TotalItems {
             break
@@ -729,7 +729,7 @@ func handleServiceDifferences(soundtouch *client.Client) {
     if err == nil {
         fmt.Printf("TuneIn: %d stations\n", len(tuneInStations.GetStations()))
     }
-    
+
     // Pandora: Requires user account
     pandoraResults, err := soundtouch.SearchPandoraStations("user_account", "rock")
     if err == nil {
@@ -737,7 +737,7 @@ func handleServiceDifferences(soundtouch *client.Client) {
         artists := pandoraResults.GetArtists()
         fmt.Printf("Pandora: %d artists\n", len(artists))
     }
-    
+
     // Spotify: Requires user account, returns tracks/playlists
     spotifyResults, err := soundtouch.SearchSpotifyContent("spotify_user", "pop")
     if err == nil {
@@ -752,13 +752,13 @@ func handleServiceDifferences(soundtouch *client.Client) {
 ```go
 func userFriendlySearch(soundtouch *client.Client, searchTerm string) {
     fmt.Printf("🔍 Searching for '%s'...\n", searchTerm)
-    
+
     results, err := soundtouch.SearchTuneInStations(searchTerm)
     if err != nil {
         fmt.Printf("❌ Search failed: %v\n", err)
         return
     }
-    
+
     if results.IsEmpty() {
         fmt.Printf("😞 No results found for '%s'\n", searchTerm)
         fmt.Println("💡 Try different search terms like:")
@@ -767,10 +767,10 @@ func userFriendlySearch(soundtouch *client.Client, searchTerm string) {
         fmt.Println("   - Station types: news, talk, music")
         return
     }
-    
+
     stations := results.GetStations()
     fmt.Printf("🎵 Found %d stations:\n", len(stations))
-    
+
     for i, station := range stations {
         fmt.Printf("%d. 📻 %s", i+1, station.GetDisplayName())
         if station.Description != "" {
@@ -790,10 +790,10 @@ func userFriendlySearch(soundtouch *client.Client, searchTerm string) {
 func efficientBrowsing(soundtouch *client.Client) {
     // Use reasonable page sizes
     const optimalPageSize = 25 // Good balance of network efficiency and memory usage
-    
+
     // Cache frequently accessed data
     var cachedSources *models.Sources
-    
+
     getSources := func() (*models.Sources, error) {
         if cachedSources == nil {
             var err error
@@ -802,13 +802,13 @@ func efficientBrowsing(soundtouch *client.Client) {
         }
         return cachedSources, nil
     }
-    
+
     // Use the cached sources
     sources, err := getSources()
     if err != nil {
         return
     }
-    
+
     // Process efficiently
     for _, source := range sources.SourceItem {
         if source.Status.IsReady() {
@@ -823,30 +823,30 @@ func efficientBrowsing(soundtouch *client.Client) {
 
 ### Navigation Methods
 
-| Method | Description | Parameters | Returns |
-|--------|-------------|------------|---------|
-| `Navigate()` | Browse content source | source, account, start, count | NavigateResponse |
-| `NavigateWithMenu()` | Browse with menu/sort | source, account, menu, sort, start, count | NavigateResponse |
-| `NavigateContainer()` | Browse into directory | source, account, start, count, container | NavigateResponse |
-| `GetTuneInStations()` | Convenience for TuneIn | account | NavigateResponse |
-| `GetPandoraStations()` | Convenience for Pandora | account | NavigateResponse |
-| `GetStoredMusicLibrary()` | Convenience for stored music | account | NavigateResponse |
+| Method                    | Description                  | Parameters                                | Returns          |
+|---------------------------|------------------------------|-------------------------------------------|------------------|
+| `Navigate()`              | Browse content source        | source, account, start, count             | NavigateResponse |
+| `NavigateWithMenu()`      | Browse with menu/sort        | source, account, menu, sort, start, count | NavigateResponse |
+| `NavigateContainer()`     | Browse into directory        | source, account, start, count, container  | NavigateResponse |
+| `GetTuneInStations()`     | Convenience for TuneIn       | account                                   | NavigateResponse |
+| `GetPandoraStations()`    | Convenience for Pandora      | account                                   | NavigateResponse |
+| `GetStoredMusicLibrary()` | Convenience for stored music | account                                   | NavigateResponse |
 
 ### Search Methods
 
-| Method | Description | Parameters | Returns |
-|--------|-------------|------------|---------|
-| `SearchStation()` | Generic station search | source, account, term | SearchStationResponse |
-| `SearchTuneInStations()` | Search TuneIn | term | SearchStationResponse |
-| `SearchPandoraStations()` | Search Pandora | account, term | SearchStationResponse |
-| `SearchSpotifyContent()` | Search Spotify | account, term | SearchStationResponse |
+| Method                    | Description            | Parameters            | Returns               |
+|---------------------------|------------------------|-----------------------|-----------------------|
+| `SearchStation()`         | Generic station search | source, account, term | SearchStationResponse |
+| `SearchTuneInStations()`  | Search TuneIn          | term                  | SearchStationResponse |
+| `SearchPandoraStations()` | Search Pandora         | account, term         | SearchStationResponse |
+| `SearchSpotifyContent()`  | Search Spotify         | account, term         | SearchStationResponse |
 
 ### Station Management Methods
 
-| Method | Description | Parameters | Returns |
-|--------|-------------|------------|---------|
-| `AddStation()` | Add station (plays immediately) | source, account, token, name | error |
-| `RemoveStation()` | Remove station from collection | contentItem | error |
+| Method            | Description                     | Parameters                   | Returns |
+|-------------------|---------------------------------|------------------------------|---------|
+| `AddStation()`    | Add station (plays immediately) | source, account, token, name | error   |
+| `RemoveStation()` | Remove station from collection  | contentItem                  | error   |
 
 ### Response Helper Methods
 
@@ -854,7 +854,7 @@ func efficientBrowsing(soundtouch *client.Client) {
 
 - `GetPlayableItems()` - Filter playable items
 - `GetDirectories()` - Filter directories
-- `GetTracks()` - Filter music tracks  
+- `GetTracks()` - Filter music tracks
 - `GetStations()` - Filter radio stations
 - `IsEmpty()` - Check if response has no items
 
@@ -879,14 +879,14 @@ func efficientBrowsing(soundtouch *client.Client) {
 
 ### Common Source Types
 
-| Source | Description | Account Required | Search Support |
-|--------|-------------|------------------|----------------|
-| `TUNEIN` | Internet radio stations | No | Yes |
-| `PANDORA` | Pandora music service | Yes | Yes |
-| `SPOTIFY` | Spotify music service | Yes | Yes |
-| `STORED_MUSIC` | Local/network music | Device account | No |
-| `BLUETOOTH` | Bluetooth audio input | No | No |
-| `AUX` | Auxiliary input | No | No |
+| Source         | Description             | Account Required | Search Support |
+|----------------|-------------------------|------------------|----------------|
+| `TUNEIN`       | Internet radio stations | No               | Yes            |
+| `PANDORA`      | Pandora music service   | Yes              | Yes            |
+| `SPOTIFY`      | Spotify music service   | Yes              | Yes            |
+| `STORED_MUSIC` | Local/network music     | Device account   | No             |
+| `BLUETOOTH`    | Bluetooth audio input   | No               | No             |
+| `AUX`          | Auxiliary input         | No               | No             |
 
 ## Troubleshooting
 
@@ -902,7 +902,7 @@ func efficientBrowsing(soundtouch *client.Client) {
 - Check if the service is working (try via SoundTouch app)
 - Verify account has access to content
 
-**"AddStation failed"** 
+**"AddStation failed"**
 - Ensure the token is valid (from search results)
 - Check that the service supports adding stations
 - Verify account permissions

--- a/docs/content/docs/appendix/NAVIGATION-GUIDE.md
+++ b/docs/content/docs/appendix/NAVIGATION-GUIDE.md
@@ -100,6 +100,30 @@ if err != nil {
 }
 ```
 
+### What a navigate item actually contains
+
+Measured on a SoundTouch 10 (FW 27.0.6) against two independent media servers,
+a FRITZ!Box UPnP server and this repository's `cmd/example-dlna-server`. Both
+agreed, and three details matter to anyone parsing this by hand:
+
+- **Every item carries two ContentItems.** The one inside
+  `<mediaItemContainer>` is the *parent container* and repeats identically on
+  every item of the page; the item's own is the sibling that follows it.
+  `models.NavigateItem` keeps them apart, so read `item.ContentItem` and not
+  the container's.
+- **Directories report `Playable="1"` and `isPresetable="true"`.** The speaker
+  will play a whole folder, and will store one as a preset. Note that
+  `models.ContentItem.IsPresetable` is a plain bool, so an absent attribute and
+  an explicit `false` arrive identically: treat `false` on a playable directory
+  as "unknown" rather than "no".
+- **The item's ContentItem has no `type` attribute.** The kind is the `<type>`
+  element on the item (`dir`, `track`). Anything reconstructing a ContentItem
+  for `/select` has to supply the type itself.
+
+Location tokens are opaque and server-specific (`4:cont1:20:0:0:` on one
+server, `1` on another) and index-dependent, so they can break when the media
+server reindexes.
+
 ### Navigate Into Directories
 
 ```go

--- a/docs/content/docs/reference/PRESET-MANAGEMENT.md
+++ b/docs/content/docs/reference/PRESET-MANAGEMENT.md
@@ -14,7 +14,7 @@ Bose SoundTouch devices support up to 6 presets that can store favorite music so
 - Comprehensive preset analysis and helper methods
 - Integration with CLI tool for viewing presets
 
-### ❌ **Not Supported - Write Operations**  
+### ❌ **Not Supported - Write Operations**
 - `POST /presets` - Officially marked as "N/A" in Bose API documentation
 - Preset clearing/deletion via API
 - Direct preset creation from currently playing content
@@ -68,38 +68,38 @@ import (
 func main() {
     // Create client
     soundtouchClient := client.NewClientFromHost("192.0.2.10")
-    
+
     // Get all presets
     presets, err := soundtouchClient.GetPresets()
     if err != nil {
         panic(err)
     }
-    
+
     // Display preset information
     fmt.Printf("Total presets: %d\n", presets.GetPresetCount())
     fmt.Printf("Used slots: %d\n", len(presets.GetUsedPresetSlots()))
     fmt.Printf("Empty slots: %v\n", presets.GetEmptyPresetSlots())
-    
+
     // Check for Spotify presets
     spotifyPresets := presets.GetSpotifyPresets()
     fmt.Printf("Spotify presets: %d\n", len(spotifyPresets))
-    
+
     // Get specific preset
     preset1 := presets.GetPresetByID(1)
     if preset1 != nil && !preset1.IsEmpty() {
         fmt.Printf("Preset 1: %s\n", preset1.GetDisplayName())
         fmt.Printf("  Source: %s\n", preset1.GetSource())
         fmt.Printf("  Type: %s\n", preset1.GetContentType())
-        
+
         if preset1.HasTimestamps() {
             fmt.Printf("  Created: %s\n", preset1.GetCreatedTime())
             fmt.Printf("  Updated: %s\n", preset1.GetUpdatedTime())
         }
     }
-    
+
     // Find most recent preset
     if recent := presets.GetMostRecentPreset(); recent != nil {
-        fmt.Printf("Most recent: Preset %d (%s)\n", 
+        fmt.Printf("Most recent: Preset %d (%s)\n",
             recent.ID, recent.GetDisplayName())
     }
 }
@@ -111,16 +111,16 @@ func main() {
 ```xml
 <presets>
   <preset id="1" createdOn="1745991460" updatedOn="1745991460">
-    <ContentItem source="SPOTIFY" type="tracklisturl" 
-                 location="/playback/container/..." 
-                 sourceAccount="user@example.com" 
+    <ContentItem source="SPOTIFY" type="tracklisturl"
+                 location="/playback/container/..."
+                 sourceAccount="user@example.com"
                  isPresetable="true">
       <itemName>My Favorite Songs</itemName>
       <containerArt>https://i.scdn.co/image/...</containerArt>
     </ContentItem>
   </preset>
   <preset id="2">
-    <ContentItem source="TUNEIN" type="station" 
+    <ContentItem source="TUNEIN" type="station"
                  location="s12345" isPresetable="true">
       <itemName>Classic Rock Radio</itemName>
       <containerArt>https://cdn-radiotime-logos.tunein.com/...</containerArt>
@@ -190,14 +190,14 @@ if preset.HasTimestamps() {
 
 Common content types found in presets:
 
-| Source | Type | Description | Example Location |
-|--------|------|-------------|------------------|
-| `SPOTIFY` | `tracklisturl` | Playlist/Album | `/playback/container/c3Bv...` |
-| `SPOTIFY` | `track` | Single Track | `/playback/container/c3Bv...` |
-| `TUNEIN` | `station` | Radio Station | `s12345` |
-| `PANDORA` | `station` | Pandora Station | `TR:station:12345` |
-| `AMAZON` | `playlist` | Amazon Playlist | `amzn1.dv.gti...` |
-| `STORED_MUSIC` | *(none)* | Media-server folder or track | `4:cont1:20:0:0:`, `1` |
+| Source         | Type           | Description                  | Example Location              |
+|----------------|----------------|------------------------------|-------------------------------|
+| `SPOTIFY`      | `tracklisturl` | Playlist/Album               | `/playback/container/c3Bv...` |
+| `SPOTIFY`      | `track`        | Single Track                 | `/playback/container/c3Bv...` |
+| `TUNEIN`       | `station`      | Radio Station                | `s12345`                      |
+| `PANDORA`      | `station`      | Pandora Station              | `TR:station:12345`            |
+| `AMAZON`       | `playlist`     | Amazon Playlist              | `amzn1.dv.gti...`             |
+| `STORED_MUSIC` | *(none)*       | Media-server folder or track | `4:cont1:20:0:0:`, `1`        |
 
 ### Folder presets (STORED_MUSIC)
 
@@ -337,7 +337,7 @@ if len(emptySlots) == 0 {
 ```go
 // Get summary statistics
 summary := presets.GetPresetsSummary()
-fmt.Printf("Total: %d, Used: %d, Empty: %d\n", 
+fmt.Printf("Total: %d, Used: %d, Empty: %d\n",
     summary["total"], summary["used"], summary["empty"])
 
 // Check source distribution
@@ -353,12 +353,12 @@ if summary["TUNEIN"] > 0 {
 ```go
 // Find recently used presets
 if recent := presets.GetMostRecentPreset(); recent != nil {
-    fmt.Printf("Most recently updated: Preset %d (%s)\n", 
+    fmt.Printf("Most recently updated: Preset %d (%s)\n",
         recent.ID, recent.GetDisplayName())
 }
 
 if oldest := presets.GetOldestPreset(); oldest != nil {
-    fmt.Printf("Oldest preset: Preset %d (%s)\n", 
+    fmt.Printf("Oldest preset: Preset %d (%s)\n",
         oldest.ID, oldest.GetDisplayName())
 }
 ```
@@ -385,7 +385,7 @@ The original API limitation appears to have been either:
 This implementation now provides the full preset management lifecycle:
 - ✅ **Create** - Store new presets from any supported content source
 - ✅ **Read** - List and inspect all configured presets
-- ✅ **Update** - Modify existing preset content and metadata  
+- ✅ **Update** - Modify existing preset content and metadata
 - ✅ **Delete** - Remove presets and clear slots
 - ✅ **Select** - Activate presets for immediate playback
 - ✅ **Monitor** - Real-time WebSocket events for preset changes

--- a/docs/content/docs/reference/PRESET-MANAGEMENT.md
+++ b/docs/content/docs/reference/PRESET-MANAGEMENT.md
@@ -197,6 +197,31 @@ Common content types found in presets:
 | `TUNEIN` | `station` | Radio Station | `s12345` |
 | `PANDORA` | `station` | Pandora Station | `TR:station:12345` |
 | `AMAZON` | `playlist` | Amazon Playlist | `amzn1.dv.gti...` |
+| `STORED_MUSIC` | *(none)* | Media-server folder or track | `4:cont1:20:0:0:`, `1` |
+
+### Folder presets (STORED_MUSIC)
+
+A folder on a DLNA/NAS media server can be saved to a preset slot, and
+recalling it reopens and plays that folder. Verified on a SoundTouch 10 against
+two independent servers. No special API is involved:
+
+1. Play the folder (`/select` with the folder's ContentItem and `type="dir"`).
+2. Read `/now_playing`. It keeps the **folder** location, not the playing
+   track's, and reports `isPresetable="true"`. The `<track>` element advances
+   with playback; the ContentItem does not.
+3. Store it with the ordinary "save what is playing" preset flow. The stored
+   ContentItem carries **no `type` attribute**, because now-playing does not
+   report one, and the speaker accepts and persists it regardless.
+
+Two caveats:
+
+- **A folder preset is more fragile than a station preset.** Media-server
+  location tokens are opaque, server-specific and index-dependent, so a preset
+  can break when the server reindexes its library. Nothing in the protocol
+  identifies content independently of that index.
+- **The folder has to be playing before it can be saved.** Storing one without
+  playing it first would need a route that accepts an arbitrary ContentItem,
+  which does not exist today.
 
 ## Preset Selection
 

--- a/pkg/service/marge/i697_storedmusic_preset_skip_test.go
+++ b/pkg/service/marge/i697_storedmusic_preset_skip_test.go
@@ -1,0 +1,278 @@
+package marge
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+	"github.com/gesellix/bose-soundtouch/pkg/service/constants"
+)
+
+// Issue 697: syncing a device that holds both RADIO_BROWSER and STORED_MUSIC
+// presets silently drops the STORED_MUSIC ones. The reporter's log shows the
+// skip branch firing with an empty source id and an account that is the media
+// server's *display name*:
+//
+//	[Marge] /full: skipping preset 2 — source "STORED_MUSIC" (id="",
+//	account="<server display name>") not in configured sources and not
+//	synthesisable; the speaker's preset slot will revert to empty …
+//
+// Both halves of that line matter. A configured STORED_MUSIC source is keyed
+// by account "<UDN>/0" (see AddSource), so an account holding a display name
+// cannot match it; and canonicalDefaultsByType has no STORED_MUSIC entry, so
+// the synthesise branch cannot rescue it either. The preset is therefore
+// dropped from /full, and the speaker empties that slot.
+//
+// syncPresets stores SourceAccount from p.Source.Username, i.e. whatever the
+// speaker reported in the preset's source block, which is where the display
+// name comes from.
+//
+// Identifiers below are placeholders; only the shape is from the report.
+const (
+	i697ServerUDN         = "UUUUUUUU-UUUU-UUUU-UUUU-UUUUUUUUUUUU/0"
+	i697ServerDisplayName = "MEDIASERVER1"
+)
+
+func i697ConfiguredSources() []models.ConfiguredSource {
+	return []models.ConfiguredSource{
+		{
+			ID:               "10005",
+			Type:             "Audio",
+			SourceKeyType:    constants.ProviderRadioBrowser,
+			SourceProviderID: strconv.Itoa(constants.RadioBrowserProviderID),
+			CreatedOn:        constants.DateStr,
+			UpdatedOn:        constants.DateStr,
+		},
+		{
+			// As AddSource persists a media server: the account identity is
+			// the UDN, while the human-readable name lives alongside it.
+			ID:               "10007",
+			Type:             "Audio",
+			SourceKeyType:    constants.ProviderStoredMusic,
+			SourceKeyAccount: i697ServerUDN,
+			SourceName:       i697ServerDisplayName,
+			SourceProviderID: strconv.Itoa(constants.StoredMusicProviderID),
+			CreatedOn:        constants.DateStr,
+			UpdatedOn:        constants.DateStr,
+		},
+	}
+}
+
+func i697PresetButtons(t *testing.T, presets []models.FullResponsePreset) map[string]string {
+	t.Helper()
+
+	out := map[string]string{}
+
+	for i := range presets {
+		out[presets[i].ButtonNumber] = presets[i].Name
+	}
+
+	return out
+}
+
+// TestMapPresetsToFullResponse_StoredMusicPresetByServerName_GH697 is the
+// reproducer: a STORED_MUSIC preset whose account is the server's display
+// name, next to a resolvable RADIO_BROWSER preset, must survive the mapping.
+func TestMapPresetsToFullResponse_StoredMusicPresetByServerName_GH697(t *testing.T) {
+	presets := []models.ServicePreset{
+		{
+			ServiceContentItem: models.ServiceContentItem{
+				Name:            "A Station",
+				Source:          constants.ProviderRadioBrowser,
+				SourceID:        "10005",
+				Location:        "/stations/byuuid/00000000-0000-0000-0000-000000000000",
+				ContentItemType: "stationurl",
+			},
+			ButtonNumber: "1",
+		},
+		{
+			// The speaker reported the source block's username as the media
+			// server's display name, and no source id at all.
+			ServiceContentItem: models.ServiceContentItem{
+				Name:          "A Folder",
+				Source:        constants.ProviderStoredMusic,
+				SourceAccount: i697ServerDisplayName,
+				Location:      "4:cont2:615:part12:39",
+			},
+			ButtonNumber: "2",
+		},
+		{
+			ServiceContentItem: models.ServiceContentItem{
+				Name:          "Another Folder",
+				Source:        constants.ProviderStoredMusic,
+				SourceAccount: i697ServerDisplayName,
+				Location:      "4:cont2:615:part12:40",
+			},
+			ButtonNumber: "3",
+		},
+	}
+
+	got := mapPresetsToFullResponse(presets, i697ConfiguredSources())
+	buttons := i697PresetButtons(t, got)
+
+	if len(got) != len(presets) {
+		t.Errorf("embedded %d preset(s), want %d — a dropped preset empties that slot on the speaker (got %v)",
+			len(got), len(presets), buttons)
+	}
+
+	for _, button := range []string{"1", "2", "3"} {
+		if _, ok := buttons[button]; !ok {
+			t.Errorf("preset %s was skipped", button)
+		}
+	}
+
+	// The STORED_MUSIC presets must bind to the media server's own source, so
+	// play-time still resolves the right account.
+	for i := range got {
+		if got[i].ButtonNumber == "1" {
+			continue
+		}
+
+		if got[i].Source.SourceProviderID != strconv.Itoa(constants.StoredMusicProviderID) {
+			t.Errorf("preset %s bound to sourceproviderid %q, want the STORED_MUSIC provider",
+				got[i].ButtonNumber, got[i].Source.SourceProviderID)
+		}
+
+		if got[i].Source.Username != i697ServerUDN && got[i].Source.Username != "" {
+			t.Errorf("preset %s bound to username %q, want the server's UDN account or empty",
+				got[i].ButtonNumber, got[i].Source.Username)
+		}
+	}
+}
+
+// Recents are matched the same way and were dropped the same way.
+func TestMapRecentsToFullResponse_StoredMusicRecentByServerName_GH697(t *testing.T) {
+	recents := []models.ServiceRecent{
+		{
+			ServiceContentItem: models.ServiceContentItem{
+				ID:            "1",
+				Name:          "A Folder",
+				Source:        constants.ProviderStoredMusic,
+				SourceAccount: i697ServerDisplayName,
+				Location:      "4:cont2:615:part12:39",
+			},
+		},
+	}
+
+	got := mapRecentsToFullResponse(recents, i697ConfiguredSources())
+
+	if len(got) != 1 {
+		t.Fatalf("embedded %d recent(s), want 1", len(got))
+	}
+
+	if got[0].Source.SourceProviderID != strconv.Itoa(constants.StoredMusicProviderID) {
+		t.Errorf("bound to sourceproviderid %q, want the STORED_MUSIC provider", got[0].Source.SourceProviderID)
+	}
+}
+
+// A media server that is genuinely gone from the configured list must still
+// leave the preset in place: the slot keeps its name and play-time fails
+// visibly, rather than the speaker emptying the slot.
+func TestMapPresetsToFullResponse_StoredMusicServerGone_GH697(t *testing.T) {
+	presets := []models.ServicePreset{
+		{
+			ServiceContentItem: models.ServiceContentItem{
+				Name:          "A Folder",
+				Source:        constants.ProviderStoredMusic,
+				SourceAccount: "SOMEOTHERSERVER",
+				Location:      "4:cont2:615:part12:39",
+			},
+			ButtonNumber: "2",
+		},
+	}
+
+	// Only RADIO_BROWSER is configured: no media server at all.
+	configured := i697ConfiguredSources()[:1]
+
+	got := mapPresetsToFullResponse(presets, configured)
+
+	if len(got) != 1 {
+		t.Fatalf("embedded %d preset(s), want 1: an unresolvable media server must not empty the slot", len(got))
+	}
+
+	if got[0].Source.SourceProviderID != strconv.Itoa(constants.StoredMusicProviderID) {
+		t.Errorf("synthesised sourceproviderid %q, want the STORED_MUSIC provider", got[0].Source.SourceProviderID)
+	}
+}
+
+// The write path stops the mismatch being persisted again.
+func TestCanonicalSourceAccount_GH697(t *testing.T) {
+	sources := i697ConfiguredSources()
+
+	tests := []struct {
+		name       string
+		sourceType string
+		reported   string
+		want       string
+	}{
+		{
+			name:       "media server display name resolves to its account",
+			sourceType: constants.ProviderStoredMusic,
+			reported:   i697ServerDisplayName,
+			want:       i697ServerUDN,
+		},
+		{
+			name:       "the account form is already canonical",
+			sourceType: constants.ProviderStoredMusic,
+			reported:   i697ServerUDN,
+			want:       i697ServerUDN,
+		},
+		{
+			name:       "an unexplained account is kept verbatim",
+			sourceType: constants.ProviderStoredMusic,
+			reported:   "SOMEOTHERSERVER",
+			want:       "SOMEOTHERSERVER",
+		},
+		{
+			name:       "empty stays empty",
+			sourceType: constants.ProviderStoredMusic,
+			reported:   "",
+			want:       "",
+		},
+		{
+			// Only STORED_MUSIC accepts a display name. Elsewhere the account
+			// is the identity, and rewriting it could bind the wrong account.
+			name:       "a display name is not resolved for other providers",
+			sourceType: constants.ProviderRadioBrowser,
+			reported:   i697ServerDisplayName,
+			want:       i697ServerDisplayName,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := canonicalSourceAccount(sources, test.sourceType, test.reported); got != test.want {
+				t.Errorf("canonicalSourceAccount(%q, %q) = %q, want %q",
+					test.sourceType, test.reported, got, test.want)
+			}
+		})
+	}
+}
+
+// TestMapPresetsToFullResponse_StoredMusicPresetByAccount_GH697 is the control
+// case: the same preset keyed by the account form AddSource persists resolves
+// today, which is what makes the display-name case a mismatch rather than a
+// missing feature.
+func TestMapPresetsToFullResponse_StoredMusicPresetByAccount_GH697(t *testing.T) {
+	presets := []models.ServicePreset{
+		{
+			ServiceContentItem: models.ServiceContentItem{
+				Name:          "A Folder",
+				Source:        constants.ProviderStoredMusic,
+				SourceAccount: i697ServerUDN,
+				Location:      "4:cont2:615:part12:39",
+			},
+			ButtonNumber: "2",
+		},
+	}
+
+	got := mapPresetsToFullResponse(presets, i697ConfiguredSources())
+
+	if len(got) != 1 {
+		t.Fatalf("embedded %d preset(s), want 1: the account form must resolve", len(got))
+	}
+
+	if got[0].Source.SourceProviderID != strconv.Itoa(constants.StoredMusicProviderID) {
+		t.Errorf("bound to sourceproviderid %q, want the STORED_MUSIC provider", got[0].Source.SourceProviderID)
+	}
+}

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -470,8 +470,8 @@ func findMatchingSourceForPreset(sources []models.ConfiguredSource, p models.Ser
 	// Then try type and account match
 	for j := range sources {
 		s := &sources[j]
-		if (s.SourceKey.Type == p.Source && (p.SourceAccount == "" || s.SourceKey.Account == p.SourceAccount)) ||
-			(s.SourceKeyType == p.Source && (p.SourceAccount == "" || s.SourceKeyAccount == p.SourceAccount)) {
+		if (s.SourceKey.Type == p.Source || s.SourceKeyType == p.Source) &&
+			sourceAccountMatchesClaim(*s, p.Source, p.SourceAccount) {
 			return s
 		}
 	}
@@ -515,7 +515,8 @@ func RecentsToXML(ds *datastore.DataStore, account, deviceID string) ([]byte, er
 		} else if r.Source != "" {
 			// Try to find by Source and SourceAccount if SourceID didn't match
 			for j := range sources {
-				if sources[j].SourceKeyType == r.Source && sources[j].SourceKeyAccount == r.SourceAccount {
+				if sources[j].SourceKeyType == r.Source &&
+					sourceAccountMatchesClaim(sources[j], r.Source, r.SourceAccount) {
 					matchingSrc = &sources[j]
 					PrepareConfiguredSource(matchingSrc)
 
@@ -875,6 +876,8 @@ func canonicalProviderIDByID(id string) string {
 		return strconv.Itoa(constants.TuneinProviderID)
 	case "10005":
 		return strconv.Itoa(constants.RadioBrowserProviderID)
+	case "10007":
+		return strconv.Itoa(constants.StoredMusicProviderID)
 	}
 
 	return ""
@@ -945,6 +948,14 @@ func canonicalDefaultsByType(sourceKeyType string) (id, providerID string) {
 		return "10004", strconv.Itoa(constants.TuneinProviderID)
 	case constants.ProviderRadioBrowser:
 		return "10005", strconv.Itoa(constants.RadioBrowserProviderID)
+	case constants.ProviderStoredMusic:
+		// A media server's account is its UDN, which we cannot invent, so a
+		// synthesised block carries no credential and play-time will fail
+		// until the server is registered again. That is still better than
+		// dropping the preset, which empties the speaker's slot (issue 697).
+		// With the display-name match in sourceAccountMatchesClaim this only
+		// fires when the server is genuinely gone from the configured list.
+		return "10007", strconv.Itoa(constants.StoredMusicProviderID)
 	}
 
 	return "", ""
@@ -994,7 +1005,7 @@ func mapPresetsToFullResponse(presets []models.ServicePreset, sources []models.C
 		if matchedSource == nil {
 			for j := range sources {
 				s := sources[j]
-				if s.SourceKeyType == p.Source && (p.SourceAccount == "" || s.SourceKeyAccount == p.SourceAccount) {
+				if s.SourceKeyType == p.Source && sourceAccountMatchesClaim(s, p.Source, p.SourceAccount) {
 					copySource := s
 					PrepareConfiguredSource(&copySource)
 					matchedSource = &copySource
@@ -1121,7 +1132,7 @@ func findMatchingSourceForRecent(r *models.ServiceRecent, sources []models.Confi
 
 	for j := range sources {
 		s := sources[j]
-		if s.SourceKeyType == r.Source && (r.SourceAccount == "" || s.SourceKeyAccount == r.SourceAccount) {
+		if s.SourceKeyType == r.Source && sourceAccountMatchesClaim(s, r.Source, r.SourceAccount) {
 			copySource := s
 			PrepareConfiguredSource(&copySource)
 
@@ -1159,6 +1170,41 @@ func upsertPresetByButton(presets []models.ServicePreset, next models.ServicePre
 	}
 
 	return append(presets, next)
+}
+
+// sourceAccountMatchesClaim reports whether a preset or recent claiming
+// `account` belongs to the configured source s, given its `sourceType`.
+//
+// The account a speaker reports is not always the account we keyed the source
+// by. AddSource keys a media server by its UDN ("<UDN>/0"), while the speaker
+// echoes the server's *display name* in the preset's source block, which
+// syncPresets then persists verbatim. Comparing accounts alone therefore
+// matched nothing for media-server presets, and an unmatched preset is
+// dropped from /full, which empties that slot on the speaker (issue 697).
+//
+// The display-name forms are accepted for STORED_MUSIC only. For every other
+// provider the account *is* the identity (a Spotify user name, say), where
+// matching a display name could bind a preset to the wrong account.
+func sourceAccountMatchesClaim(s models.ConfiguredSource, sourceType, account string) bool {
+	if account == "" {
+		return true
+	}
+
+	if account == s.SourceKeyAccount || account == s.SourceKey.Account {
+		return true
+	}
+
+	if sourceType != constants.ProviderStoredMusic {
+		return false
+	}
+
+	for _, name := range []string{s.SourceName, s.DisplayName, s.Name} {
+		if name != "" && account == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func sourceTypeCompatible(claimed, configured string) bool {

--- a/pkg/service/marge/sync.go
+++ b/pkg/service/marge/sync.go
@@ -196,20 +196,64 @@ func syncConfiguredSources(ds *datastore.DataStore, accountID, deviceID string, 
 	}
 }
 
+// canonicalSourceAccount resolves the account a speaker reported for a preset
+// or recent to the account identity we keyed its source by, so that what gets
+// persisted is the form /full later matches on (issue 697). A speaker reports
+// a media server's display name here, while the source is keyed by its UDN.
+//
+// The reported value is returned unchanged when nothing matches: an account we
+// cannot explain is still better evidence than an empty one, and the read-side
+// match in sourceAccountMatchesClaim covers what remains.
+//
+// Note the order in SyncFromAccountFull: presets and recents are written
+// before syncConfiguredSources runs, so this reads the sources persisted by
+// the previous sync. A media server's entry survives between syncs, which is
+// the case this repairs; a server seen for the very first time normalises on
+// the next sync instead.
+func canonicalSourceAccount(sources []models.ConfiguredSource, sourceType, reported string) string {
+	if reported == "" || sourceType == "" {
+		return reported
+	}
+
+	for i := range sources {
+		s := sources[i]
+		if s.SourceKeyType != sourceType && s.SourceKey.Type != sourceType {
+			continue
+		}
+
+		if !sourceAccountMatchesClaim(s, sourceType, reported) {
+			continue
+		}
+
+		if s.SourceKeyAccount != "" {
+			return s.SourceKeyAccount
+		}
+
+		if s.SourceKey.Account != "" {
+			return s.SourceKey.Account
+		}
+	}
+
+	return reported
+}
+
 func syncPresets(ds *datastore.DataStore, accountID, deviceID string, presetsSource []models.FullResponsePreset) {
 	var presets []models.ServicePreset
 
+	knownSources, _ := ds.GetConfiguredSources(accountID, deviceID)
+
 	for i := range presetsSource {
 		p := &presetsSource[i]
+		sourceType := sourceKeyTypeFromFullSource(p.Source)
 		preset := models.ServicePreset{
 			ServiceContentItem: models.ServiceContentItem{
 				ID:              p.ButtonNumber,
 				ContentItemType: p.ContentItemType,
 				Location:        p.Location,
 				Name:            p.Name,
-				Source:          sourceKeyTypeFromFullSource(p.Source),
+				Source:          sourceType,
 				SourceID:        p.Source.ID,
-				SourceAccount:   p.Source.Username,
+				SourceAccount:   canonicalSourceAccount(knownSources, sourceType, p.Source.Username),
 				Type:            p.ContentItemType,
 			},
 			ButtonNumber: p.ButtonNumber,
@@ -229,17 +273,20 @@ func syncPresets(ds *datastore.DataStore, accountID, deviceID string, presetsSou
 func syncRecents(ds *datastore.DataStore, accountID, deviceID string, recentsSource []models.FullResponseRecent) {
 	var recents []models.ServiceRecent
 
+	knownSources, _ := ds.GetConfiguredSources(accountID, deviceID)
+
 	for i := range recentsSource {
 		r := &recentsSource[i]
+		sourceType := sourceKeyTypeFromFullSource(r.Source)
 		recent := models.ServiceRecent{
 			ServiceContentItem: models.ServiceContentItem{
 				ID:              r.ID,
 				ContentItemType: r.ContentItemType,
 				Location:        r.Location,
 				Name:            r.Name,
-				Source:          sourceKeyTypeFromFullSource(r.Source),
+				Source:          sourceType,
 				SourceID:        r.Source.ID,
-				SourceAccount:   r.Source.Username,
+				SourceAccount:   canonicalSourceAccount(knownSources, sourceType, r.Source.Username),
 				Type:            r.ContentItemType,
 			},
 			CreatedOn:    r.CreatedOn,

--- a/pkg/service/soundtouchweb/frontend_test/presets.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/presets.test.mjs
@@ -14,6 +14,18 @@ test('the save button is disabled rather than hidden when nothing is playing', (
     assert.doesNotMatch(presets, /\$\{canSave && html/);
 });
 
+// Issue 700: a STORED_MUSIC preset tile showed the raw source name and had no
+// accent colour, leaving it the only tile rendered with the default border.
+// RADIO_BROWSER had the same label gap.
+test('library and radio-browser presets get a readable label', () => {
+    assert.match(presets, /STORED_MUSIC:\s*'Library'/);
+    assert.match(presets, /RADIO_BROWSER:\s*'Radio Browser'/);
+});
+
+test('a library preset tile has its own accent colour', () => {
+    assert.match(css, /\[data-source="STORED_MUSIC"\][^{]*\{[^}]*--slot-color/);
+});
+
 test('the save button is not hidden behind a hover reveal', () => {
     const rule = css.match(/\.preset-save-btn \{[^}]*\}/);
     assert.ok(rule, 'expected a .preset-save-btn rule');

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -1592,16 +1592,35 @@ func (app *WebApp) HandleDeviceRecents(w http.ResponseWriter, r *http.Request) {
 }
 
 // storedMusicTypeForReplay derives a STORED_MUSIC ContentItem type from the
-// speaker-native location, which ends with the item kind (e.g. "1$4$2 TRACK"
-// or a container's "… DIR"). Recents don't store the type, and the speaker
-// rejects an empty-type STORED_MUSIC select with INVALID_SOURCE. Falls back to
-// "track" when the location has no kind suffix.
+// speaker-native location. Recents don't store the type, and the speaker
+// rejects an empty-type STORED_MUSIC select with INVALID_SOURCE.
+//
+// An explicit kind suffix is honoured; everything else is a container.
+// Measured on a SoundTouch 10 (FW 27.0.6) against two independent media
+// servers, plus a third shape from the issue 702 report:
+//
+//	tracks      "1$0 TRACK", "5:audio5:part13:3171:5 TRACK"
+//	containers  "1", "4:cont1:20:0:0:", "22$2935"
+//
+// Track locations reliably carry the suffix on every server seen; container
+// locations never do, and the " DIR" suffix this function's first version
+// assumed was not produced by any of them.
+//
+// The fallback therefore points at "dir", not "track" (issue 702). It used to
+// be "track", which silently mis-typed every folder recent: replaying one
+// selected a directory as a track, and the failure surfaced at play time
+// rather than at write time. The remaining exposure is a server that emits
+// track locations without the suffix, which would now be typed as a
+// container; none of the three seen does. Keeping the real type instead of
+// deriving it would remove the guess altogether, since /navigate reports the
+// kind in the item's <type> element and nowSelectionUpdated carries
+// type="dir" explicitly.
 func storedMusicTypeForReplay(location string) string {
 	if fields := strings.Fields(location); len(fields) >= 2 {
 		return strings.ToLower(fields[len(fields)-1])
 	}
 
-	return "track"
+	return "dir"
 }
 
 // HandleDevicePlay plays an arbitrary content item on a device. Generic

--- a/pkg/service/soundtouchweb/handler_library.go
+++ b/pkg/service/soundtouchweb/handler_library.go
@@ -40,6 +40,18 @@ type libraryEntry struct {
 	SourceAccount string `json:"sourceAccount"`
 	Playable      bool   `json:"playable"`
 	IsDir         bool   `json:"isDir"`
+
+	// IsPresetable reports the speaker's own isPresetable attribute for this
+	// item, which is what says whether it can be saved to a preset slot. It
+	// was previously dropped here, so the UI had no way to know.
+	//
+	// Read false as "unknown", not "no": models.ContentItem.IsPresetable is a
+	// plain bool, so an absent attribute and an explicit false are the same
+	// value by the time it reaches us. Both media servers measured (a
+	// FRITZ!Box UPnP server and this repo's example-dlna-server) reported
+	// true on every directory and track, so a false in practice means the
+	// attribute was missing.
+	IsPresetable bool `json:"isPresetable"`
 }
 
 // libraryPage wraps a slice of libraryEntry as the Data payload.
@@ -445,8 +457,14 @@ func (app *WebApp) HandleLibraryBrowse(w http.ResponseWriter, r *http.Request) {
 
 	for _, item := range resp.Items {
 		loc := ""
+		presetable := false
+
+		// The item's own ContentItem, not the one inside mediaItemContainer:
+		// that one repeats the parent container identically on every item.
+		// models.NavigateItem keeps them apart.
 		if item.ContentItem != nil {
 			loc = item.ContentItem.Location
+			presetable = item.ContentItem.IsPresetable
 		}
 
 		entries = append(entries, libraryEntry{
@@ -456,6 +474,7 @@ func (app *WebApp) HandleLibraryBrowse(w http.ResponseWriter, r *http.Request) {
 			SourceAccount: account,
 			Playable:      item.Playable == 1,
 			IsDir:         item.Type == "dir",
+			IsPresetable:  presetable,
 		})
 	}
 

--- a/pkg/service/soundtouchweb/handler_library_test.go
+++ b/pkg/service/soundtouchweb/handler_library_test.go
@@ -14,25 +14,51 @@ import (
 	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
 )
 
-// cannedNavigateResponse is a minimal XML navigateResponse the fake speaker
-// returns for /navigate in browse tests. It contains one directory and one
-// track so we can assert both are mapped correctly.
+// cannedNavigateResponse is an XML navigateResponse the fake speaker returns
+// for /navigate in browse tests: one directory and one track, so we can assert
+// both are mapped correctly.
+//
+// The shape is taken from real captures (issue 700) rather than written by
+// hand, because the hand-written version disagreed with hardware on four
+// counts and the wrong one was load-bearing: it claimed isPresetable="false"
+// on the directory, which was the only reason to doubt that saving a folder to
+// a preset works at all. Captured from a SoundTouch 10 (FW 27.0.6) against two
+// independent media servers, which agreed on all of it:
+//
+//   - directories report Playable="1", not "0"
+//   - isPresetable is "true" on directories and tracks alike
+//   - the ContentItem carries NO type attribute; the kind is the <type>
+//     element on the item
+//   - every item carries a <mediaItemContainer> whose ContentItem repeats the
+//     parent container, so each item has two ContentItems
+//
+// Names and identifiers are placeholders; the structure is verbatim.
 // Note: totalItems is an XML element, not an attribute, per models.NavigateResponse.
 const cannedNavigateResponse = `<?xml version="1.0" encoding="UTF-8" ?>
 <navigateResponse source="STORED_MUSIC" sourceAccount="uuid:test-udn/0">
   <totalItems>2</totalItems>
   <items>
-    <item Playable="0">
+    <item Playable="1">
       <name>Albums</name>
       <type>dir</type>
-      <ContentItem source="STORED_MUSIC" type="dir" location="4:cont2:150:0:0:" sourceAccount="uuid:test-udn/0" isPresetable="false">
+      <mediaItemContainer offset="0">
+        <ContentItem source="STORED_MUSIC" location="0" sourceAccount="uuid:test-udn/0" isPresetable="true">
+          <itemName>uuid:test-udn/0</itemName>
+        </ContentItem>
+      </mediaItemContainer>
+      <ContentItem source="STORED_MUSIC" location="4:cont2:150:0:0:" sourceAccount="uuid:test-udn/0" isPresetable="true">
         <itemName>Albums</itemName>
       </ContentItem>
     </item>
     <item Playable="1">
       <name>Great Song</name>
       <type>track</type>
-      <ContentItem source="STORED_MUSIC" type="track" location="5:audio5:part13:3171:5 TRACK" sourceAccount="uuid:test-udn/0" isPresetable="true">
+      <mediaItemContainer offset="1">
+        <ContentItem source="STORED_MUSIC" location="4:cont2:150:0:0:" sourceAccount="uuid:test-udn/0" isPresetable="true">
+          <itemName>Albums</itemName>
+        </ContentItem>
+      </mediaItemContainer>
+      <ContentItem source="STORED_MUSIC" location="5:audio5:part13:3171:5 TRACK" sourceAccount="uuid:test-udn/0" isPresetable="true">
         <itemName>Great Song</itemName>
       </ContentItem>
     </item>
@@ -300,10 +326,20 @@ func TestHandleLibraryBrowse_RootMapsEntries(t *testing.T) {
 		t.Error("dir.IsDir should be true")
 	}
 
-	if dir.Playable {
-		t.Error("dir.Playable should be false")
+	// Hardware reports Playable="1" on directories: the speaker will happily
+	// play a whole folder, which is what makes a folder preset work.
+	if !dir.Playable {
+		t.Error("dir.Playable should be true, as hardware reports Playable=1 for directories")
 	}
 
+	// Dropped before issue 700, so the UI could not tell whether a folder was
+	// savable to a preset.
+	if !dir.IsPresetable {
+		t.Error("dir.IsPresetable should be true")
+	}
+
+	// The item's own ContentItem, not the parent repeated inside
+	// mediaItemContainer (location "0" here).
 	if dir.Location != "4:cont2:150:0:0:" {
 		t.Errorf("dir location: expected '4:cont2:150:0:0:', got %q", dir.Location)
 	}

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -71,6 +71,10 @@ img { display: block; max-width: 100%; }
 [data-source="DEEZER"]               { --slot-color: #A238FF; }
 [data-source="IHEARTRADIO"]          { --slot-color: #C6002B; }
 [data-source="BLUETOOTH"]            { --slot-color: #0082FC; }
+/* Local media-server content. Deliberately the one desaturated accent here:
+   it is the only source that is not a brand, and it used to be the only tile
+   left with the default border (issue 700). */
+[data-source="STORED_MUSIC"]         { --slot-color: #7D8CA1; }
 
 /* ── Layout ──────────────────────────────────────────────────────────────── */
 .app { display: flex; flex-direction: column; min-height: 100vh; }

--- a/pkg/service/soundtouchweb/static/js/components/Presets.js
+++ b/pkg/service/soundtouchweb/static/js/components/Presets.js
@@ -10,6 +10,10 @@ const SOURCE_LABELS = {
     TUNEIN: 'TuneIn', SPOTIFY: 'Spotify', AMAZON: 'Amazon',
     PANDORA: 'Pandora', IHEARTRADIO: 'iHeart', DEEZER: 'Deezer',
     LOCAL_INTERNET_RADIO: 'Internet Radio',
+    // A folder or track from a DLNA/NAS media server. Without this the tile
+    // showed the raw source name (issue 700).
+    STORED_MUSIC: 'Library',
+    RADIO_BROWSER: 'Radio Browser',
 };
 
 function sourceLabel(source) {

--- a/pkg/service/soundtouchweb/storedmusic_replay_test.go
+++ b/pkg/service/soundtouchweb/storedmusic_replay_test.go
@@ -5,22 +5,42 @@ import "testing"
 // TestStoredMusicTypeForReplay covers deriving the ContentItem type from a
 // STORED_MUSIC recent's location when the stored type is empty. Without a type
 // the speaker rejects the select with INVALID_SOURCE.
+//
+// The locations are real shapes, captured on a SoundTouch 10 (FW 27.0.6)
+// against two independent media servers, plus one from the issue 702 report.
+// Tracks carry a kind suffix; containers carry none, and no server produced
+// the " DIR" suffix the first version of this helper assumed.
 func TestStoredMusicTypeForReplay(t *testing.T) {
 	cases := []struct {
+		name     string
 		location string
 		want     string
 	}{
-		{"1$4$2 TRACK", "track"},
-		{"5:audio5:part13:5521:5 TRACK", "track"},
-		{"1 DIR", "dir"},
-		{"1 CONTAINER", "container"},
-		{"noSuffix", "track"}, // fallback
-		{"", "track"},         // fallback
+		{"track, example-dlna-server", "1$0 TRACK", "track"},
+		{"track, FRITZ!Box", "5:audio5:part13:3171:5 TRACK", "track"},
+		{"track, suffix wins over anything else", "1$4$2 TRACK", "track"},
+
+		// Containers: no whitespace, no kind suffix. Typing these as "track"
+		// was issue 702 — a folder recent replayed as a single track.
+		{"album container, example-dlna-server", "1", "dir"},
+		{"folder container, FRITZ!Box", "4:cont1:20:0:0:", "dir"},
+		{"folder container, reporter's server", "22$2935", "dir"},
+		{"folder container from a recentsUpdated frame", "4:cont2:615:part12:39", "dir"},
+
+		// An explicit suffix is still honoured, whatever it says.
+		{"explicit DIR suffix", "1 DIR", "dir"},
+		{"explicit CONTAINER suffix", "1 CONTAINER", "container"},
+
+		// The handler rejects an empty location before reaching here, so this
+		// only pins that the fallback is the container side.
+		{"empty location", "", "dir"},
 	}
 
 	for _, c := range cases {
-		if got := storedMusicTypeForReplay(c.location); got != c.want {
-			t.Errorf("storedMusicTypeForReplay(%q) = %q, want %q", c.location, got, c.want)
-		}
+		t.Run(c.name, func(t *testing.T) {
+			if got := storedMusicTypeForReplay(c.location); got != c.want {
+				t.Errorf("storedMusicTypeForReplay(%q) = %q, want %q", c.location, got, c.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Three related STORED_MUSIC findings, each measured against real hardware rather than reasoned about: a SoundTouch 10 (FW 27.0.6) driving two independent media servers, a FRITZ!Box UPnP server and this repository's own `cmd/example-dlna-server`.

**Groundwork for [issue 700](https://github.com/gesellix/Bose-SoundTouch/issues/700) (folder presets are undiscoverable).** `libraryEntry` dropped the speaker's `isPresetable`, so the UI had no way to know whether a row could be saved at all; it is carried through now. Read `false` as "unknown" rather than "no": `models.ContentItem.IsPresetable` is a plain bool, so an absent attribute and an explicit `false` are the same value by the time it reaches us. The browse fixture was hand-written and disagreed with hardware on four counts, and the wrong one was load-bearing: it claimed `isPresetable="false"` on a directory, which was the only reason to doubt the feature existed. Both servers agreed that directories report `Playable="1"` and `isPresetable="true"`, that the item's ContentItem carries **no** `type` attribute, and that every item carries a `<mediaItemContainer>` whose ContentItem repeats the parent container. The fixture now has that shape, and the mapping reads the item's own ContentItem rather than the container's. A STORED_MUSIC preset tile also showed the raw source name with no accent colour, leaving it the only tile with a default border; RADIO_BROWSER had the same label gap.

**[Issue 702](https://github.com/gesellix/Bose-SoundTouch/issues/702) (a folder recent replayed as a track).** `storedMusicTypeForReplay` fell back to `"track"` when a location carried no kind suffix, so replaying a folder from Recents selected a directory as a track and failed at play time rather than at write time. The ` DIR` suffix its first version assumed does not exist on any server seen: track locations reliably carry ` TRACK` (`1$0 TRACK`, `5:audio5:part13:3171:5 TRACK`), container locations carry no suffix (`1`, `4:cont1:20:0:0:`, and `22$2935` from the report). An explicit suffix is still honoured and the fallback now points at the container side. The remaining exposure is a server that emits track locations without the suffix; none of the three does, and more servers are worth checking before treating this as settled.

**[Issue 697](https://github.com/gesellix/Bose-SoundTouch/issues/697) (syncing deletes STORED_MUSIC presets).** Reproduced as a unit test first, which moved the cause away from the report's framing: the source types are incidental, the account *form* is the bug. A configured media server is keyed by its UDN (`<UDN>/0`, see `AddSource`), but the speaker echoes the server's display name in a preset's source block, and `syncPresets` persists that verbatim. The type/account match then compares a display name against a UDN, finds nothing, and because `canonicalDefaultsByType` had no STORED_MUSIC entry the synthesise branch could not rescue it either. The preset was dropped from `/full`, and a preset missing from `/full` is what empties the slot on the speaker. Recents were matched the same way and lost the same way.

Fixed in three layers, because each covers what the others cannot:

- `sourceAccountMatchesClaim` accepts the display-name forms (`SourceName`, `DisplayName`, `Name`) in addition to the account, **for STORED_MUSIC only** — elsewhere the account is the identity and matching a name could bind the wrong account. Used by all four preset/recent match sites, and it repairs presets already stored with the wrong form without any migration.
- `canonicalDefaultsByType` gained STORED_MUSIC, so a media server that is genuinely gone leaves the preset in place with an empty credential and a visible play-time failure, instead of the slot being emptied.
- `canonicalSourceAccount` normalises the speaker-reported account on the way in, so the mismatch stops being persisted. It keeps the reported value verbatim when nothing matches, and reads the previous sync's sources, since presets are written before `syncConfiguredSources` runs (step 4 needs them on disk for deduction).

## Linked issues

- [700](https://github.com/gesellix/Bose-SoundTouch/issues/700) — groundwork only; the Library save button is still deferred, see below
- [702](https://github.com/gesellix/Bose-SoundTouch/issues/702) — fixed here, pending confirmation
- [697](https://github.com/gesellix/Bose-SoundTouch/issues/697) — fixed here, pending confirmation on a device that holds real media-server presets

No auto-close keywords: none of these is resolved until it has been confirmed against hardware that reproduced it.

## What is deliberately not here

The **Library save button** from issue 700, which is the actual feature request. It was blocked on 697 deleting STORED_MUSIC presets during a sync; that blocker is addressed in code here but not yet confirmed on hardware, and encouraging users to create folder presets before it is would not be kind.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] `node --test pkg/service/soundtouchweb/frontend_test/*.test.mjs`
- [x] Captured `/navigate` responses from two media servers via a real speaker
- [ ] The 697 fix has not yet been exercised by a real sync against a device holding media-server presets
- [ ] `make check`'s Docker-based HTTP integration leg was not run (daemon down)

The 697 fix started as a failing reproducer (`i697_storedmusic_preset_skip_test.go`): the display-name preset was dropped while its RADIO_BROWSER neighbour survived, and a control case using the `<UDN>/0` form passed, which is what identified the mismatch rather than the source types. That file now also covers the recents path, a genuinely-absent server, and the write-path normaliser including a negative case for non-STORED_MUSIC providers. The 702 test cases are the real captured location shapes rather than invented ones.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures — the reporter's server name and UDN are replaced by placeholders
- [x] Documentation updated: the navigation guide gains what a navigate item actually contains, and the preset reference gains how a folder preset is made plus why it is more fragile than a station preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)
