### PR TITLE
fix(service): log an unavailable balance on change, not on every read

### DIFF
--- a/pkg/service/soundtouchweb/websocket.go
+++ b/pkg/service/soundtouchweb/websocket.go
@@ -409,13 +409,22 @@ func (app *WebApp) readBalanceOnce(deviceID string, conn *webtypes.DeviceConnect
 	if !balance.Available {
 		// Log the whole answer, not just the fact of it: the range and target
 		// reported alongside are the evidence for why it is unavailable.
-		log.Printf("Speaker %s: balance reported unavailable (range %d..%d, default %d, target %d, actual %d)",
-			sanitizeLog(deviceID), balance.Min, balance.Max, balance.Default, balance.Target, balance.Actual)
+		//
+		// Only when the state changes. This read runs on every balanceUpdated
+		// frame and every status poll, so a speaker that reports no usable
+		// balance — a standalone unit, most of them — emitted one identical
+		// line per poll, per speaker, and buried everything else in the log.
+		if conn.MarkBalanceUnavailable() {
+			log.Printf("Speaker %s: balance reported unavailable (range %d..%d, default %d, target %d, actual %d)",
+				sanitizeLog(deviceID), balance.Min, balance.Max, balance.Default, balance.Target, balance.Actual)
+		}
 
 		app.clearBalance(conn)
 
 		return
 	}
+
+	conn.MarkBalanceAvailable()
 
 	app.applyBalanceEvent(conn, balance)
 }

--- a/pkg/service/soundtouchweb/webtypes/balance_refresh_test.go
+++ b/pkg/service/soundtouchweb/webtypes/balance_refresh_test.go
@@ -38,6 +38,44 @@ func TestBalanceRefreshCoalesces(t *testing.T) {
 	}
 }
 
+// TestBalanceUnavailableIsLoggedOnChange pins the log gate. A balance read
+// happens on every balanceUpdated frame and every status poll, so a speaker
+// that reports no usable balance — a standalone unit — used to emit one
+// identical line per poll, per speaker.
+func TestBalanceUnavailableIsLoggedOnChange(t *testing.T) {
+	conn := &DeviceConnection{}
+
+	if !conn.MarkBalanceUnavailable() {
+		t.Fatal("the first unavailable reading must be logged")
+	}
+
+	for i := range 5 {
+		if conn.MarkBalanceUnavailable() {
+			t.Errorf("poll %d logged the same unavailable state again", i+2)
+		}
+	}
+
+	// A speaker that starts reporting a usable balance, then stops again, is
+	// worth one more line: the state genuinely changed twice.
+	conn.MarkBalanceAvailable()
+
+	if !conn.MarkBalanceUnavailable() {
+		t.Error("becoming unavailable again was swallowed")
+	}
+}
+
+// A fresh connection has logged nothing yet, so the first available reading
+// must not leave the marker set and swallow a later change.
+func TestBalanceAvailableKeepsTheMarkerClear(t *testing.T) {
+	conn := &DeviceConnection{}
+
+	conn.MarkBalanceAvailable()
+
+	if !conn.MarkBalanceUnavailable() {
+		t.Error("the first unavailable reading after an available one was not logged")
+	}
+}
+
 // TestBalanceRefreshIsRaceFree exercises the CAS loops under concurrency.
 func TestBalanceRefreshIsRaceFree(t *testing.T) {
 	conn := &DeviceConnection{}

--- a/pkg/service/soundtouchweb/webtypes/types.go
+++ b/pkg/service/soundtouchweb/webtypes/types.go
@@ -82,6 +82,14 @@ type DeviceConnection struct {
 	// blocks on a sleeping speaker.
 	balanceRefresh atomic.Int32
 
+	// balanceUnavailableLogged remembers that this speaker's balance has
+	// already been reported as unavailable, so that line is logged when the
+	// state changes rather than on every read. A balance read runs on every
+	// balanceUpdated frame and every status poll, so a speaker that reports
+	// no usable balance produced one identical line per poll, per speaker,
+	// which buried everything else in the log.
+	balanceUnavailableLogged atomic.Bool
+
 	speakerConnectionKnown     bool
 	speakerConnectionConnected bool
 	speakerConnectionObserved  time.Time
@@ -685,6 +693,18 @@ func (c *DeviceConnection) EndBalanceRefresh() bool {
 			}
 		}
 	}
+}
+
+// MarkBalanceUnavailable records that this speaker reports no usable balance,
+// and reports whether that is a change — i.e. whether it is worth logging.
+func (c *DeviceConnection) MarkBalanceUnavailable() bool {
+	return c.balanceUnavailableLogged.CompareAndSwap(false, true)
+}
+
+// MarkBalanceAvailable clears the marker, so a speaker that later stops
+// reporting a usable balance is logged once more rather than silently.
+func (c *DeviceConnection) MarkBalanceAvailable() {
+	c.balanceUnavailableLogged.Store(false)
 }
 
 // ObserveEventStreamTransport applies an authoritative client transport


### PR DESCRIPTION
## Summary

`readBalanceOnce` runs on every `balanceUpdated` frame and on every status poll, and it logged the full unavailable answer each time. A standalone speaker never reports a usable balance, so two of them filled the journal with one identical line every couple of seconds:

```
Speaker 192.0.2.50: balance reported unavailable (range -7..7, default 0, target 0, actual 0)
Speaker 192.0.2.35: balance reported unavailable (range -7..7, default 0, target 0, actual 0)
Speaker 192.0.2.50: balance reported unavailable (range -7..7, default 0, target 0, actual 0)
…
```

That buried everything else, including — while diagnosing [issue 715](https://github.com/gesellix/Bose-SoundTouch/issues/715) on hardware — the lines that actually mattered.

The line now fires when the state changes. `DeviceConnection` remembers that it has already reported this speaker as unavailable, in an `atomic.Bool` alongside the existing `balanceRefresh` coalescing state, and a reading that reports a usable balance clears the marker again so a later regression is still logged once rather than silently.

The answer itself is still logged in full when it is logged: the range and target reported alongside are the evidence for *why* balance is unavailable, which is what made the original line worth having.

Not changed: `balance read failed`, which is an error rather than a steady state, and was not part of the observed noise.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactor / tests / tooling

## How was it tested?

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `go test -race ./pkg/service/soundtouchweb/...`
- [x] `golangci-lint run` (0 issues)
- [x] Observed on hardware: two standalone speakers, one line per poll each, before the change

New tests in `balance_refresh_test.go` pin the gate: the first unavailable reading logs, five further polls do not, and a speaker that becomes available and then unavailable again logs once more. A separate case covers a fresh connection, where an available reading must not leave the marker set and swallow a later change.

## Checklist

- [x] My changes are focused, and I have read the diff myself
- [x] No personal data (real LAN IPs, MAC addresses, device IDs, account IDs) in code, tests, or fixtures — the log sample above uses RFC 5737 addresses
- [x] No documentation change needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
