### PR TITLE
fix(presets): address presets by button number, not by list position

### DIFF
--- a/pkg/service/datastore/datastore.go
+++ b/pkg/service/datastore/datastore.go
@@ -1077,7 +1077,9 @@ func (ds *DataStore) GetPresets(account, device string) ([]models.ServicePreset,
 	}
 
 	if needsRewrite {
-		log.Printf("[Datastore] Presets.xml for device %s used legacy <ContentItem> format; rewriting in canonical form", sanitizeLog(device))
+		// Either the legacy <ContentItem> spelling or a duplicate button
+		// number; readPresetsNoLock logs which.
+		log.Printf("[Datastore] Presets.xml for device %s needed canonicalising; rewriting", sanitizeLog(device))
 
 		if werr := ds.SavePresets(account, device, presets); werr != nil {
 			log.Printf("[Datastore] failed to rewrite normalised Presets.xml for device %s: %s", sanitizeLog(device), sanitizeErr(werr))
@@ -1213,7 +1215,103 @@ func (ds *DataStore) readPresetsNoLock(account, device string) ([]models.Service
 		})
 	}
 
+	// Collapse duplicate button numbers, and let the caller rewrite the file
+	// once rather than filtering on every read.
+	if deduped, collapsed := collapseDuplicatePresets(presets); collapsed > 0 {
+		log.Printf("[Datastore] readPresetsNoLock: Presets.xml for device %s carries %d duplicate button number(s); collapsing to one entry per slot",
+			sanitizeLog(device), collapsed)
+
+		presets = deduped
+		needsRewrite = true
+	}
+
 	return presets, needsRewrite, nil
+}
+
+// effectivePresetButton returns the slot a preset occupies: its ButtonNumber,
+// falling back to its ID. That is the same fallback savePresetsNoLock applies
+// when writing the id attribute, so ordering and duplicate detection must use
+// it too — an entry carrying only an ID still occupies a slot.
+func effectivePresetButton(p models.ServicePreset) string {
+	if p.ButtonNumber != "" {
+		return p.ButtonNumber
+	}
+
+	return p.ID
+}
+
+// sortPresetsByButton returns the presets ordered by numeric button number.
+// Entries whose button number is missing or not a number keep their relative
+// order and sort last, since there is no slot to place them in.
+func sortPresetsByButton(presets []models.ServicePreset) []models.ServicePreset {
+	out := make([]models.ServicePreset, len(presets))
+	copy(out, presets)
+
+	button := func(p models.ServicePreset) (int, bool) {
+		n, err := strconv.Atoi(effectivePresetButton(p))
+		if err != nil {
+			return 0, false
+		}
+
+		return n, true
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		left, leftOK := button(out[i])
+		right, rightOK := button(out[j])
+
+		if leftOK != rightOK {
+			return leftOK
+		}
+
+		if !leftOK {
+			return false
+		}
+
+		return left < right
+	})
+
+	return out
+}
+
+// collapseDuplicatePresets returns the preset list with one entry per button
+// number, and how many duplicates it removed.
+//
+// UpdatePreset used to address presets by list position, so saving into a
+// sparse list could append a second entry for a button that already existed
+// (issue 715). That matters beyond tidiness: a list with more entries than the
+// speaker has slots costs a slot, which is how a preset vanished from a device
+// whose Presets.xml still held it.
+//
+// The later entry wins, since the newest save is the one the user just made,
+// while the surviving entry keeps the position of the first occurrence so slot
+// order stays stable. Entries with no button number are left alone: they carry
+// no slot identity to collide on.
+func collapseDuplicatePresets(presets []models.ServicePreset) ([]models.ServicePreset, int) {
+	positionOf := make(map[string]int, len(presets))
+	out := make([]models.ServicePreset, 0, len(presets))
+	collapsed := 0
+
+	for i := range presets {
+		button := effectivePresetButton(presets[i])
+		if button == "" {
+			out = append(out, presets[i])
+
+			continue
+		}
+
+		if at, seen := positionOf[button]; seen {
+			out[at] = presets[i]
+			collapsed++
+
+			continue
+		}
+
+		positionOf[button] = len(out)
+		out = append(out, presets[i])
+	}
+
+	return out, collapsed
 }
 
 // repairLeakedSource quietly substitutes the speaker-perspective
@@ -1322,6 +1420,23 @@ func (ds *DataStore) SavePresets(account, device string, presets []models.Servic
 // savePresetsNoLock is the lock-free write half of
 // SavePresets/MutatePresets. Callers must already hold ds.fileMutex.Lock().
 func (ds *DataStore) savePresetsNoLock(account, device string, presets []models.ServicePreset) error {
+	// Backstop, so no write path can persist two entries for one slot even if
+	// it addresses presets by position again. Mirrors SaveRecents and
+	// SaveConfiguredSources, which both deduplicate before writing.
+	if deduped, collapsed := collapseDuplicatePresets(presets); collapsed > 0 {
+		log.Printf("[Datastore] savePresetsNoLock: dropping %d duplicate button number(s) for device %s before writing",
+			collapsed, sanitizeLog(device))
+
+		presets = deduped
+	}
+
+	// Persist in button order. Callers now address presets by button number
+	// rather than by list position, so insertion order would otherwise depend
+	// on the order saves happened to arrive in — including concurrent ones. A
+	// speaker's own /presets is ordered by slot too, and an empty slot is
+	// simply absent rather than padded.
+	presets = sortPresetsByButton(presets)
+
 	path := filepath.Join(ds.AccountDeviceDir(account, device), constants.PresetsFile)
 	if err := ds.rootMkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err

--- a/pkg/service/datastore/presets_duplicate_button_test.go
+++ b/pkg/service/datastore/presets_duplicate_button_test.go
@@ -1,0 +1,171 @@
+package datastore
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+// A Presets.xml carrying two entries for button 6, as observed on a real
+// device (issue 715). Written in the canonical lowercase <contentItem>
+// spelling, so the duplicate is the only reason a rewrite would be needed.
+const duplicateButtonPresetsXML = `<?xml version="1.0" encoding="UTF-8" ?>
+<presets>
+  <preset id="1" createdOn="" updatedOn="">
+    <contentItem source="TUNEIN" type="stationurl" location="/v1/playback/station/s1" sourceAccount="" isPresetable="true">
+      <itemName>A Station</itemName>
+    </contentItem>
+  </preset>
+  <preset id="4" createdOn="" updatedOn="">
+    <contentItem source="STORED_MUSIC" type="" location="1" sourceAccount="UUUUUUUU-UUUU-UUUU-UUUU-UUUUUUUUUUUU/0" isPresetable="true">
+      <itemName>A Folder</itemName>
+    </contentItem>
+  </preset>
+  <preset id="6" createdOn="" updatedOn="">
+    <contentItem source="RADIO_BROWSER" type="stationurl" location="/stations/byuuid/0000" sourceAccount="" isPresetable="true">
+      <itemName>Stale Entry</itemName>
+    </contentItem>
+  </preset>
+  <preset id="6" createdOn="" updatedOn="">
+    <contentItem source="RADIO_BROWSER" type="stationurl" location="/stations/byuuid/0000" sourceAccount="" isPresetable="true">
+      <itemName>Fresh Entry</itemName>
+    </contentItem>
+  </preset>
+</presets>`
+
+func writeDuplicatePresets(t *testing.T) (ds *DataStore, account, device, path string) {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp("", "st-dup-preset-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() { _ = os.RemoveAll(tempDir) })
+
+	ds = NewDataStore(tempDir)
+	account = "1234567"
+	device = "001122334455"
+
+	if mkErr := os.MkdirAll(ds.AccountDeviceDir(account, device), 0o755); mkErr != nil {
+		t.Fatalf("mkdir device dir: %v", mkErr)
+	}
+
+	path = filepath.Join(ds.AccountDeviceDir(account, device), "Presets.xml")
+	if wErr := os.WriteFile(path, []byte(duplicateButtonPresetsXML), 0o600); wErr != nil {
+		t.Fatalf("write Presets.xml: %v", wErr)
+	}
+
+	return ds, account, device, path
+}
+
+func buttonNumbersOf(presets []models.ServicePreset) []string {
+	out := make([]string, 0, len(presets))
+	for i := range presets {
+		out = append(out, presets[i].ButtonNumber)
+	}
+
+	return out
+}
+
+// A preset list longer than the speaker's six slots costs a slot, so the
+// duplicate has to be collapsed — and repaired on disk, not filtered on every
+// read.
+func TestGetPresets_CollapsesDuplicateButtonAndRepairsTheFile(t *testing.T) {
+	ds, account, device, path := writeDuplicatePresets(t)
+
+	presets, err := ds.GetPresets(account, device)
+	if err != nil {
+		t.Fatalf("GetPresets: %v", err)
+	}
+
+	if got, want := buttonNumbersOf(presets), []string{"1", "4", "6"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("buttons = %v, want %v", got, want)
+	}
+
+	// Later wins: the newest save is the one the user just made.
+	if presets[2].Name != "Fresh Entry" {
+		t.Errorf("button 6 name = %q, want %q", presets[2].Name, "Fresh Entry")
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read back Presets.xml: %v", err)
+	}
+
+	if n := strings.Count(string(data), `id="6"`); n != 1 {
+		t.Errorf("Presets.xml still has %d entries for button 6, want 1 after the repair:\n%s", n, data)
+	}
+
+	if !strings.Contains(string(data), "Fresh Entry") {
+		t.Errorf("repaired file lost the surviving entry:\n%s", data)
+	}
+}
+
+// The read-only accessor exists for preflight paths that must not mutate
+// datastore state, so it may collapse in memory but must leave the file alone.
+func TestGetPresetsReadOnly_CollapsesWithoutWriting(t *testing.T) {
+	ds, account, device, path := writeDuplicatePresets(t)
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Presets.xml: %v", err)
+	}
+
+	presets, err := ds.GetPresetsReadOnly(account, device)
+	if err != nil {
+		t.Fatalf("GetPresetsReadOnly: %v", err)
+	}
+
+	if got, want := buttonNumbersOf(presets), []string{"1", "4", "6"}; strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("buttons = %v, want %v", got, want)
+	}
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Presets.xml again: %v", err)
+	}
+
+	if string(before) != string(after) {
+		t.Error("GetPresetsReadOnly rewrote Presets.xml; it must not mutate datastore state")
+	}
+}
+
+// The save path is the backstop: no writer may persist two entries for one
+// slot, mirroring SaveRecents and SaveConfiguredSources.
+func TestSavePresets_DedupesByButtonNumber(t *testing.T) {
+	ds, account, device, path := writeDuplicatePresets(t)
+
+	presets := []models.ServicePreset{
+		{
+			ServiceContentItem: models.ServiceContentItem{Name: "Stale Entry", Source: "RADIO_BROWSER"},
+			ID:                 "6",
+			ButtonNumber:       "6",
+		},
+		{
+			ServiceContentItem: models.ServiceContentItem{Name: "Fresh Entry", Source: "RADIO_BROWSER"},
+			ID:                 "6",
+			ButtonNumber:       "6",
+		},
+	}
+
+	if err := ds.SavePresets(account, device, presets); err != nil {
+		t.Fatalf("SavePresets: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Presets.xml: %v", err)
+	}
+
+	if n := strings.Count(string(data), `id="6"`); n != 1 {
+		t.Errorf("wrote %d entries for button 6, want 1:\n%s", n, data)
+	}
+
+	if !strings.Contains(string(data), "Fresh Entry") {
+		t.Errorf("kept the stale entry instead of the newest one:\n%s", data)
+	}
+}

--- a/pkg/service/marge/i715_preset_duplicate_test.go
+++ b/pkg/service/marge/i715_preset_duplicate_test.go
@@ -1,0 +1,95 @@
+package marge
+
+import (
+	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/models"
+)
+
+// Issue 715: UpdatePreset addressed presets by list position, padding the
+// slice to presetNumber and writing presets[presetNumber-1]. On a sparse list
+// that both wrote the wrong entry and appended a second one for a button that
+// already existed, and a preset list longer than the speaker's six slots costs
+// a slot.
+func TestUpsertPresetByButton_GH715(t *testing.T) {
+	preset := func(button, name string) models.ServicePreset {
+		return models.ServicePreset{
+			ServiceContentItem: models.ServiceContentItem{Name: name},
+			ID:                 button,
+			ButtonNumber:       button,
+		}
+	}
+
+	buttons := func(presets []models.ServicePreset) []string {
+		out := make([]string, 0, len(presets))
+		for i := range presets {
+			out = append(out, presets[i].ButtonNumber)
+		}
+
+		return out
+	}
+
+	t.Run("a sparse list does not gain a duplicate", func(t *testing.T) {
+		// Exactly the observed shape: slot 5 empty, save into slot 6.
+		current := []models.ServicePreset{
+			preset("1", "one"), preset("2", "two"), preset("3", "three"),
+			preset("4", "four"), preset("6", "six"),
+		}
+
+		got := upsertPresetByButton(current, preset("6", "six updated"))
+
+		if want := []string{"1", "2", "3", "4", "6"}; !equalStrings(buttons(got), want) {
+			t.Errorf("buttons = %v, want %v", buttons(got), want)
+		}
+
+		if got[4].Name != "six updated" {
+			t.Errorf("button 6 name = %q, want the updated entry", got[4].Name)
+		}
+	})
+
+	t.Run("an unused button is appended", func(t *testing.T) {
+		current := []models.ServicePreset{preset("1", "one"), preset("6", "six")}
+
+		got := upsertPresetByButton(current, preset("5", "five"))
+
+		if want := []string{"1", "6", "5"}; !equalStrings(buttons(got), want) {
+			t.Errorf("buttons = %v, want %v", buttons(got), want)
+		}
+	})
+
+	t.Run("an existing button is replaced in place", func(t *testing.T) {
+		current := []models.ServicePreset{preset("1", "one"), preset("2", "two")}
+
+		got := upsertPresetByButton(current, preset("1", "one updated"))
+
+		if len(got) != 2 {
+			t.Fatalf("len = %d, want 2: replacing must not append", len(got))
+		}
+
+		if got[0].Name != "one updated" || got[0].ButtonNumber != "1" {
+			t.Errorf("entry 0 = %+v, want the updated button 1", got[0])
+		}
+	})
+
+	t.Run("an empty list takes the first entry", func(t *testing.T) {
+		got := upsertPresetByButton(nil, preset("3", "three"))
+
+		if len(got) != 1 || got[0].ButtonNumber != "3" {
+			t.Errorf("got %v, want a single button 3", buttons(got))
+		}
+	})
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/service/marge/marge.go
+++ b/pkg/service/marge/marge.go
@@ -1138,6 +1138,29 @@ func findMatchingSourceForRecent(r *models.ServiceRecent, sources []models.Confi
 // side empty is treated as "no info, allow" (matches pre-fix behaviour for
 // records that lost their Source attribute). Refuse when both are set and
 // disagree — that's the GH-343 cross-type rewrite the speaker reflects.
+// upsertPresetByButton replaces the entry for next's button number, or appends
+// next when that button is not in the list yet.
+//
+// Addressing the preset by button number rather than by list position is the
+// point. UpdatePreset used to pad the slice to presetNumber entries and write
+// presets[presetNumber-1], which assumed the stored list was dense and ordered
+// by button. It need not be: on a list holding buttons [1 2 3 4 6], saving
+// preset 6 padded to six entries and wrote index 5, leaving the original
+// button-6 entry at index 4 — two entries for one slot. The speaker then
+// received more presets than it has slots and dropped one, which is how a
+// preset disappeared from a device whose Presets.xml still held it (issue 715).
+func upsertPresetByButton(presets []models.ServicePreset, next models.ServicePreset) []models.ServicePreset {
+	for i := range presets {
+		if presets[i].ButtonNumber == next.ButtonNumber {
+			presets[i] = next
+
+			return presets
+		}
+	}
+
+	return append(presets, next)
+}
+
 func sourceTypeCompatible(claimed, configured string) bool {
 	if claimed == "" || configured == "" {
 		return true
@@ -1693,13 +1716,7 @@ func UpdatePreset(ds *datastore.DataStore, account, device string, presetNumber 
 	// MutatePresets — this is the exact interleave that dropped a preset
 	// during #614's rapid-fire repro.
 	if _, err = ds.MutatePresets(account, device, func(presets []models.ServicePreset) ([]models.ServicePreset, error) {
-		for len(presets) < presetNumber {
-			presets = append(presets, models.ServicePreset{})
-		}
-
-		presets[presetNumber-1] = presetObj
-
-		return presets, nil
+		return upsertPresetByButton(presets, presetObj), nil
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/service/marge/update_preset_autoadd_test.go
+++ b/pkg/service/marge/update_preset_autoadd_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gesellix/bose-soundtouch/pkg/models"
 	"github.com/gesellix/bose-soundtouch/pkg/service/datastore"
 )
 
@@ -93,12 +94,26 @@ func TestUpdatePreset_AutoAddsCanonicalSource(t *testing.T) {
 		t.Fatalf("GetPresets: %v", err)
 	}
 
-	if len(presets) < 3 {
-		t.Fatalf("expected at least 3 presets stored after UpdatePreset(slot 3), got %d", len(presets))
+	// Saving slot 3 stores exactly one preset. It used to store three, because
+	// UpdatePreset padded the list to the slot's index with empty entries;
+	// addressing presets by button number instead means empty slots are simply
+	// absent, which is also what a speaker's own /presets does (issue 715).
+	var stored *models.ServicePreset
+
+	for i := range presets {
+		if presets[i].ButtonNumber == "3" {
+			stored = &presets[i]
+
+			break
+		}
 	}
 
-	if presets[2].Name != "SMOOTH JAZZ" {
-		t.Errorf("preset 3: expected name SMOOTH JAZZ, got %q", presets[2].Name)
+	if stored == nil {
+		t.Fatalf("expected a preset stored for button 3 after UpdatePreset(slot 3), got %+v", presets)
+	}
+
+	if stored.Name != "SMOOTH JAZZ" {
+		t.Errorf("preset 3: expected name SMOOTH JAZZ, got %q", stored.Name)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes [issue 715](https://github.com/gesellix/Bose-SoundTouch/issues/715), found while verifying the 697 fix on hardware: a device lost a preset slot after a sync, and the account's preset list turned out to hold two entries for button 6. `/full` then carried seven presets for six slots and the speaker dropped one. The vanished preset was present in the `/full` body with its source block intact, so the source-mapping logic was not at fault — the list shape was.

**`UpdatePreset` created the duplicate.** It padded the slice to `presetNumber` entries and wrote `presets[presetNumber-1]`, which assumes the stored list is dense and ordered by button. It need not be: on a list holding buttons `[1 2 3 4 6]`, saving preset 6 padded to six entries and wrote index 5, leaving the original button-6 entry at index 4. It now replaces the entry whose button matches and appends when that button is absent.

**Persisted duplicates are repaired, not filtered on every read.** `readPresetsNoLock` collapses them and sets the `needsRewrite` flag that `GetPresets` already uses to canonicalise the file once, so an affected `Presets.xml` is cleaned on first read. `GetPresetsReadOnly` keeps its no-mutation contract and only collapses in memory. `SavePresets` collapses too, as a backstop mirroring `SaveRecents` and `SaveConfiguredSources`, so no write path can persist two entries for one slot again. Later wins in all three, since the newest save is the one the user just made.

**Presets are now persisted in button order.** Callers address them by button rather than by position, so insertion order would otherwise depend on the order saves arrived in, including concurrent ones. Ordering and duplicate detection both key on `ButtonNumber` falling back to `ID`, the same fallback the writer applies to the `id` attribute.

## Verified on hardware

Full before/after is in the [issue comment](https://github.com/gesellix/Bose-SoundTouch/issues/715#issuecomment-5646284252). In short: a single `/full` read collapsed seven entries to six with the previously lost preset intact, and after restoring that entry to the instance the speaker actually talks to, the speaker repopulated the slot. Read back from the speaker itself: presets 1–6, each exactly once, no duplicate.

One operational note recorded there as well: **recovery must not go through a sync.** The sync path harvests the speaker into the datastore (`SavePresets(accountID, deviceID, incomingPresets)` in `pkg/service/setup/setup.go`), so syncing a device that has already lost a preset overwrites the last copy of it.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Refactor / tests / tooling

## How was it tested?

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `golangci-lint run` (0 issues)
- [x] Verified end to end on a SoundTouch 10 (FW 27.0.6), service on linux/arm64
- [ ] `make check`'s Docker-based HTTP integration leg was not run (daemon down)

New tests cover the collapse and the one-off file repair, that `GetPresetsReadOnly` does not write, the `SavePresets` backstop, and the upsert itself: a sparse list gaining no duplicate, an unused button being appended, an existing button replaced in place.

Two existing tests asserted the padding artefact. The concurrent-update test indexed presets by position, which the new button ordering satisfies unchanged. The auto-add test expected three stored presets after saving slot 3; saving slot 3 now stores exactly one, and an empty slot is simply absent — which is also what a speaker's own `/presets` does.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures
- [x] No documentation change needed: this restores intended behaviour rather than changing it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
