### PR TITLE
feat(player): store album art with a library preset

### DIFF
--- a/docs/content/docs/appendix/NAVIGATION-GUIDE.md
+++ b/docs/content/docs/appendix/NAVIGATION-GUIDE.md
@@ -120,9 +120,24 @@ agreed, and three details matter to anyone parsing this by hand:
   element on the item (`dir`, `track`). Anything reconstructing a ContentItem
   for `/select` has to supply the type itself.
 
+- **No artwork, anywhere.** Neither the item nor its ContentItem carries a
+  `containerArt`, on any of the servers measured. The cover you see while a
+  library track plays comes from the speaker resolving the media server's own
+  metadata at play time, which is why a folder saved to a preset straight from
+  a navigate result has no art unless the caller supplies it.
+
 Location tokens are opaque and server-specific (`4:cont1:20:0:0:` on one
 server, `1` on another) and index-dependent, so they can break when the media
 server reindexes.
+
+They are, however, the media server's own DLNA object IDs: a container's
+location is its object ID verbatim, and a playable item's is the object ID plus
+a ` TRACK` suffix. Measured on MiniDLNA (album `1$6$7$2`, track
+`1$6$7$2$5 TRACK`) and a FRITZ!Box (container `4:cont2:150:0:0:`, track
+`5:audio5:part13:3171:5 TRACK`). That is what lets AfterTouch ask the media
+server directly about an item the speaker named, e.g. for the album art the
+navigate response omits (`pkg/dlna.Metadata`, a ContentDirectory
+`BrowseMetadata` call).
 
 ### Navigate Into Directories
 

--- a/pkg/discovery/mediaserver.go
+++ b/pkg/discovery/mediaserver.go
@@ -117,6 +117,26 @@ func DiscoverMediaServers(ctx context.Context, timeout time.Duration) ([]MediaSe
 	return out, nil
 }
 
+// MediaServerAt resolves a single media server from the URL of its UPnP root
+// description, skipping SSDP entirely. A SoundTouch speaker already reports
+// that URL for every server it knows (/listMediaServers -> location), so a
+// caller holding a speaker's own list can reach a server's ContentDirectory
+// without sweeping the LAN, which is both slower and blind to anything the
+// service host cannot see but the speaker can.
+//
+// ok=false means the description parsed but exposes no ContentDirectory, i.e.
+// the device is not a usable media server.
+func MediaServerAt(ctx context.Context, location string) (MediaServer, bool, error) {
+	desc, err := FetchDescription(ctx, location)
+	if err != nil {
+		return MediaServer{}, false, err
+	}
+
+	srv, ok := mediaServerFromDescription(desc)
+
+	return srv, ok, nil
+}
+
 // mediaServerFromDescription maps a parsed Description to a MediaServer.
 // Returns ok=false when the description does not expose a ContentDirectory
 // service (i.e. the device is not a usable DLNA media server).

--- a/pkg/dlna/browse.go
+++ b/pkg/dlna/browse.go
@@ -31,6 +31,12 @@ type Container struct {
 	ParentID   string
 	Title      string
 	ChildCount int
+	// AlbumArtURL is the container's own cover, which album containers
+	// generally carry: MiniDLNA reports it on every musicAlbum container (but
+	// not on its synthetic "- All Albums -" node). It is the only source of
+	// art for a folder, since a SoundTouch speaker's /navigate response
+	// carries no artwork at all.
+	AlbumArtURL string
 }
 
 // Item is a single playable object (track, photo, video). Use IsAudioItem to
@@ -64,16 +70,29 @@ func (it Item) IsAudioItem() bool {
 // objectID "0" is the server root. start is the page offset, count the page
 // size (0 defaults to 50 on the caller side so the request is always bounded).
 func Browse(ctx context.Context, srv discovery.MediaServer, objectID string, start, count int) (BrowseResult, error) {
+	if count <= 0 {
+		count = 50
+	}
+
+	return browse(ctx, srv, objectID, "BrowseDirectChildren", start, count)
+}
+
+// Metadata calls ContentDirectory:Browse with BrowseMetadata, which describes
+// one object rather than listing its children. The result holds exactly one
+// container or one item, so it is the cheapest way to answer a question about
+// a single known object ID (e.g. "what is this album's cover?") without
+// paging through its parent.
+func Metadata(ctx context.Context, srv discovery.MediaServer, objectID string) (BrowseResult, error) {
+	return browse(ctx, srv, objectID, "BrowseMetadata", 0, 1)
+}
+
+func browse(ctx context.Context, srv discovery.MediaServer, objectID, flag string, start, count int) (BrowseResult, error) {
 	if srv.CDSControlURL == "" {
 		return BrowseResult{}, fmt.Errorf("dlna: server %q has no ContentDirectory control URL", srv.FriendlyName)
 	}
 
 	if objectID == "" {
 		objectID = "0"
-	}
-
-	if count <= 0 {
-		count = 50
 	}
 
 	body := fmt.Sprintf(
@@ -83,7 +102,7 @@ func Browse(ctx context.Context, srv discovery.MediaServer, objectID string, sta
 			`<s:Body>`+
 			`<u:Browse xmlns:u="urn:schemas-upnp-org:service:ContentDirectory:1">`+
 			`<ObjectID>%s</ObjectID>`+
-			`<BrowseFlag>BrowseDirectChildren</BrowseFlag>`+
+			`<BrowseFlag>%s</BrowseFlag>`+
 			`<Filter>*</Filter>`+
 			`<StartingIndex>%d</StartingIndex>`+
 			`<RequestedCount>%d</RequestedCount>`+
@@ -91,7 +110,7 @@ func Browse(ctx context.Context, srv discovery.MediaServer, objectID string, sta
 			`</u:Browse>`+
 			`</s:Body>`+
 			`</s:Envelope>`,
-		xmlEscape(objectID), start, count,
+		xmlEscape(objectID), flag, start, count,
 	)
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.CDSControlURL, strings.NewReader(body))
@@ -146,6 +165,7 @@ type didlContainer struct {
 	ParentID   string `xml:"parentID,attr"`
 	ChildCount int    `xml:"childCount,attr"`
 	Title      string `xml:"title"`
+	AlbumArt   string `xml:"albumArtURI"`
 }
 
 type didlItem struct {
@@ -197,10 +217,11 @@ func parseBrowseResponse(raw []byte) (BrowseResult, error) {
 
 	for _, c := range didl.Containers {
 		out.Containers = append(out.Containers, Container{
-			ID:         c.ID,
-			ParentID:   c.ParentID,
-			Title:      c.Title,
-			ChildCount: c.ChildCount,
+			ID:          c.ID,
+			ParentID:    c.ParentID,
+			Title:       c.Title,
+			ChildCount:  c.ChildCount,
+			AlbumArtURL: strings.TrimSpace(c.AlbumArt),
 		})
 	}
 

--- a/pkg/dlna/browse_test.go
+++ b/pkg/dlna/browse_test.go
@@ -252,3 +252,69 @@ func TestIsAudioItem(t *testing.T) {
 		}
 	}
 }
+
+// TestMetadata_ContainerAlbumArt covers the single-object lookup and the
+// container's own artwork. Both exist for the same reason: a SoundTouch
+// speaker's /navigate response carries no artwork at all (measured on
+// hardware), so saving a library folder as a preset has to ask the media
+// server, and a container's albumArtURI is the only art a folder has.
+//
+// BrowseMetadata is the cheap way to ask, since it describes exactly the one
+// object whose ID we already hold.
+func TestMetadata_ContainerAlbumArt(t *testing.T) {
+	tree := &dlnatest.Tree{Containers: []*dlnatest.Container{{
+		ID:         "1$6$7$2",
+		ParentID:   "1$6$7",
+		Title:      "Some Album",
+		Class:      "object.container.album.musicAlbum",
+		ArtPayload: []byte{0x89, 'P', 'N', 'G'},
+		ArtMime:    "image/png",
+		Children: []*dlnatest.Item{{
+			ID:         "1$6$7$2$5",
+			ParentID:   "1$6$7$2",
+			Title:      "Great Song",
+			Class:      "object.item.audioItem.musicTrack",
+			MimeType:   "audio/mpeg",
+			ArtPayload: []byte{0x89, 'P', 'N', 'G'},
+			ArtMime:    "image/jpeg",
+		}},
+	}}}
+
+	ts, _ := dlnatest.NewHTTPTest(dlnatest.WithTree(tree))
+	defer ts.Close()
+
+	srv := discovery.MediaServer{
+		FriendlyName:  "Test Server",
+		CDSControlURL: ts.URL + "/ctl/ContentDir",
+	}
+
+	ctx := context.Background()
+
+	container, err := dlna.Metadata(ctx, srv, "1$6$7$2")
+	if err != nil {
+		t.Fatalf("Metadata container: %v", err)
+	}
+
+	if len(container.Containers) != 1 || len(container.Items) != 0 {
+		t.Fatalf("Metadata container: got %d containers / %d items, want exactly 1 container",
+			len(container.Containers), len(container.Items))
+	}
+
+	if art := container.Containers[0].AlbumArtURL; art == "" {
+		t.Error("container metadata carries no AlbumArtURL")
+	}
+
+	item, err := dlna.Metadata(ctx, srv, "1$6$7$2$5")
+	if err != nil {
+		t.Fatalf("Metadata item: %v", err)
+	}
+
+	if len(item.Items) != 1 || len(item.Containers) != 0 {
+		t.Fatalf("Metadata item: got %d containers / %d items, want exactly 1 item",
+			len(item.Containers), len(item.Items))
+	}
+
+	if art := item.Items[0].AlbumArtURL; art == "" {
+		t.Error("item metadata carries no AlbumArtURL")
+	}
+}

--- a/pkg/service/soundtouchweb/handler.go
+++ b/pkg/service/soundtouchweb/handler.go
@@ -127,6 +127,13 @@ type WebApp struct {
 	// mutation lock covers concurrent CLI-like requests from every browser.
 	StereoPairs StereoPairLifecycle
 
+	// mediaServers caches the ContentDirectory of each DLNA server behind a
+	// STORED_MUSIC account, keyed by bare UDN (see mediaServerForAccount). It
+	// exists so the album-art lookup on a preset save costs one SOAP call
+	// instead of also re-resolving the server every time.
+	mediaServersMu sync.Mutex
+	mediaServers   map[string]cachedMediaServer
+
 	discoveryStatus atomic.Value // stores *webtypes.DiscoveryStatus
 }
 
@@ -799,6 +806,14 @@ func (app *WebApp) HandleStorePresetContent(w http.ResponseWriter, r *http.Reque
 	// value speakers echo back (source name == source account, e.g. "TUNEIN").
 	if req.SourceAccount != "" && req.SourceAccount != req.Source {
 		contentItem.SourceAccount = req.SourceAccount
+	}
+
+	// A library item has no artwork by the time it reaches us: the speaker's
+	// /navigate carries none, so a saved folder showed a generic tile even
+	// though the same folder playing showed its cover. Ask the media server
+	// for it, best effort (see storedMusicArtURL).
+	if contentItem.ContainerArt == "" && req.Source == "STORED_MUSIC" {
+		contentItem.ContainerArt = app.storedMusicArtURL(r.Context(), device, contentItem.SourceAccount, contentItem.Location)
 	}
 
 	logPlaybackRequest("store-preset", deviceID, contentItem.Source, contentItem.SourceAccount, contentItem.Location, contentItem.ItemName)

--- a/pkg/service/soundtouchweb/handler_storepreset_test.go
+++ b/pkg/service/soundtouchweb/handler_storepreset_test.go
@@ -4,7 +4,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+
+	"github.com/gesellix/bose-soundtouch/pkg/dlna/dlnatest"
 )
 
 // The /storePreset body shape below is not invented: it was measured against a
@@ -194,5 +197,222 @@ func TestHandleStorePresetContent_UnknownDevice(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// The art lookup below exists because the speaker cannot answer the question:
+// its /navigate response carries no artwork (verified on hardware), so a
+// folder saved from the Library used to land in a preset slot with no art at
+// all, while the same folder playing showed its cover, which the speaker
+// resolves from the media server itself at play time.
+//
+// The mapping the lookup relies on was measured on a SoundTouch 10 (FW
+// 27.0.6): a STORED_MUSIC location IS the DLNA object ID, except that a
+// playable item's location carries a " TRACK" suffix.
+
+// libraryArtTestApp wires a speaker whose /listMediaServers points at the
+// given DLNA server, which is how the art lookup finds a ContentDirectory
+// without an SSDP sweep.
+func libraryArtTestApp(t *testing.T, udn, dlnaURL string) (*WebApp, map[string]string) {
+	t.Helper()
+
+	listing := `<?xml version="1.0" encoding="UTF-8" ?>` +
+		`<ListMediaServersResponse>` +
+		`<media_server id="` + strings.TrimPrefix(udn, "uuid:") + `" ip="192.0.2.10"` +
+		` friendly_name="Test MediaServer" location="` + dlnaURL + `/rootDesc.xml" />` +
+		`</ListMediaServersResponse>`
+
+	speaker, captured := setupSpeakerMock(t, map[string]string{"/listMediaServers": listing})
+	t.Cleanup(speaker.Close)
+
+	return newLibraryTestApp(speaker.URL), captured
+}
+
+// storePresetContent posts one save request and fails the test unless the
+// handler answered 200.
+func storePresetContent(t *testing.T, app *WebApp, slot, body string) {
+	t.Helper()
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/preset/"+slot, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req = withChiParams(req, map[string]string{"id": "lib-device", "slot": slot})
+	w := httptest.NewRecorder()
+
+	app.HandleStorePresetContent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// artTree is a one-album tree whose container advertises its own cover, the
+// case that matters here: MiniDLNA reports albumArtURI on every musicAlbum
+// container, and that is the only artwork a folder has.
+func artTree() *dlnatest.Tree {
+	return &dlnatest.Tree{Containers: []*dlnatest.Container{{
+		ID:         "1$6$7$2",
+		ParentID:   "1$6$7",
+		Title:      "Some Album",
+		Class:      "object.container.album.musicAlbum",
+		ArtPayload: []byte{0x89, 'P', 'N', 'G'},
+		ArtMime:    "image/png",
+		Children: []*dlnatest.Item{{
+			ID:         "1$6$7$2$5",
+			ParentID:   "1$6$7$2",
+			Title:      "Great Song",
+			Class:      "object.item.audioItem.musicTrack",
+			MimeType:   "audio/mpeg",
+			ArtPayload: []byte{0x89, 'P', 'N', 'G'},
+			ArtMime:    "image/jpeg",
+		}},
+	}}}
+}
+
+// TestHandleStorePresetContent_FillsFolderArtFromTheMediaServer stores a
+// folder and expects the container's own cover to be saved with it.
+func TestHandleStorePresetContent_FillsFolderArtFromTheMediaServer(t *testing.T) {
+	const udn = "uuid:4d696e69-444c-164e-9d41-2497ed3da6ad"
+
+	media, _ := dlnatest.NewHTTPTest(dlnatest.WithUDN(udn), dlnatest.WithTree(artTree()))
+	defer media.Close()
+
+	app, captured := libraryArtTestApp(t, udn, media.URL)
+
+	storePresetContent(t, app, "6", `{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "4d696e69-444c-164e-9d41-2497ed3da6ad/0",
+		"location":      "1$6$7$2",
+		"type":          "",
+		"itemName":      "Some Album"
+	}`)
+
+	if want := `<containerArt>` + media.URL + `/AlbumArt/1%246%247%242.png</containerArt>`; !strings.Contains(captured["/storePreset"], want) {
+		t.Errorf("storePreset XML should contain %q, got:\n%s", want, captured["/storePreset"])
+	}
+}
+
+// TestHandleStorePresetContent_FillsTrackArtFromTheMediaServer covers the
+// " TRACK" suffix: the speaker's location for a playable item is the object ID
+// plus that word, so the lookup has to strip it to ask about the right object.
+func TestHandleStorePresetContent_FillsTrackArtFromTheMediaServer(t *testing.T) {
+	const udn = "uuid:4d696e69-444c-164e-9d41-2497ed3da6ad"
+
+	media, _ := dlnatest.NewHTTPTest(dlnatest.WithUDN(udn), dlnatest.WithTree(artTree()))
+	defer media.Close()
+
+	app, captured := libraryArtTestApp(t, udn, media.URL)
+
+	storePresetContent(t, app, "5", `{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "4d696e69-444c-164e-9d41-2497ed3da6ad/0",
+		"location":      "1$6$7$2$5 TRACK",
+		"type":          "track",
+		"itemName":      "Great Song"
+	}`)
+
+	if want := `/AlbumArt/1%246%247%242%245.jpg</containerArt>`; !strings.Contains(captured["/storePreset"], want) {
+		t.Errorf("storePreset XML should contain the track's own art %q, got:\n%s", want, captured["/storePreset"])
+	}
+}
+
+// TestHandleStorePresetContent_KeepsGivenArt leaves a caller-supplied
+// containerArt alone: whoever already knows the artwork (a provider result,
+// say) is a better source than our own lookup.
+func TestHandleStorePresetContent_KeepsGivenArt(t *testing.T) {
+	const udn = "uuid:4d696e69-444c-164e-9d41-2497ed3da6ad"
+
+	media, _ := dlnatest.NewHTTPTest(dlnatest.WithUDN(udn), dlnatest.WithTree(artTree()))
+	defer media.Close()
+
+	app, captured := libraryArtTestApp(t, udn, media.URL)
+
+	storePresetContent(t, app, "6", `{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "4d696e69-444c-164e-9d41-2497ed3da6ad/0",
+		"location":      "1$6$7$2",
+		"containerArt":  "http://192.0.2.20/cover.jpg",
+		"itemName":      "Some Album"
+	}`)
+
+	if want := `<containerArt>http://192.0.2.20/cover.jpg</containerArt>`; !strings.Contains(captured["/storePreset"], want) {
+		t.Errorf("storePreset XML should keep the given art %q, got:\n%s", want, captured["/storePreset"])
+	}
+}
+
+// TestHandleStorePresetContent_StoresWithoutArtWhenLookupFails is the
+// failsafe: artwork is decoration, so an unknown server (or any other lookup
+// failure) must still store the preset.
+func TestHandleStorePresetContent_StoresWithoutArtWhenLookupFails(t *testing.T) {
+	media, _ := dlnatest.NewHTTPTest(dlnatest.WithUDN("uuid:some-other-server"), dlnatest.WithTree(artTree()))
+	defer media.Close()
+
+	app, captured := libraryArtTestApp(t, "uuid:some-other-server", media.URL)
+
+	storePresetContent(t, app, "6", `{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "4d696e69-444c-164e-9d41-2497ed3da6ad/0",
+		"location":      "1$6$7$2",
+		"itemName":      "Some Album"
+	}`)
+
+	if storeXML := captured["/storePreset"]; !strings.Contains(storeXML, `location="1$6$7$2"`) {
+		t.Errorf("the preset must be stored even without art, got:\n%s", storeXML)
+	}
+
+	if strings.Contains(captured["/storePreset"], "containerArt") {
+		t.Errorf("no art was resolvable, so none should be stored, got:\n%s", captured["/storePreset"])
+	}
+}
+
+// TestStoredMusicArtLookupResolvesTheServerOnce pins the cache: repeated saves
+// must not re-resolve the media server, which costs the speaker a
+// /listMediaServers call and the server a description fetch every time.
+func TestStoredMusicArtLookupResolvesTheServerOnce(t *testing.T) {
+	const udn = "uuid:4d696e69-444c-164e-9d41-2497ed3da6ad"
+
+	media, _ := dlnatest.NewHTTPTest(dlnatest.WithUDN(udn), dlnatest.WithTree(artTree()))
+	defer media.Close()
+
+	var mu sync.Mutex
+	listings := 0
+
+	listing := `<?xml version="1.0" encoding="UTF-8" ?>` +
+		`<ListMediaServersResponse>` +
+		`<media_server id="4d696e69-444c-164e-9d41-2497ed3da6ad" location="` + media.URL + `/rootDesc.xml" />` +
+		`</ListMediaServersResponse>`
+
+	speaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/listMediaServers" {
+			mu.Lock()
+			listings++
+			mu.Unlock()
+
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(listing))
+
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	body := `{
+		"source":        "STORED_MUSIC",
+		"sourceAccount": "4d696e69-444c-164e-9d41-2497ed3da6ad/0",
+		"location":      "1$6$7$2",
+		"itemName":      "Some Album"
+	}`
+
+	storePresetContent(t, app, "6", body)
+	storePresetContent(t, app, "5", body)
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if listings != 1 {
+		t.Errorf("listMediaServers calls = %d, want 1 (the resolved server is cached)", listings)
 	}
 }

--- a/pkg/service/soundtouchweb/library_art.go
+++ b/pkg/service/soundtouchweb/library_art.go
@@ -73,7 +73,11 @@ func (app *WebApp) storedMusicArtURL(ctx context.Context, device *webtypes.Devic
 
 	result, err := dlna.Metadata(ctx, server, objectID)
 	if err != nil {
-		slog.Debug("library art: metadata lookup failed", "object", objectID, "err", err.Error())
+		// The object ID comes from a request body and the error can quote a
+		// media server's response, so both are sanitised (CodeQL
+		// go/log-injection, same reason as logPlaybackRequest).
+		slog.Debug("library art: metadata lookup failed",
+			"object", sanitizeLog(objectID), "err", sanitizeLog(err.Error()))
 
 		return ""
 	}
@@ -121,7 +125,7 @@ func (app *WebApp) mediaServerForAccount(ctx context.Context, device *webtypes.D
 	if location := app.mediaServerLocation(device, udn); location != "" {
 		server, ok, err := discovery.MediaServerAt(ctx, location)
 		if err != nil {
-			slog.Debug("library art: media server description fetch failed", "err", err.Error())
+			slog.Debug("library art: media server description fetch failed", "err", sanitizeLog(err.Error()))
 		}
 
 		resolved.server = server
@@ -145,7 +149,7 @@ func (app *WebApp) mediaServerLocation(device *webtypes.DeviceConnection, udn st
 	resp, err := device.Client.ListMediaServers()
 	if err != nil || resp == nil {
 		if err != nil {
-			slog.Debug("library art: listMediaServers failed", "err", err.Error())
+			slog.Debug("library art: listMediaServers failed", "err", sanitizeLog(err.Error()))
 		}
 
 		return ""

--- a/pkg/service/soundtouchweb/library_art.go
+++ b/pkg/service/soundtouchweb/library_art.go
@@ -1,0 +1,162 @@
+package soundtouchweb
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/gesellix/bose-soundtouch/pkg/discovery"
+	"github.com/gesellix/bose-soundtouch/pkg/dlna"
+	"github.com/gesellix/bose-soundtouch/pkg/service/soundtouchweb/webtypes"
+)
+
+const (
+	// storedMusicArtBudget bounds the whole art lookup. It runs inside a
+	// user-facing request (saving a preset), so a slow or half-answering media
+	// server must cost a moment, not the request.
+	storedMusicArtBudget = 4 * time.Second
+
+	// mediaServerCacheTTL is how long a resolved ContentDirectory URL is
+	// reused. Servers keep theirs across restarts in practice, and a stale
+	// entry only costs one failed lookup, after which the art is simply
+	// missing.
+	mediaServerCacheTTL = 10 * time.Minute
+)
+
+// cachedMediaServer is one resolved media server plus the time it was
+// resolved. A miss is cached too (ok=false), so a server that is gone or has
+// no ContentDirectory is not re-resolved on every save.
+type cachedMediaServer struct {
+	server   discovery.MediaServer
+	ok       bool
+	resolved time.Time
+}
+
+// storedMusicObjectID maps a speaker-native STORED_MUSIC location to the DLNA
+// object ID it came from.
+//
+// They are the same string, except that the speaker appends " TRACK" to a
+// playable item's ID. Measured against a SoundTouch 10 (FW 27.0.6) on two
+// servers, which agreed: MiniDLNA album "1$6$7$2" and its track
+// "1$6$7$2$5 TRACK"; a FRITZ!Box container "4:cont2:150:0:0:" and its track
+// "5:audio5:part13:3171:5 TRACK". Containers carry no suffix.
+func storedMusicObjectID(location string) string {
+	return strings.TrimSuffix(location, " TRACK")
+}
+
+// storedMusicArtURL returns the album art for one STORED_MUSIC location, or
+// "" when it cannot be determined.
+//
+// The speaker cannot answer this: its /navigate response carries no artwork
+// (verified on hardware), which is why a folder saved as a preset used to
+// show a generic icon while the same folder playing showed its cover, the
+// latter coming from the speaker's own metadata at play time. So we ask the
+// media server, whose DIDL-Lite does carry albumArtURI on both album
+// containers and tracks.
+//
+// Every failure path returns "" rather than an error: art is decoration, and
+// nothing here may prevent a preset from being stored.
+func (app *WebApp) storedMusicArtURL(ctx context.Context, device *webtypes.DeviceConnection, account, location string) string {
+	objectID := storedMusicObjectID(location)
+	if objectID == "" {
+		return ""
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, storedMusicArtBudget)
+	defer cancel()
+
+	server, ok := app.mediaServerForAccount(ctx, device, account)
+	if !ok {
+		return ""
+	}
+
+	result, err := dlna.Metadata(ctx, server, objectID)
+	if err != nil {
+		slog.Debug("library art: metadata lookup failed", "object", objectID, "err", err.Error())
+
+		return ""
+	}
+
+	// BrowseMetadata answers with exactly one object, which is a container for
+	// a folder and an item for a track.
+	for _, c := range result.Containers {
+		if c.AlbumArtURL != "" {
+			return c.AlbumArtURL
+		}
+	}
+
+	for i := range result.Items {
+		if art := result.Items[i].AlbumArtURL; art != "" {
+			return art
+		}
+	}
+
+	return ""
+}
+
+// mediaServerForAccount resolves the ContentDirectory of the server behind a
+// STORED_MUSIC sourceAccount ("<udn>/0").
+//
+// The speaker itself is the directory: its /listMediaServers reports each
+// server's UDN together with the URL of its UPnP description, so no SSDP
+// sweep is needed. That also keeps the lookup working when the service host
+// and the speaker do not see the same network segment, which is the whole
+// reason HandleDiscoverLibraryServers queries both paths.
+func (app *WebApp) mediaServerForAccount(ctx context.Context, device *webtypes.DeviceConnection, account string) (discovery.MediaServer, bool) {
+	udn := normalizeUDN(strings.TrimSuffix(account, "/0"))
+	if udn == "" || device == nil || device.Client == nil {
+		return discovery.MediaServer{}, false
+	}
+
+	app.mediaServersMu.Lock()
+	defer app.mediaServersMu.Unlock()
+
+	if cached, found := app.mediaServers[udn]; found && time.Since(cached.resolved) < mediaServerCacheTTL {
+		return cached.server, cached.ok
+	}
+
+	resolved := cachedMediaServer{resolved: time.Now()}
+
+	if location := app.mediaServerLocation(device, udn); location != "" {
+		server, ok, err := discovery.MediaServerAt(ctx, location)
+		if err != nil {
+			slog.Debug("library art: media server description fetch failed", "err", err.Error())
+		}
+
+		resolved.server = server
+		resolved.ok = ok && err == nil
+	}
+
+	if app.mediaServers == nil {
+		app.mediaServers = map[string]cachedMediaServer{}
+	}
+
+	app.mediaServers[udn] = resolved
+
+	return resolved.server, resolved.ok
+}
+
+// mediaServerLocation asks the speaker where a given media server's UPnP
+// description lives. An empty return means the speaker does not know that
+// server (or the call failed), which is not an error here: the caller then
+// simply has no art to store.
+func (app *WebApp) mediaServerLocation(device *webtypes.DeviceConnection, udn string) string {
+	resp, err := device.Client.ListMediaServers()
+	if err != nil || resp == nil {
+		if err != nil {
+			slog.Debug("library art: listMediaServers failed", "err", err.Error())
+		}
+
+		return ""
+	}
+
+	for i := range resp.MediaServers {
+		s := &resp.MediaServers[i]
+		if normalizeUDN(s.ID) == udn {
+			return s.Location
+		}
+	}
+
+	return ""
+}


### PR DESCRIPTION
Follow-up to https://github.com/gesellix/Bose-SoundTouch/pull/718, which added the Library save button but stored presets without artwork.

A folder saved from the Library landed in its slot with a generic disc tile, while the same folder playing showed its cover. The speaker cannot help: its `/navigate` response carries no `containerArt` at all (measured on three media servers), and the cover during playback is the speaker resolving the media server's metadata itself.

So ask the media server. A STORED_MUSIC location turns out to be the server's own DLNA object ID, with a ` TRACK` suffix for playable items:

| server | container | track |
| --- | --- | --- |
| MiniDLNA | `1$6$7$2` | `1$6$7$2$5 TRACK` |
| FRITZ!Box | `4:cont2:150:0:0:` | `5:audio5:part13:3171:5 TRACK` |

That makes one ContentDirectory `BrowseMetadata` call enough to answer what a known object's artwork is. Album containers advertise their own `albumArtURI`, which is the only art a folder has.

Finding the server needs no SSDP sweep: the speaker's `/listMediaServers` already reports each server's UDN together with the URL of its UPnP description. That also keeps this working when the service host and the speaker do not see the same network segment (the same reason the discovery handler queries both paths), and the resolved ContentDirectory is cached so repeated saves cost one SOAP call.

Every failure path stores the preset without art: artwork is decoration and must never be the reason a save fails.

## Changes

- `pkg/dlna`: `Metadata` (a `BrowseMetadata` call for a single object) and `Container.AlbumArtURL`, which the parser previously dropped.
- `pkg/discovery`: `MediaServerAt`, resolving one server from the URL of its UPnP description.
- `pkg/service/soundtouchweb`: the lookup plus its server cache, wired into the preset-store handler for STORED_MUSIC items that arrive without art.
- `NAVIGATION-GUIDE.md`: the location-to-object-ID mapping and the no-artwork finding.

## Verification

Hardware, before committing, through the production code path and with the two locations from the speaker's own preset entries: the album resolved to `.../AlbumArt/46-298.jpg` and the track to `.../AlbumArt/46-303.jpg` on MiniDLNA. After deploying, both preset tiles show their real covers.

Tests: the folder and track art paths against an in-process DLNA server, a caller-supplied `containerArt` being left alone, the failsafe (unknown server still stores the preset, with no art), and the server cache resolving once across two saves. `make check` and `make lint` are clean.

Caveat worth knowing: the stored URL points at the media server, so a tile renders only while that server is reachable from the browser, and the URL breaks if the server reindexes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)