### PR TITLE
feat(player): save a library item as a preset without playing it first

### DIFF
--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -195,6 +195,7 @@ POST     /api/control/devices/{id}/library/play                       soundtouch
 POST     /api/control/devices/{id}/library/servers                    soundtouchweb.(*WebApp).HandleAddLibraryServer-fm
 POST     /api/control/devices/{id}/play                               soundtouchweb.(*WebApp).HandleDevicePlay-fm
 POST     /api/control/devices/{id}/power                              soundtouchweb.(*WebApp).HandleDevicePower-fm
+POST     /api/control/devices/{id}/preset/{slot}                      soundtouchweb.(*WebApp).HandleStorePresetContent-fm
 POST     /api/control/devices/{id}/providers/radiobrowser/play        soundtouchweb.(*WebApp).HandlePlayRadioBrowser-fm
 POST     /api/control/devices/{id}/providers/tts/play                 soundtouchweb.(*WebApp).HandleAPISpeakText-fm
 POST     /api/control/devices/{id}/providers/tunein/play              soundtouchweb.(*WebApp).HandlePlayTuneIn-fm

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -3280,6 +3280,108 @@ func TestStaleSourcesRemainVisibleButCannotBeSelected(t *testing.T) {
 	}
 }
 
+// TestLibraryRowSavesNamedContentToAPreset covers the issue 700 save button:
+// a Library row stores itself into a slot by naming its content, so nothing
+// has to start playing first. It asserts the request body the row sends (a
+// folder with no type, a track with one), the inline save feedback, and that
+// a row already occupying a slot says so.
+func TestLibraryRowSavesNamedContentToAPreset(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { Library } from '/app/static/js/components/Library.js';
+const status = {
+  revision: 1,
+  presets: { Preset: [{ ID: 3, ContentItem: { Source: 'STORED_MUSIC', Location: '5:audio5:part13:3171:5 TRACK' } }] },
+};
+function Fixture() {
+  const [devices] = useState({ speaker: { info: { device_id: 'DEVICE1', name: 'Speaker' }, status } });
+  return h('section', { id: 'library' }, h(Library, { devices, onPlaybackRequest: () => true }));
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	var stored []string
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/library/servers", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: []any{
+				map[string]any{"udn": "uuid:library", "name": "Media server", "ready": true, "account": "uuid:library/0"},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/library/browse", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"entries": []any{
+					map[string]any{"name": "Some Album", "location": "1$7$0", "type": "dir", "isDir": true, "isPresetable": true},
+					map[string]any{"name": "Great Song", "location": "5:audio5:part13:3171:5 TRACK", "type": "track", "playable": true, "isPresetable": true},
+				},
+			}})
+		})
+		r.Post("/api/control/devices/speaker/preset/{slot}", func(w http.ResponseWriter, req *http.Request) {
+			body, _ := io.ReadAll(req.Body)
+			mu.Lock()
+			stored = append(stored, chi.URLParam(req, "slot")+" "+string(body))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var trackStarTitle string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`#library .tunein-item`, chromedp.ByQuery),
+		// The first list is the registered servers; open it to get the rows.
+		chromedp.Click(`#library .tunein-item`, chromedp.ByQuery),
+		chromedp.WaitVisible(`#library .library-preset-btn`, chromedp.ByQuery),
+
+		// Row 1 is the folder: save it to slot 4 and wait for the ✓.
+		chromedp.Click(`#library .tunein-item:nth-child(1) .library-preset-btn`, chromedp.ByQuery),
+		chromedp.Click(`#library .tunein-item:nth-child(1) .preset-picker-slot:nth-child(4)`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('#library .tunein-item:nth-child(1) .preset-picker-slot.saved')?.textContent === '✓'`, nil),
+
+		// Row 2 is a single track, and it already occupies slot 3, so its star
+		// is marked and says which slot without the popover being opened.
+		chromedp.Evaluate(`document.querySelector('#library .tunein-item:nth-child(2) .library-preset-btn').title`, &trackStarTitle),
+		chromedp.Click(`#library .tunein-item:nth-child(2) .library-preset-btn`, chromedp.ByQuery),
+		chromedp.Click(`#library .tunein-item:nth-child(2) .preset-picker-slot:nth-child(1)`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('#library .tunein-item:nth-child(2) .preset-picker-slot.saved') !== null`, nil),
+	); err != nil {
+		t.Fatalf("save library rows as presets: %v", err)
+	}
+
+	var mappedClass bool
+	if err := chromedp.Run(ctx,
+		chromedp.Evaluate(`document.querySelector('#library .tunein-item:nth-child(2) .library-preset-btn').classList.contains('mapped')`, &mappedClass),
+	); err != nil {
+		t.Fatalf("read mapped star: %v", err)
+	}
+	if !mappedClass {
+		t.Error("a row already saved in a slot should have a mapped star")
+	}
+	if !strings.Contains(trackStarTitle, "preset 3") {
+		t.Errorf("mapped star title = %q, want it to name preset 3", trackStarTitle)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(stored) != 2 {
+		t.Fatalf("store requests = %d (%v), want 2", len(stored), stored)
+	}
+	// The folder: type is sent empty, which is how the speaker stores a
+	// container itself (issue 700 hardware run).
+	for _, want := range []string{`4 `, `"source":"STORED_MUSIC"`, `"sourceAccount":"uuid:library/0"`, `"location":"1$7$0"`, `"type":""`, `"itemName":"Some Album"`} {
+		if !strings.Contains(stored[0], want) {
+			t.Errorf("folder store request should contain %q, got %s", want, stored[0])
+		}
+	}
+	for _, want := range []string{`1 `, `"location":"5:audio5:part13:3171:5 TRACK"`, `"type":"track"`} {
+		if !strings.Contains(stored[1], want) {
+			t.Errorf("track store request should contain %q, got %s", want, stored[1])
+		}
+	}
+}
+
 // TestNowPlayingStarSavesThroughTheSharedPicker renders the now-playing card
 // in Chrome and saves the current content to a slot. The card's star was
 // extracted into the shared PresetPicker for issue 700 and nothing exercised

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -3279,3 +3279,58 @@ func TestStaleSourcesRemainVisibleButCannotBeSelected(t *testing.T) {
 		t.Errorf("empty inventory: hidden=%v staleAnnounced=%v", emptyInventoryHidden, staleEmptyAnnounced)
 	}
 }
+
+// TestNowPlayingStarSavesThroughTheSharedPicker renders the now-playing card
+// in Chrome and saves the current content to a slot. The card's star was
+// extracted into the shared PresetPicker for issue 700 and nothing exercised
+// it in a browser, so two module-level mistakes (a missing import, and the
+// card rendering the shared picker directly with the wrapper's props) went
+// unnoticed: both leave the star gone or inert at runtime.
+func TestNowPlayingStarSavesThroughTheSharedPicker(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { NowPlaying } from '/app/static/js/components/NowPlaying.js';
+const nowPlaying = {
+  Source: 'STORED_MUSIC', PlayStatus: 'PLAY_STATE', Track: 'Great Song',
+  ContentItem: { Source: 'STORED_MUSIC', Location: '5:audio5:part13:3171:5 TRACK', ItemName: 'Great Song' },
+};
+const presets = { Preset: [{ ID: 2, ContentItem: { Source: 'STORED_MUSIC', Location: '5:audio5:part13:3171:5 TRACK' } }] };
+render(h(NowPlaying, { nowPlaying, deviceId: 'speaker', presets }), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	var slots []string
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/action/storepreset", func(w http.ResponseWriter, req *http.Request) {
+			mu.Lock()
+			slots = append(slots, req.URL.Query().Get("id"))
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var starTitle string
+	var mapped bool
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`.now-playing-fav-btn`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelector('.now-playing-fav-btn').title`, &starTitle),
+		chromedp.Evaluate(`document.querySelector('.now-playing-fav-btn').classList.contains('mapped')`, &mapped),
+		chromedp.Click(`.now-playing-fav-btn`, chromedp.ByQuery),
+		chromedp.Click(`.preset-picker-slot:nth-child(5)`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelector('.preset-picker-slot.saved')?.textContent === '✓'`, nil),
+	); err != nil {
+		t.Fatalf("save the now-playing content as a preset: %v", err)
+	}
+
+	if !mapped || !strings.Contains(starTitle, "preset 2") {
+		t.Errorf("now-playing star: mapped=%v title=%q, want it marked and naming preset 2", mapped, starTitle)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(slots) != 1 || slots[0] != "5" {
+		t.Errorf("storepreset calls = %v, want one for slot 5", slots)
+	}
+}

--- a/pkg/service/soundtouchweb/frontend_test/nowPlaying.test.mjs
+++ b/pkg/service/soundtouchweb/frontend_test/nowPlaying.test.mjs
@@ -4,6 +4,8 @@ import test from 'node:test';
 
 const nowPlaying = await readFile(
     new URL('../static/js/components/NowPlaying.js', import.meta.url), 'utf8');
+const presetPicker = await readFile(
+    new URL('../static/js/components/PresetPicker.js', import.meta.url), 'utf8');
 
 // Radio stations carry their logo on the ContentItem rather than in the <art>
 // element, so the now-playing card showed nothing for a TuneIn station whose
@@ -14,7 +16,15 @@ test('the now-playing card falls back to the ContentItem artwork', () => {
 });
 
 // The star used to say only "Saved as preset", leaving you to hunt for which
-// slot it meant.
+// slot it meant. The star itself moved into the shared PresetPicker when the
+// Library rows grew one too (issue 700), so that is where the wording lives.
 test('the preset star names the slot it is saved in', () => {
-    assert.match(nowPlaying, /Saved as preset \$\{mappedPreset\.ID\}/);
+    assert.match(presetPicker, /Saved as preset \$\{mappedSlot\}/);
+});
+
+// The now-playing card keeps its own star styling and slot mapping, and hands
+// them to the shared picker rather than rendering a second popover.
+test('the now-playing card delegates its star to the shared picker', () => {
+    assert.match(nowPlaying, /import \{ PresetPicker \} from '\.\/PresetPicker\.js'/);
+    assert.match(nowPlaying, /mappedSlot=\$\{mappedPreset \? mappedPreset\.ID : null\}/);
 });

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -726,6 +726,87 @@ func (app *WebApp) handleStorePreset(w http.ResponseWriter, r *http.Request, dev
 	app.sendControlResponse(w, err, fmt.Sprintf("Stored current as preset %d", presetID))
 }
 
+// HandleStorePresetContent stores an explicitly named ContentItem in a preset
+// slot, without requiring that content to be playing first.
+//
+// The speaker's own /storePreset endpoint takes the ContentItem, so naming the
+// content is enough — the same path `soundtouch-cli preset store` has always
+// used. handleStorePreset above reaches for StoreCurrentAsPreset, which reads
+// /now_playing instead, and that is the only reason saving something from a
+// browser used to require playing it first (issue 700).
+//
+// Verified on hardware for the awkward case, a STORED_MUSIC folder: the
+// speaker accepted a ContentItem carrying no type attribute at all, and
+// recalling the preset played the folder from its first track. The speaker
+// then PUT the new preset back to AfterTouch's marge endpoint on its own, so
+// the datastore picks it up without this handler writing anything.
+func (app *WebApp) HandleStorePresetContent(w http.ResponseWriter, r *http.Request) {
+	deviceID := chi.URLParam(r, "id")
+
+	device, exists := app.GetDevice(deviceID)
+	if !exists {
+		app.sendError(w, "Device not found", http.StatusNotFound)
+		return
+	}
+
+	if device.Client == nil {
+		app.sendError(w, "Device client not available", http.StatusInternalServerError)
+		return
+	}
+
+	slot, err := strconv.Atoi(chi.URLParam(r, "slot"))
+	if err != nil || slot < 1 || slot > 6 {
+		app.sendError(w, "Preset slot must be between 1 and 6", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Source        string `json:"source"`
+		Type          string `json:"type"`
+		Location      string `json:"location"`
+		SourceAccount string `json:"sourceAccount"`
+		ItemName      string `json:"itemName"`
+		ContainerArt  string `json:"containerArt"`
+	}
+
+	if decErr := json.NewDecoder(r.Body).Decode(&req); decErr != nil {
+		app.sendError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Source == "" {
+		app.sendError(w, "source is required", http.StatusBadRequest)
+		return
+	}
+
+	if req.Location == "" {
+		app.sendError(w, "location is required", http.StatusBadRequest)
+		return
+	}
+
+	contentItem := &models.ContentItem{
+		Source:       req.Source,
+		Type:         req.Type,
+		Location:     req.Location,
+		ItemName:     req.ItemName,
+		ContainerArt: req.ContainerArt,
+		// A preset the speaker stores for itself is presetable by definition;
+		// saying otherwise would have it refuse its own entry on recall.
+		IsPresetable: true,
+	}
+
+	// Only pass SourceAccount when it's a real credential, not the placeholder
+	// value speakers echo back (source name == source account, e.g. "TUNEIN").
+	if req.SourceAccount != "" && req.SourceAccount != req.Source {
+		contentItem.SourceAccount = req.SourceAccount
+	}
+
+	logPlaybackRequest("store-preset", deviceID, contentItem.Source, contentItem.SourceAccount, contentItem.Location, contentItem.ItemName)
+
+	err = device.Client.StorePreset(slot, contentItem)
+	app.sendControlResponse(w, err, fmt.Sprintf("Stored %s as preset %d", req.Source, slot))
+}
+
 // handleBassControl processes bass control requests
 func (app *WebApp) handleBassControl(w http.ResponseWriter, r *http.Request, device *webtypes.DeviceConnection) {
 	if r.Method != http.MethodPost {

--- a/pkg/service/soundtouchweb/handler_storepreset_test.go
+++ b/pkg/service/soundtouchweb/handler_storepreset_test.go
@@ -1,0 +1,198 @@
+package soundtouchweb
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// The /storePreset body shape below is not invented: it was measured against a
+// SoundTouch 10 (FW 27.0.6) for issue 700. The speaker accepts an arbitrary
+// ContentItem, so a Library row can be saved to a slot without playing it
+// first, and it accepts a STORED_MUSIC folder whose ContentItem carries *no*
+// type attribute at all, which is exactly how the speaker stores one itself.
+// Recall then plays the folder from offset 0.
+
+// TestHandleStorePresetContent_XMLShape asserts the ContentItem the handler
+// posts to /storePreset: the named content, marked presetable, with the folder
+// case carrying no type attribute.
+func TestHandleStorePresetContent_XMLShape(t *testing.T) {
+	speaker, captured := setupSpeakerMock(t, nil)
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	body := strings.NewReader(`{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "uuid:test-udn/0",
+		"location":      "1$7$0",
+		"type":          "",
+		"itemName":      "Some Album"
+	}`)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/preset/6", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": "lib-device", "slot": "6"})
+	w := httptest.NewRecorder()
+
+	app.HandleStorePresetContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	storeXML := captured["/storePreset"]
+	if storeXML == "" {
+		t.Fatal("speaker /storePreset was never called")
+	}
+
+	for _, want := range []string{
+		`id="6"`,
+		`source="STORED_MUSIC"`,
+		`sourceAccount="uuid:test-udn/0"`,
+		`location="1$7$0"`,
+		`isPresetable="true"`,
+		`<itemName>Some Album</itemName>`,
+	} {
+		if !strings.Contains(storeXML, want) {
+			t.Errorf("storePreset XML should contain %q, got:\n%s", want, storeXML)
+		}
+	}
+
+	// A container carries no type. models.ContentItem always marshals the
+	// attribute, so it goes out empty rather than absent; the speaker accepted
+	// that form for the folder above (issue 700 hardware run).
+	if want := `type=""`; !strings.Contains(storeXML, want) {
+		t.Errorf("storePreset XML should contain %q for a folder, got:\n%s", want, storeXML)
+	}
+}
+
+// TestHandleStorePresetContent_KeepsTrackType checks the non-container case
+// still carries the type, so a single track is recalled as a track.
+func TestHandleStorePresetContent_KeepsTrackType(t *testing.T) {
+	speaker, captured := setupSpeakerMock(t, nil)
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	body := strings.NewReader(`{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "uuid:test-udn/0",
+		"location":      "5:audio5:part13:3171:5 TRACK",
+		"type":          "track",
+		"itemName":      "Great Song"
+	}`)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/preset/2", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": "lib-device", "slot": "2"})
+	w := httptest.NewRecorder()
+
+	app.HandleStorePresetContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if want := `type="track"`; !strings.Contains(captured["/storePreset"], want) {
+		t.Errorf("storePreset XML should contain %q, got:\n%s", want, captured["/storePreset"])
+	}
+}
+
+// TestHandleStorePresetContent_DropsPlaceholderAccount covers the pattern
+// where a speaker echoes the source name back as the account when there is no
+// credential (see the SourceAccount placeholder fix, PR 376): storing that
+// value would persist a fake account, so it is dropped.
+func TestHandleStorePresetContent_DropsPlaceholderAccount(t *testing.T) {
+	speaker, captured := setupSpeakerMock(t, nil)
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	body := strings.NewReader(`{
+		"source":        "TUNEIN",
+		"sourceAccount": "TUNEIN",
+		"location":      "/v1/playback/station/s12345",
+		"itemName":      "Some Station"
+	}`)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/preset/1", body)
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": "lib-device", "slot": "1"})
+	w := httptest.NewRecorder()
+
+	app.HandleStorePresetContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if strings.Contains(captured["/storePreset"], `sourceAccount="TUNEIN"`) {
+		t.Errorf("placeholder sourceAccount should be dropped, got:\n%s", captured["/storePreset"])
+	}
+}
+
+// TestHandleStorePresetContent_Rejects verifies the input guards run before
+// any speaker call: an out-of-range slot and the two required fields.
+func TestHandleStorePresetContent_Rejects(t *testing.T) {
+	tests := []struct {
+		name string
+		slot string
+		body string
+	}{
+		{"slot zero", "0", `{"source":"STORED_MUSIC","location":"1$7$0"}`},
+		{"slot seven", "7", `{"source":"STORED_MUSIC","location":"1$7$0"}`},
+		{"slot not a number", "x", `{"source":"STORED_MUSIC","location":"1$7$0"}`},
+		{"no source", "1", `{"location":"1$7$0"}`},
+		{"no location", "1", `{"source":"STORED_MUSIC"}`},
+		{"unparseable body", "1", `not json`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			speaker, captured := setupSpeakerMock(t, nil)
+			defer speaker.Close()
+
+			app := newLibraryTestApp(speaker.URL)
+
+			req := httptest.NewRequest("POST", "/api/control/devices/lib-device/preset/"+tt.slot, strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			req = withChiParams(req, map[string]string{"id": "lib-device", "slot": tt.slot})
+			w := httptest.NewRecorder()
+
+			app.HandleStorePresetContent(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+			}
+
+			// 400 must mean the command never reached the speaker: the player's
+			// checkedReq treats 4xx as definitive proof of exactly that.
+			if _, called := captured["/storePreset"]; called {
+				t.Error("speaker /storePreset must not be called on a rejected request")
+			}
+		})
+	}
+}
+
+// TestHandleStorePresetContent_UnknownDevice keeps the 404 distinct from the
+// validation failures above.
+func TestHandleStorePresetContent_UnknownDevice(t *testing.T) {
+	speaker, _ := setupSpeakerMock(t, nil)
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/nope/preset/1",
+		strings.NewReader(`{"source":"STORED_MUSIC","location":"1$7$0"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": "nope", "slot": "1"})
+	w := httptest.NewRecorder()
+
+	app.HandleStorePresetContent(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -75,6 +75,9 @@ func (app *WebApp) MountWeb(r chi.Router, discoveryService *discovery.UnifiedDis
 				r.Get("/now-playing", app.HandleDeviceNowPlaying)
 				// Low-level "play this ContentItem" primitive (not a provider).
 				r.Post("/play", app.HandleDevicePlay)
+				// Low-level "store this ContentItem in a slot" primitive. The
+				// /action/storepreset form stores whatever is playing instead.
+				r.Post("/preset/{slot}", app.HandleStorePresetContent)
 				// Generic key / preset / source / bass actions. Source selection is
 				// canonically POSTed as JSON; its GET form remains temporarily for
 				// compatibility and marks every response as deprecated.

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -73,6 +73,8 @@ func TestMountWebControlAPIShape(t *testing.T) {
 		"/api/control/devices/{id}/providers/url/play",
 		"/api/control/devices/{id}/providers/tts/play",
 		"/api/control/devices/{id}/stereo-pair/",
+		// The named-content preset store (issue 700), sibling of /play.
+		"/api/control/devices/{id}/preset/{slot}",
 	}
 	for _, want := range mustExist {
 		if !registered[want] {

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -678,6 +678,26 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 .preset-picker-slot.saved  { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
 .preset-picker-slot.error  { border-color: var(--danger); color: var(--danger); }
 
+/* Library rows reuse the picker overlay above. The star sits beside the row's
+   play button, so it is sized like that button, wears the gold --fav colour
+   the other save gestures use, and its popover hangs off the right edge
+   because the controls are right-aligned in the row. */
+.library-preset-wrap { position: relative; display: inline-flex; flex-shrink: 0; }
+.library-preset-btn {
+    background: transparent;
+    border: 1px solid var(--text-dim);
+    color: var(--text-dim);
+    border-radius: 999px;
+    width: 32px; height: 32px;
+    display: inline-flex; align-items: center; justify-content: center;
+    cursor: pointer; flex-shrink: 0;
+    font-size: .8rem; line-height: 1; padding: 0;
+    transition: background .15s, border-color .15s, color .15s;
+}
+.library-preset-btn:hover, .library-preset-btn.open { border-color: var(--fav); color: var(--fav); }
+.library-preset-btn.mapped { color: var(--fav); border-color: var(--fav); }
+.library-preset-wrap .preset-picker-overlay { right: 0; left: auto; }
+
 /* ── Presets ─────────────────────────────────────────────────────────────── */
 .presets-section, .sources-section { margin-top: 1.25rem; }
 .section-title { font-size: .8rem; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; color: var(--text-dim); margin-bottom: .6rem; }

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -107,6 +107,13 @@ export const api = {
     control: (id, action, presetId) => req(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
     controlChecked: (id, action, presetId) => checkedReq(`/api/control/devices/${id}/action/${action}?id=${presetId}`),
     storePreset: (id, slotId) => req(`/api/control/devices/${id}/action/storepreset?id=${slotId}`),
+    // Stores named content rather than whatever is playing, so a Library row
+    // can be saved to a slot without interrupting playback (issue 700).
+    storePresetContent: (id, slotId, item) => req(`/api/control/devices/${id}/preset/${slotId}`, {
+        method: 'POST',
+        headers: JSON_HEADERS,
+        body: JSON.stringify(item),
+    }),
     selectSource: (id, source, account) => checkedReq(`/api/control/devices/${id}/action/source`, {
         method: 'POST',
         headers: JSON_HEADERS,

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -2,6 +2,7 @@ import { h } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
+import { PresetPicker } from './PresetPicker.js';
 
 const html = htm.bind(h);
 
@@ -140,6 +141,42 @@ export function Library({
                 itemName: entry.name,
             },
         });
+    }
+
+    // Saving a row to a preset names the content rather than storing whatever
+    // is playing, so nothing has to be interrupted first (issue 700). The
+    // speaker accepts a folder ContentItem with no type attribute at all —
+    // that is how it stores one itself — so the type is sent only for items
+    // that are not containers.
+    function savePresetFor(entry, slot) {
+        const account = server?.account;
+
+        if (!deviceId || !account || !entry?.location) {
+            return Promise.reject(new Error('no device, server or location'));
+        }
+
+        return api.storePresetContent(deviceId, slot, {
+            source: 'STORED_MUSIC',
+            sourceAccount: account,
+            location: entry.location,
+            type: entry.isDir ? '' : (entry.type || 'track'),
+            itemName: entry.name,
+        }).then(res => {
+            if (!res?.success) throw new Error(res?.error || 'preset save failed');
+        });
+    }
+
+    // The slot this row already occupies, if any, so the star can say so.
+    const presetList = devices[deviceId]?.status?.presets?.Preset ?? [];
+
+    function mappedSlotFor(entry) {
+        const match = entry?.location
+            ? presetList.find(p =>
+                p.ContentItem?.Source === 'STORED_MUSIC' &&
+                p.ContentItem?.Location === entry.location)
+            : undefined;
+
+        return match ? match.ID : null;
     }
 
     function toggleFinding() {
@@ -288,6 +325,14 @@ export function Library({
                                         disabled=${playbackBusy}
                                         onClick=${(e) => { e.stopPropagation(); playEntry(entry); }}
                                     >▶</button>
+                                    <${PresetPicker}
+                                        onSave=${slot => savePresetFor(entry, slot)}
+                                        mappedSlot=${mappedSlotFor(entry)}
+                                        label=${entry.isDir ? 'Save folder as preset' : 'Save as preset'}
+                                        wrapClass="library-preset-wrap"
+                                        buttonClass="library-preset-btn"
+                                        overlayClass="preset-picker-overlay"
+                                    />
                                 ` : null}
                                 ${entry.isDir ? html`<span class="tunein-item-arrow">›</span>` : null}
                             </li>

--- a/pkg/service/soundtouchweb/static/js/components/NowPlaying.js
+++ b/pkg/service/soundtouchweb/static/js/components/NowPlaying.js
@@ -1,8 +1,9 @@
 import { h } from 'preact';
-import { useState, useEffect, useRef } from 'preact/hooks';
+import { useState, useEffect } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
 import { SourceIcon } from '../sourceIcons.js';
+import { PresetPicker } from './PresetPicker.js';
 
 const html = htm.bind(h);
 
@@ -13,19 +14,17 @@ function fmt(secs) {
     return `${m}:${s.toString().padStart(2, '0')}`;
 }
 
-// PresetPicker — ★ star button in the top-right corner of the now-playing card.
-// Translucent when nothing is mapped; golden when the current content already
-// exists in one of the device's presets, in which case the tooltip names the
-// slot.  Click to open a slot picker (1–6).
-function PresetPicker({ deviceId, nowPlaying, presets }) {
-    const [open, setOpen] = useState(false);
-    const [savingSlot, setSavingSlot] = useState(null);
-    const [savedSlot, setSavedSlot] = useState(null);
-    const [errorSlot, setErrorSlot] = useState(null);
-    const wrapRef = useRef(null);
-
+// NowPlayingPresetPicker — the ★ star button in the top-right corner of the
+// now-playing card. Translucent when nothing is mapped; golden when the
+// current content already exists in one of the device's presets, in which
+// case the tooltip names the slot.
+//
+// The popover itself lives in PresetPicker, shared with the Library rows
+// (issue 700). Here the store is a single request against whatever is already
+// playing, so its result is known immediately and shown inline.
+function NowPlayingPresetPicker({ deviceId, nowPlaying, presets }) {
     // Detect whether the current content is already saved as any preset.
-    const currentSource   = nowPlaying?.ContentItem?.Source;
+    const currentSource = nowPlaying?.ContentItem?.Source;
     const currentLocation = nowPlaying?.ContentItem?.Location;
     const presetList = presets?.Preset ?? [];
     // Keep the matching preset, not just a boolean, so the tooltip can name
@@ -33,67 +32,22 @@ function PresetPicker({ deviceId, nowPlaying, presets }) {
     const mappedPreset = currentLocation
         ? presetList.find(p =>
             p.ContentItem?.Location === currentLocation &&
-            p.ContentItem?.Source   === currentSource)
+            p.ContentItem?.Source === currentSource)
         : undefined;
-    const isMapped = !!mappedPreset;
-    const favTitle = isMapped
-        ? `Saved as preset ${mappedPreset.ID}. Save again to update.`
-        : 'Save as preset';
-
-    // Close popover on outside click.
-    useEffect(() => {
-        if (!open) return;
-        function onDocClick(e) {
-            if (!wrapRef.current?.contains(e.target)) setOpen(false);
-        }
-        document.addEventListener('click', onDocClick, true);
-        return () => document.removeEventListener('click', onDocClick, true);
-    }, [open]);
-
-    // Mirrors the feedback the preset tiles give (see Presets.js): a failed
-    // save used to close the overlay silently, which looked identical to a
-    // successful one.
-    function finish(setter, slotId) {
-        setSavingSlot(null);
-        setter(slotId);
-        setTimeout(() => {
-            setter(null);
-            setOpen(false);
-        }, 900);
-    }
 
     function save(slotId) {
-        setSavingSlot(slotId);
-        api.storePreset(deviceId, slotId)
-            .then(res => finish(res.success ? setSavedSlot : setErrorSlot, slotId))
-            .catch(() => finish(setErrorSlot, slotId));
+        return api.storePreset(deviceId, slotId).then(res => {
+            if (!res?.success) throw new Error(res?.error || 'preset save failed');
+        });
     }
 
-    return html`
-        <div class="now-playing-fav-wrap" ref=${wrapRef}>
-            <button
-                class="now-playing-fav-btn ${isMapped ? 'mapped' : ''} ${open ? 'open' : ''}"
-                onClick=${() => setOpen(o => !o)}
-                title=${favTitle}
-                aria-label=${favTitle}
-            >★</button>
-            ${open && html`
-                <div class="now-playing-fav-overlay">
-                    <div class="preset-picker-label">Save as preset</div>
-                    <div class="preset-picker-slots">
-                        ${[1, 2, 3, 4, 5, 6].map(n => html`
-                            <button
-                                key=${n}
-                                class="preset-picker-slot ${savingSlot === n ? 'saving' : savedSlot === n ? 'saved' : errorSlot === n ? 'error' : ''}"
-                                onClick=${() => save(n)}
-                                disabled=${savingSlot !== null}
-                            >${savedSlot === n ? '✓' : errorSlot === n ? '✗' : n}</button>
-                        `)}
-                    </div>
-                </div>
-            `}
-        </div>
-    `;
+    return html`<${PresetPicker}
+        onSave=${save}
+        mappedSlot=${mappedPreset ? mappedPreset.ID : null}
+        wrapClass="now-playing-fav-wrap"
+        buttonClass="now-playing-fav-btn"
+        overlayClass="now-playing-fav-overlay"
+    />`;
 }
 
 export function NowPlaying({ nowPlaying, deviceId, presets }) {
@@ -161,7 +115,7 @@ export function NowPlaying({ nowPlaying, deviceId, presets }) {
                 `}
             </div>
             ${deviceId && html`
-                <${PresetPicker}
+                <${NowPlayingPresetPicker}
                     deviceId=${deviceId}
                     nowPlaying=${nowPlaying}
                     presets=${presets}

--- a/pkg/service/soundtouchweb/static/js/components/PresetPicker.js
+++ b/pkg/service/soundtouchweb/static/js/components/PresetPicker.js
@@ -1,0 +1,104 @@
+import { h } from 'preact';
+import { useState, useEffect, useRef } from 'preact/hooks';
+import htm from 'htm';
+
+const html = htm.bind(h);
+
+const SLOTS = [1, 2, 3, 4, 5, 6];
+
+// PresetPicker is the ★ button plus its 1–6 slot popover, shared by the
+// now-playing card and the Library rows (issue 700). It owns the popover
+// state and the save feedback; what a save *does* is the caller's business.
+//
+// onSave(slot) may return a thenable, in which case the picker shows the
+// saving / ✓ / ✗ feedback inline: both current callers do, because the store
+// is a single request whose result is known immediately. A caller that
+// returns nothing is saying the outcome will be reported elsewhere (e.g. by a
+// playback banner), so the picker only closes.
+export function PresetPicker({
+    onSave,
+    mappedSlot = null,
+    label = 'Save as preset',
+    title,
+    wrapClass = 'preset-picker-wrap',
+    buttonClass = 'preset-picker-btn',
+    overlayClass = 'preset-picker-overlay',
+}) {
+    const [open, setOpen] = useState(false);
+    const [savingSlot, setSavingSlot] = useState(null);
+    const [savedSlot, setSavedSlot] = useState(null);
+    const [errorSlot, setErrorSlot] = useState(null);
+    const wrapRef = useRef(null);
+
+    // Close the popover on an outside click.
+    useEffect(() => {
+        if (!open) return;
+
+        function onDocClick(e) {
+            if (!wrapRef.current?.contains(e.target)) setOpen(false);
+        }
+
+        document.addEventListener('click', onDocClick, true);
+
+        return () => document.removeEventListener('click', onDocClick, true);
+    }, [open]);
+
+    // Mirrors the feedback the preset tiles give (see Presets.js): a failed
+    // save used to close the overlay silently, which looked identical to a
+    // successful one.
+    function finish(setter, slotId) {
+        setSavingSlot(null);
+        setter(slotId);
+        setTimeout(() => {
+            setter(null);
+            setOpen(false);
+        }, 900);
+    }
+
+    function save(slotId) {
+        const pending = onSave?.(slotId);
+
+        if (!pending?.then) {
+            // The caller reports the outcome itself.
+            setOpen(false);
+
+            return;
+        }
+
+        setSavingSlot(slotId);
+        pending
+            .then(() => finish(setSavedSlot, slotId))
+            .catch(() => finish(setErrorSlot, slotId));
+    }
+
+    const isMapped = mappedSlot !== null && mappedSlot !== undefined;
+    const buttonTitle = title || (isMapped
+        ? `Saved as preset ${mappedSlot}. Save again to update.`
+        : label);
+
+    return html`
+        <div class=${wrapClass} ref=${wrapRef}>
+            <button
+                class="${buttonClass} ${isMapped ? 'mapped' : ''} ${open ? 'open' : ''}"
+                onClick=${e => { e.stopPropagation(); setOpen(o => !o); }}
+                title=${buttonTitle}
+                aria-label=${buttonTitle}
+            >★</button>
+            ${open && html`
+                <div class=${overlayClass}>
+                    <div class="preset-picker-label">${label}</div>
+                    <div class="preset-picker-slots">
+                        ${SLOTS.map(n => html`
+                            <button
+                                key=${n}
+                                class="preset-picker-slot ${savingSlot === n ? 'saving' : savedSlot === n ? 'saved' : errorSlot === n ? 'error' : ''}"
+                                onClick=${e => { e.stopPropagation(); save(n); }}
+                                disabled=${savingSlot !== null}
+                            >${savedSlot === n ? '✓' : errorSlot === n ? '✗' : n}</button>
+                        `)}
+                    </div>
+                </div>
+            `}
+        </div>
+    `;
+}


### PR DESCRIPTION
Closes https://github.com/gesellix/Bose-SoundTouch/issues/700

The Library rows had no way to save an item as a preset. The existing store path (`/action/storepreset`) saves whatever is playing, so saving a folder meant interrupting playback, starting the folder, then pressing the star on the now-playing card.

That turns out to be unnecessary. The speaker's own `/storePreset` accepts an arbitrary ContentItem. Measured against a SoundTouch 10 (FW 27.0.6):

- a STORED_MUSIC folder stored with no type at all is accepted
- recall plays the folder from offset 0
- the speaker then PUTs the preset back to AfterTouch itself, so nothing has to be written on our side

So every Library row gets a preset star, backed by a new `POST /api/control/devices/{id}/preset/{slot}` that names the content to store. Containers are sent without a type, mirroring how the speaker stores one itself; single items keep theirs. A row that already occupies a slot says which one.

## Commits

1. `refactor(player): extract the preset star into a shared component` — the now-playing card's star, its 1-6 popover, the save feedback and the "already saved in slot N" marking move into `PresetPicker`, which the Library rows then reuse. What a save *does* stays with the caller. The card keeps its own styling through class-name props, so nothing changes visually. This commit also adds the browser test the card's star never had: the extraction is exactly the kind of change that leaves a star missing or inert at runtime while every source-level test still passes (it caught two such mistakes while being written).
2. `feat(player): save a library item as a preset without playing it first` — the endpoint, the route, the API call and the star on each row.

## Tests

- Handler tests for the `/storePreset` body against a fake speaker: the folder shape, the track shape, the placeholder-account drop (a speaker echoing the source name back as the account), the 400 guards (each asserting the speaker is never called, since the player treats 4xx as proof of that), and the 404.
- The new route in the mount snapshot test and in the service router snapshot.
- Browser tests for a Library row save and for the now-playing star, both verified failing without their fix.

`make check`, `make lint` and the browser suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)