### PR TITLE
fix(on-device): unblock upgrades that abort for lack of space, and roll back when one fails

### DIFF
--- a/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
+++ b/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
@@ -46,7 +46,7 @@ A separate machine (Raspberry Pi, NAS, always-on laptop) runs `soundtouch-servic
 User SSHes in once, pipes the installer. Installs to `/mnt/nv/aftertouch`, symlinks `/opt/aftertouch`, registers `/etc/init.d/aftertouch` via `update-rc.d`. Daemon serves `:8000` on the speaker's own LAN address.
 
 - **Pros:** no separate host, per-speaker isolation, survives router replacement.
-- **Cons:** SSH required for install and updates, ~12 MB binary stresses tiny rootfs partitions, no in-process restart on crash, some firmware images bind only loopback (issue #196).
+- **Cons:** SSH required for install and updates, a ~15.5 MB binary (v0.131.0) stresses tiny rootfs partitions, no in-process restart on crash, some firmware images bind only loopback (issue #196).
 
 #### Pattern C — Stick-driven on-device (*not* implemented here)
 
@@ -105,7 +105,11 @@ No new SSH plumbing required. The pieces already exist for the setup probes.
 
 ### Storage budget
 
-The on-device patterns share one hard constraint: storage. ST20 stock rootfs has ~4 MB free (issue #268); even with `/mnt/nv` (~30 MB free) the budget is tight, and a second binary for safe OTA updates doubles it. This is the primary motivation for a slimmer `soundtouch-service-mini` build target — see the appendix.
+The on-device patterns share one hard constraint: storage. ST20 stock rootfs has ~4 MB free (issue #268). `/mnt/nv` is ~31 MB in total, leaving ~20 MB free once AfterTouch (~15.5 MB at v0.131.0) is installed, so the budget is tight and a second binary for safe OTA updates does not fit alongside it. The installer works within this by charging an upgrade only the difference between the old and new binary, and by keeping its rollback backup gzip-compressed.
+
+Measured on an ST speaker (2026-09-12): `/mnt/nv` 31.6 MB total, 20.2 MB free with AfterTouch installed; rootfs 8.9 MB free; `/mnt/update` 6.2 MB free; 120 MB RAM with no swap. Neither rootfs nor `/mnt/update` can hold the binary.
+
+This is the primary motivation for a slimmer `soundtouch-service-mini` build target — see the appendix.
 
 ### Open decisions for this journey
 
@@ -249,7 +253,7 @@ A mini build target in this repo would look like:
 - same codebase, different `cmd/` entry point,
 - compiled with only the packages needed for Internet Radio + TuneIn shim + presets,
 - no Spotify, no parity tests, no setup wizard, no Bose-protocol-level proxy,
-- target size: under 4 MB so it fits the rootfs without `/mnt/nv` gymnastics, leaving room for a second binary for safe updates.
+- target size: as small as Go allows, which is not very small. Measured floor for `GOOS=linux GOARCH=arm GOARM=7` with `-trimpath -ldflags="-s -w"`: 5.8 MB for `net/http` alone, 6.4 MB adding TLS/x509/XML, 7.0 MB adding `miekg/dns`, chi and gorilla/websocket. A realistic mini target is therefore ~7-9 MB, not the "under 4 MB" this document previously claimed; 4 MB is unreachable in Go and would mean a different language, which is not on the table. Even at 7-9 MB it does not fit the ~4 MB rootfs, so a mini build buys headroom on `/mnt/nv`, not freedom from it.
 
 Open questions before committing:
 

--- a/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
+++ b/docs/content/docs/architecture/DEVICE-LOCAL-INSTALL.md
@@ -221,7 +221,7 @@ Where today's surfaces fall short for this user:
 |------------------------------------|---------------------|-------------------|-------------------|------------------------|
 | `soundtouch-cli`                   | partial (today)     | partial (today)   | no                | primary                |
 | `soundtouch-service` web UI        | wizard portion      | primary           | partial           | indirect (REST)        |
-| `soundtouch-player`                   | no                  | no                | primary           | no                     |
+| `soundtouch-player`                | no                  | no                | primary           | no                     |
 | GUI admin app (Gio, planned)       | primary             | primary           | mobile mode       | no                     |
 | Pre-flashed stick (hypothetical)   | primary             | recovery          | no                | no                     |
 | Physical preset buttons            | no                  | no                | primary           | no                     |

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -87,7 +87,9 @@ df -h /mnt/nv   # confirm space recovered
 
 > **From v0.93.0 onwards the installer prunes stale artefacts automatically**
 > during every upgrade — manual cleanup should no longer be necessary on
-> fresh installs.
+> fresh installs. The flip side: if an install still aborts for lack of
+> space, there is probably nothing left for you to delete. See the
+> Troubleshooting entry for that error below.
 
 ---
 
@@ -404,6 +406,9 @@ should start playing the corresponding stream.
 | Radio source error 1005                              | `margeAccountUUID` is empty — complete Step 7 first |
 | `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20`            |
 | No space left on device during install               | Run the cleanup in Step 2; check `df -h /mnt/nv`    |
+| Install aborts with `ERROR: not enough free space … needed` | The installer has already pruned its own leftovers, so there is usually nothing left for you to delete. Update the installer first (it is fetched fresh from `main` by the one-liner), and if it still aborts, install an older, smaller release with `--version` |
+| `Continue without a backup? [y/N]` prompt during install | `/mnt/nv` has room for the new binary but not also for a rollback backup. Answering `n` (the default) aborts and changes nothing. To proceed unattended, re-run with `AFTERTOUCH_FORCE_NO_BACKUP=yes` — but then keep your own copy of the current binary first |
+| `subsystem request failed` when copying a binary with `scp` | The speakers ship no `sftp-server`; use `scp -O` |
 
 For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 
@@ -435,14 +440,30 @@ speaker first**: an Admin UI tab left open from before the update, or a
 browser cache of the previous page load, can otherwise still show the old
 version even though the new binary is already running.
 
-**Rollback:** the installer keeps a `.backup` file alongside the binary:
+**Rollback:** the installer keeps one backup alongside the binary, named
+after the version it replaced. It is normally gzip-compressed
+(`.backup.gz`); the uncompressed `.backup` form only appears when `gzip`
+was unavailable:
 
 ```bash
-ls /mnt/nv/aftertouch/aftertouch-service*.backup
+ls /mnt/nv/aftertouch/aftertouch-service*.backup*   # note the trailing *
+
+# compressed (.backup.gz) — the usual case:
+gunzip -c /mnt/nv/aftertouch/aftertouch-service.<old-version>.backup.gz \
+   > /mnt/nv/aftertouch/aftertouch-service
+
+# or, for an uncompressed .backup:
 cp /mnt/nv/aftertouch/aftertouch-service.<old-version>.backup \
    /mnt/nv/aftertouch/aftertouch-service
+
+chmod +x /mnt/nv/aftertouch/aftertouch-service
 /etc/init.d/aftertouch restart
 ```
+
+You usually won't need this by hand: an install that fails to write the
+binary, or whose new binary doesn't answer on `:8000`, restores this backup
+and restarts by itself before reporting failure (installers released after
+v0.131.0).
 
 **Testing a pre-release build (from `main`, not yet tagged):** `install.sh`
 only ever downloads from GitHub Releases, so there's no one-line installer
@@ -455,13 +476,24 @@ make build-linux-armv7   # builds build/soundtouch-service-linux-armv7,
                           # build/soundtouch-cli-linux-armv7, and
                           # build/soundtouch-backup-linux-armv7
 
-scp build/soundtouch-service-linux-armv7 root@192.0.2.1:/mnt/nv/aftertouch/aftertouch-service.new
+# First, on the speaker: stop the service and compress the current binary
+# into a rollback backup. Order matters — /mnt/nv has only ~20 MB free, so a
+# second full-size binary plus an uncompressed backup does not fit.
 ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
-
 rw
 /etc/init.d/aftertouch stop
-cp /mnt/nv/aftertouch/aftertouch-service /mnt/nv/aftertouch/aftertouch-service.pre-test.backup
-mv /mnt/nv/aftertouch/aftertouch-service.new /mnt/nv/aftertouch/aftertouch-service
+gzip -c /mnt/nv/aftertouch/aftertouch-service \
+   > /mnt/nv/aftertouch/aftertouch-service.pre-test.backup.gz
+exit
+
+# Then, from your machine, copy the new binary straight over the old one.
+# -O is required: the speakers ship no sftp-server, and OpenSSH 9.0+ uses
+# SFTP by default, so plain `scp` fails with "subsystem request failed".
+scp -O build/soundtouch-service-linux-armv7 \
+   root@192.0.2.1:/mnt/nv/aftertouch/aftertouch-service
+
+# Back on the speaker:
+ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1
 chmod +x /mnt/nv/aftertouch/aftertouch-service
 /etc/init.d/aftertouch start
 ```
@@ -471,11 +503,11 @@ service), swap that binary too — same idea, and it lands in the same
 `/mnt/nv/aftertouch` directory Step 9 above uses:
 
 ```bash
-scp build/soundtouch-cli-linux-armv7 root@192.0.2.1:/mnt/nv/aftertouch/soundtouch-cli
+scp -O build/soundtouch-cli-linux-armv7 root@192.0.2.1:/mnt/nv/aftertouch/soundtouch-cli
 ssh -oHostKeyAlgorithms=+ssh-rsa root@192.0.2.1 chmod +x /mnt/nv/aftertouch/soundtouch-cli
 ```
 
-Roll back the same way as above, using the `.pre-test.backup` file.
+Roll back the same way as above, using the `.pre-test.backup.gz` file.
 
 ---
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -398,17 +398,17 @@ should start playing the corresponding stream.
 
 ## Troubleshooting
 
-| Symptom                                              | First check                                         |
-|------------------------------------------------------|-----------------------------------------------------|
-| SSH "no matching host key type"                      | Add `-oHostKeyAlgorithms=+ssh-rsa`                  |
-| Port 8000 not reachable from LAN                     | Use the SSH tunnel (Step 5)                         |
-| `margeAccountUUID` still empty after reboot          | Re-run Health QuickFix, reboot again; if it still won't stick, try `setup pair --mode=bare` (Step 7), which pairs over a different channel |
-| Radio source error 1005                              | `margeAccountUUID` is empty — complete Step 7 first |
-| `http://localhost:8000` not responding after install | `logread \| grep aftertouch \| tail -20`            |
-| No space left on device during install               | Run the cleanup in Step 2; check `df -h /mnt/nv`    |
+| Symptom                                                     | First check                                                                                                                                                                                                                                                       |
+|-------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| SSH "no matching host key type"                             | Add `-oHostKeyAlgorithms=+ssh-rsa`                                                                                                                                                                                                                                |
+| Port 8000 not reachable from LAN                            | Use the SSH tunnel (Step 5)                                                                                                                                                                                                                                       |
+| `margeAccountUUID` still empty after reboot                 | Re-run Health QuickFix, reboot again; if it still won't stick, try `setup pair --mode=bare` (Step 7), which pairs over a different channel                                                                                                                        |
+| Radio source error 1005                                     | `margeAccountUUID` is empty — complete Step 7 first                                                                                                                                                                                                               |
+| `http://localhost:8000` not responding after install        | `logread \| grep aftertouch \| tail -20`                                                                                                                                                                                                                          |
+| No space left on device during install                      | Run the cleanup in Step 2; check `df -h /mnt/nv`                                                                                                                                                                                                                  |
 | Install aborts with `ERROR: not enough free space … needed` | The installer has already pruned its own leftovers, so there is usually nothing left for you to delete. Update the installer first (it is fetched fresh from `main` by the one-liner), and if it still aborts, install an older, smaller release with `--version` |
-| `Continue without a backup? [y/N]` prompt during install | `/mnt/nv` has room for the new binary but not also for a rollback backup. Answering `n` (the default) aborts and changes nothing. To proceed unattended, re-run with `AFTERTOUCH_FORCE_NO_BACKUP=yes` — but then keep your own copy of the current binary first |
-| `subsystem request failed` when copying a binary with `scp` | The speakers ship no `sftp-server`; use `scp -O` |
+| `Continue without a backup? [y/N]` prompt during install    | `/mnt/nv` has room for the new binary but not also for a rollback backup. Answering `n` (the default) aborts and changes nothing. To proceed unattended, re-run with `AFTERTOUCH_FORCE_NO_BACKUP=yes` — but then keep your own copy of the current binary first   |
+| `subsystem request failed` when copying a binary with `scp` | The speakers ship no `sftp-server`; use `scp -O`                                                                                                                                                                                                                  |
 
 For more detail see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
 

--- a/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
+++ b/docs/content/docs/guides/ON-DEVICE-INSTALL-WALKTHROUGH.md
@@ -58,8 +58,9 @@ You should see a prompt such as `root@soundtouch-device:~#`.
 
 ## Step 2 — Check free space (and clean up if needed)
 
-The persistent `/mnt/nv` partition typically has 20–40 MB free — enough for
-the AfterTouch binary (~12 MB) plus one backup. Check first:
+The persistent `/mnt/nv` partition is ~31 MB in total, with ~20 MB free once
+AfterTouch (~15.5 MB at v0.131.0) is installed. That is enough for the binary
+plus one gzip-compressed rollback backup, but not for much else. Check first:
 
 ```bash
 rw            # remount rootfs read-write

--- a/scripts/on-device-install/README.md
+++ b/scripts/on-device-install/README.md
@@ -19,13 +19,18 @@ If your device doesn't expose the port, you can still use the on-device installe
 
 ### Space Limitation
 
-The storage space on the SoundTouch devices is very limited — stock rootfs typically has only a few MB free (e.g. ~4 MB on the ST20, see issue #268), well below the AfterTouch binary's ~12 MB. To work around this, the installer puts everything on `/mnt/nv/aftertouch` by default (the persistent partition, typically ~30 MB free) and points `/opt/aftertouch` at it via a symlink so the init script and runtime paths stay unchanged. Override the install target with `INSTALL_DIR=/some/path` if you've got room elsewhere.
+The storage space on the SoundTouch devices is very limited — stock rootfs typically has only a few MB free (e.g. ~4 MB on the ST20, see issue #268), well below the AfterTouch binary's ~15.5 MB (v0.131.0). To work around this, the installer puts everything on `/mnt/nv/aftertouch` by default (the persistent partition, ~31 MB in total and ~20 MB still free once AfterTouch is installed) and points `/opt/aftertouch` at it via a symlink so the init script and runtime paths stay unchanged. Override the install target with `INSTALL_DIR=/some/path` if you've got room elsewhere.
+
+The binary grows with every Go toolchain bump — roughly 1.4 MB over the ten releases up to v0.131.0, almost none of it from this project's own code — so the headroom shrinks over time.
 
 Updating is genuinely tight on this partition, since the old binary, the new one, and a rollback backup can't all comfortably fit at once, and binaries only keep growing (the Go toolchain's own defaults alone add hundreds of KB per major version, independent of anything in this project). The installer handles this in a few ways:
 - The rollback backup is gzip-compressed (`.backup.gz`) rather than a plain copy, cutting its footprint by roughly a third.
 - Before downloading anything, it checks whether there's actually enough free space for the update, using the new binary's real size (a HEAD request), not a guess.
+- An **upgrade is charged only the difference** between the new binary and the one it replaces, because the new file is written over the old path and releases its blocks in the same operation. A fresh install is charged the full size. (Charging upgrades the full size is what made installs abort on speakers that had ample room — see [#693](https://github.com/gesellix/Bose-SoundTouch/issues/693).)
 - If there's enough room for the update itself but not enough extra for a backup, it asks for confirmation before proceeding without one — reading from `/dev/tty` since the installer is normally run as `curl | sh`. The default (empty input, or no `/dev/tty` available at all) is always to abort rather than silently skip the backup; set `AFTERTOUCH_FORCE_NO_BACKUP=yes` to skip that prompt for unattended/scripted installs.
-- If there isn't even enough room for the update itself, it aborts before downloading anything, rather than leaving a partially-overwritten, non-executable binary in place.
+- If there isn't even enough room for the update itself, it aborts before downloading anything, rather than leaving a partially-overwritten, non-executable binary in place. The abort message names both binary sizes and suggests installing an older, smaller release with `--version`.
+- If a write fails anyway, or the newly-installed binary doesn't answer on `:8000`, the installer **restores the backup, restarts, and re-checks** before reporting failure — so a failed update leaves the speaker running what it ran before, not a broken binary.
+- The download is verified against the `.sha256` published alongside it. A mismatch aborts before anything is replaced; a missing checksum or a firmware without `sha256sum` skips the check with a note.
 
 ### Logs
 

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -226,6 +226,37 @@ curl \
   --fail \
   "$BINARY_URL"
 
+# Verify the download against the checksum published alongside it before it is
+# allowed anywhere near the installed binary. `curl --fail` already catches
+# HTTP errors, and a body short of its Content-Length, so this is not about
+# truncation: it is about the download being intact but wrong (a corrupted
+# proxy cache, a tampered mirror).
+#
+# Best effort by design: releases before the checksum assets existed, a
+# firmware without sha256sum, or an offline mirror serving only the binary all
+# skip the check with a warning rather than blocking an install that would
+# otherwise have worked. A checksum that is present and does NOT match is
+# always fatal.
+CHECKSUM_URL=${CHECKSUM_URL:-$BINARY_URL.sha256}
+if ! command -v sha256sum >/dev/null 2>&1; then
+  echo "NOTE: sha256sum is not available; skipping checksum verification." >&2
+elif ! EXPECTED_SHA=$(curl -sSL --fail "$CHECKSUM_URL" 2>/dev/null | awk 'NR==1 {print $1}') \
+    || [ -z "$EXPECTED_SHA" ]; then
+  echo "NOTE: no checksum published at $CHECKSUM_URL; skipping verification." >&2
+else
+  ACTUAL_SHA=$(sha256sum < "$UPDATE_TMP_DIR/binary" | awk '{print $1}')
+  if [ "$ACTUAL_SHA" != "$EXPECTED_SHA" ]; then
+    echo "ERROR: the downloaded binary does not match its published checksum." >&2
+    echo "  expected: $EXPECTED_SHA" >&2
+    echo "  actual:   $ACTUAL_SHA" >&2
+    echo "Nothing was installed. Retry; if it keeps failing, download the" >&2
+    echo "binary on another machine and copy it over instead." >&2
+    rm -f "$UPDATE_TMP_DIR/binary"
+    exit 1
+  fi
+  echo "Checksum verified (sha256 $(echo "$ACTUAL_SHA" | cut -c1-8)...)."
+fi
+
 # Put the backed-up binary back in place. Used on every path that can leave a
 # broken or incomplete binary installed: a failed write (disk full mid-copy is
 # the documented failure mode on this filesystem) and a service that does not

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -429,8 +429,12 @@ else
   echo "  http://localhost:8000 isn't responding. The daemon may have" >&2
   echo "  panicked shortly after start. Recent aftertouch syslog:" >&2
   echo "" >&2
-  logread 2>/dev/null | grep aftertouch | tail -20 >&2 || \
-    echo "  (logread returned nothing for tag 'aftertouch'; the daemon" >&2
+  logread 2>/dev/null | grep aftertouch | tail -20 >&2 || {
+    echo "  (logread returned nothing for tag 'aftertouch': the daemon may" >&2
+    echo "   have died before it could log anything, or syslogd is not" >&2
+    echo "   running on this firmware. Try '/etc/init.d/aftertouch status'" >&2
+    echo "   and 'logread | tail -50'.)" >&2
+  }
   echo "" >&2
   echo "  For a live view of the daemon's output, run:" >&2
   echo "    logread -f | grep aftertouch" >&2

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -226,6 +226,40 @@ curl \
   --fail \
   "$BINARY_URL"
 
+# Put the backed-up binary back in place. Used on every path that can leave a
+# broken or incomplete binary installed: a failed write (disk full mid-copy is
+# the documented failure mode on this filesystem) and a service that does not
+# answer after the install. Without this the installer exits leaving the
+# speaker with no working AfterTouch and the rollback left to the operator --
+# who, on a headless device reached over SSH, may not get a second chance.
+#
+# Returns non-zero when there is nothing to restore (fresh install, or the
+# operator chose to proceed without a backup), so callers can say so.
+restore_backup() {
+  if [ -z "$BACKUP_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+    return 1
+  fi
+
+  echo "Restoring the previous binary from $BACKUP_FILE ..." >&2
+  case "$BACKUP_FILE" in
+    *.gz)
+      if ! gunzip -c "$BACKUP_FILE" > "$INSTALL_DIR/aftertouch-service"; then
+        echo "ERROR: could not restore from $BACKUP_FILE." >&2
+        return 1
+      fi
+      ;;
+    *)
+      if ! cp -p "$BACKUP_FILE" "$INSTALL_DIR/aftertouch-service"; then
+        echo "ERROR: could not restore from $BACKUP_FILE." >&2
+        return 1
+      fi
+      ;;
+  esac
+
+  chmod +x "$INSTALL_DIR/aftertouch-service"
+  return 0
+}
+
 # Back up the current binary before overwriting so a one-step rollback
 # is always available.  The version string comes from the binary itself;
 # if it is absent (very old build or corrupted) we fall back to a timestamp.
@@ -260,7 +294,23 @@ if [ -f "$INSTALL_DIR/aftertouch-service" ] && [ "$SKIP_BACKUP" != "yes" ]; then
   echo "Backed up current binary ($current_version) → $BACKUP_FILE"
 fi
 
-mv "$UPDATE_TMP_DIR/binary" "$INSTALL_DIR/aftertouch-service"
+# `set -e` would abort here on a failed write, leaving a truncated binary in
+# place and the backup untouched on disk -- the exact state the preflight check
+# above exists to prevent, but it cannot rule out (the filesystem may still
+# refuse a write it was predicted to accept). Handle it instead of aborting.
+if ! mv "$UPDATE_TMP_DIR/binary" "$INSTALL_DIR/aftertouch-service"; then
+  echo "" >&2
+  echo "ERROR: writing the new binary to $INSTALL_DIR failed (out of space?)." >&2
+  if restore_backup; then
+    echo "The previous binary is back in place; AfterTouch is unchanged." >&2
+    /etc/init.d/aftertouch restart || true
+  else
+    echo "No rollback backup is available, so the installed binary may be" >&2
+    echo "incomplete. Re-run this installer to replace it, optionally with" >&2
+    echo "an older --version." >&2
+  fi
+  exit 1
+fi
 chmod +x "$INSTALL_DIR/aftertouch-service"
 
 # Keep only the backup we just created; prune all older *.backup, *.old, and
@@ -384,5 +434,26 @@ else
   echo "" >&2
   echo "  For a live view of the daemon's output, run:" >&2
   echo "    logread -f | grep aftertouch" >&2
+
+  # A new binary that does not answer is worse than the old one that did, and
+  # the operator is typically on a single SSH session with no local console to
+  # fall back to. Put the previous binary back and restart, so the speaker is
+  # left in the state it was in before this install rather than in a broken
+  # one. The install still reports failure -- this is a rollback, not a
+  # success path.
+  echo "" >&2
+  if restore_backup; then
+    /etc/init.d/aftertouch restart || true
+    if curl -fsS --max-time 10 http://localhost:8000 >/dev/null 2>&1; then
+      echo "  Rolled back to the previous binary, which is answering again." >&2
+      echo "  AfterTouch $VERSION was NOT installed." >&2
+    else
+      echo "  Rolled back to the previous binary, but it is not answering" >&2
+      echo "  either -- the problem is unlikely to be this release." >&2
+    fi
+  else
+    echo "  No rollback backup was kept, so the new binary is still in place." >&2
+  fi
+
   exit 1
 fi

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -136,13 +136,40 @@ SKIP_BACKUP=no
 
 if [ -n "$NEW_BINARY_BYTES" ]; then
   NEW_BINARY_KB=$((NEW_BINARY_BYTES / 1024))
+
+  # What an upgrade costs is the DIFFERENCE between the new binary and the one
+  # it replaces, not the new binary's full size: the new file is written over
+  # the existing path (the `mv` further down), so the old file's blocks are
+  # released by the same operation that consumes new ones. Charging for the
+  # full size counts the installed binary twice and aborts upgrades on devices
+  # that have ample room -- 72KB short on a 31.6MB /mnt/nv in
+  # https://github.com/gesellix/Bose-SoundTouch/issues/693, where the speaker
+  # was replacing a 14.1MB binary with a 15.5MB one.
+  #
+  # A fresh install still needs the full size, which is exactly what
+  # CURRENT_BINARY_KB=0 yields here. A downgrade frees space rather than
+  # consuming it, so the difference is floored at zero.
+  #
+  # The difference is also the only figure that stays honest on a compressing
+  # filesystem: `df` reports what UBIFS actually stores, while both sizes here
+  # are logical (HEAD Content-Length and `du`, which reports the uncompressed
+  # size on UBIFS). Old and new compress at the same ratio, so the unknown
+  # ratio cancels out of the difference -- it does not cancel out of a
+  # full-size comparison.
+  REPLACE_COST_KB=$((NEW_BINARY_KB - CURRENT_BINARY_KB))
+  if [ "$REPLACE_COST_KB" -lt 0 ]; then
+    REPLACE_COST_KB=0
+  fi
+
   # Backups compress to roughly 70% of the original size in practice
   # (observed: a ~14.8MB binary gzipped to ~10.1MB); used as a conservative
   # estimate since the real ratio isn't known until compression actually runs.
+  # Unlike the binary itself this is a genuine addition to what is stored, so
+  # it is charged in full.
   BACKUP_ESTIMATE_KB=$((CURRENT_BINARY_KB * 7 / 10))
 
-  NEEDED_WITH_BACKUP_KB=$((NEW_BINARY_KB + BACKUP_ESTIMATE_KB + SAFETY_MARGIN_KB))
-  NEEDED_NO_BACKUP_KB=$((NEW_BINARY_KB + SAFETY_MARGIN_KB))
+  NEEDED_WITH_BACKUP_KB=$((REPLACE_COST_KB + BACKUP_ESTIMATE_KB + SAFETY_MARGIN_KB))
+  NEEDED_NO_BACKUP_KB=$((REPLACE_COST_KB + SAFETY_MARGIN_KB))
 
   if [ "$AVAILABLE_KB" -ge "$NEEDED_WITH_BACKUP_KB" ]; then
     : # plenty of room; proceed normally, with a backup
@@ -177,7 +204,14 @@ if [ -n "$NEW_BINARY_BYTES" ]; then
   else
     echo "ERROR: not enough free space on $INSTALL_DIR to install AfterTouch" >&2
     echo "$VERSION safely (${AVAILABLE_KB}KB available, ~${NEEDED_NO_BACKUP_KB}KB" >&2
-    echo "needed). Free up space and try again." >&2
+    echo "needed for a ${NEW_BINARY_KB}KB binary replacing a ${CURRENT_BINARY_KB}KB one)." >&2
+    echo "" >&2
+    echo "The installer already pruned its own leftovers, so there may be" >&2
+    echo "nothing left for you to delete. Options:" >&2
+    echo "  * install an older, smaller release, e.g.:" >&2
+    echo "      curl -sSL https://raw.githubusercontent.com/$GH_REPO/main/scripts/on-device-install/install.sh | sh -s -- --version $FALLBACK_VERSION" >&2
+    echo "  * free space elsewhere on $INSTALL_DIR (ls -lh $INSTALL_DIR)" >&2
+    echo "  * see docs: guides/ON-DEVICE-INSTALL-WALKTHROUGH.md, Troubleshooting" >&2
     exit 1
   fi
 else

--- a/scripts/on-device-install/install.sh
+++ b/scripts/on-device-install/install.sh
@@ -58,8 +58,10 @@ INIT_SCRIPT_URL=${INIT_SCRIPT_URL:-https://raw.githubusercontent.com/$GH_REPO/v$
 # Default install location is /mnt/nv/aftertouch (the persistent
 # partition), not /opt/aftertouch on rootfs. Stock SoundTouch rootfs
 # has ~4 MB free on devices like the ST20 (issue #268); the
-# AfterTouch binary is ~12 MB. /mnt/nv typically has tens of MB
-# free and persists across reboots the same way /opt would.
+# AfterTouch binary is ~15.5 MB as of v0.130.0 and grows by roughly
+# 1 MB per Go toolchain bump. /mnt/nv is ~31 MB in total, of which
+# ~20 MB is free with AfterTouch installed, and it persists across
+# reboots the same way /opt would.
 #
 # /opt/aftertouch becomes a symlink into the install target so the
 # init script's hardcoded DAEMON path keeps working unchanged.

--- a/scripts/on-device-install/uninstall.sh
+++ b/scripts/on-device-install/uninstall.sh
@@ -21,7 +21,7 @@ rm -f /etc/init.d/aftertouch
 update-rc.d -f aftertouch remove
 
 # If /opt/aftertouch is a symlink, resolve it and remove the target
-# before unlinking, so we don't leave ~12 MB of orphan binary on
+# before unlinking, so we don't leave ~15 MB of orphan binary on
 # /mnt/nv. Tolerate either layout — readlink -f returns the same
 # path for a real directory, and rm -rf on a missing path with
 # set -eu would abort.


### PR DESCRIPTION
On-device upgrades have been aborting on speakers that have plenty of room. The preflight disk-space check required `new binary + 5 MB margin` free on `/mnt/nv` even when it was about to overwrite an existing binary of almost the same size, so the installed binary was counted twice.

Reported in [issue #693](https://github.com/gesellix/Bose-SoundTouch/issues/693): a speaker with 20920 KB free refused to replace a 14.1 MB binary with a 15.5 MB one because the check asked for 20992 KB. A 72 KB shortfall, for an upgrade whose real cost is 1.4 MB. The installer's own advice ("free up space") does not help, because it has already pruned its leftovers and there is nothing left to delete.

## What changed

**The preflight charges the difference, not the full size.** The new file is written over the old path, so the old file's blocks are released by the same operation that consumes new ones. A fresh install still pays the full size (`CURRENT_BINARY_KB` is 0 there); a downgrade is floored at zero. The backup estimate is unchanged and still charged in full, since unlike the binary it is a genuine addition.

The difference is also the only figure that stays honest on UBIFS, which compresses: `df` reports what is really stored, while `Content-Length` and `du` are both logical sizes. Old and new compress at the same ratio, so the unknown ratio cancels out of a difference but not out of a full-size comparison.

**A failed install now rolls itself back.** Two paths could leave a speaker with no working AfterTouch and the recovery entirely up to the operator: a failed write of the new binary (`set -e` aborted, leaving a truncated binary next to a perfectly good backup) and a new binary that installs but never answers on `:8000`. Both now restore the backup, restart, and re-check before reporting failure, so the operator is told whether the previous binary is answering again (this release is the problem) or not. Failure is still reported as failure; only what is left on disk changes.

**The download is verified against its published `.sha256`.** Every release publishes one and the installer ignored it. Best effort by design: an older release, a firmware without `sha256sum`, or a mirror serving only the binary skip the check with a note; a checksum that is present and does not match is always fatal.

**Docs.** The "~12 MB binary" and "~30 MB free" figures predate several releases; measured on hardware, the v0.131.0 armv7 binary is 15.5 MB and `/mnt/nv` is 31.6 MB with 20.2 MB free. The rollback recipe documented only a plain `.backup` and its glob did not match the `.backup.gz` the installer actually writes. The pre-release test procedure needed ~31 MB of writes on a ~20 MB volume, so it could not work; it now compresses the backup first and copies straight over the old path. `scp` gained `-O` (the speakers ship no `sftp-server`). Troubleshooting gained entries for the preflight abort, the backup prompt and the scp failure. The mini-build appendix's "under 4 MB" target is restated as ~7-9 MB, against measured Go floors.

## Verification

- The preflight block was exercised against six scenarios: #693's numbers and a second speaker's now take the backup path (16650 and 16230 KB needed, against 20920 and 20684 available), fresh-install and genuinely-full volumes still abort, and a downgrade floors at zero.
- The checksum logic was tested against the real v0.131.0 release assets: the published checksum parses and matches, a modified file is rejected, a missing `.sha256` skips.
- `sh -n` and `bash -n` clean on `install.sh` and `uninstall.sh`. No Go code is touched.
- Not verified on hardware yet. The rollback paths in particular want one real run on a speaker before this is called resolved, and issue #693 stays open until its reporter confirms.

## Follow-up, deliberately not in this PR

`BACKUP_ESTIMATE_KB` assumes a gzipped backup is ~70% of the binary. Measured here with `gzip -9`, it is 38% (16,449,696 to 6,246,060 bytes), which would free another ~4.7 MB of the requirement. That measurement is a desktop gzip on a local build, not BusyBox gzip on a speaker, and being pessimistic is the safe direction for a check that decides whether a backup fits. One command on hardware settles it: `gzip -c /mnt/nv/aftertouch/aftertouch-service | wc -c`.

Note the walkthrough tells users that installers "released after v0.131.0" roll back by themselves, so that sentence only becomes true once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
