### PR TITLE
fix(player): page through large library folders, and refresh a speaker's media servers

### DIFF
--- a/cmd/soundtouch-service/testdata/router_routes.txt
+++ b/cmd/soundtouch-service/testdata/router_routes.txt
@@ -193,6 +193,7 @@ POST     /api/control/devices/{id}/action/{action}                    soundtouch
 POST     /api/control/devices/{id}/key/{key}                          soundtouchweb.(*WebApp).HandleDeviceKey-fm
 POST     /api/control/devices/{id}/library/play                       soundtouchweb.(*WebApp).HandlePlayLibrary-fm
 POST     /api/control/devices/{id}/library/servers                    soundtouchweb.(*WebApp).HandleAddLibraryServer-fm
+POST     /api/control/devices/{id}/library/servers/refresh            soundtouchweb.(*WebApp).HandleRefreshLibraryServers-fm
 POST     /api/control/devices/{id}/play                               soundtouchweb.(*WebApp).HandleDevicePlay-fm
 POST     /api/control/devices/{id}/power                              soundtouchweb.(*WebApp).HandleDevicePower-fm
 POST     /api/control/devices/{id}/preset/{slot}                      soundtouchweb.(*WebApp).HandleStorePresetContent-fm

--- a/docs/content/docs/guides/dlna-music-library.md
+++ b/docs/content/docs/guides/dlna-music-library.md
@@ -144,7 +144,7 @@ command you need to run first.
 
 ---
 
-## Player UI (BETA)
+## Player UI
 
 The soundtouch-player "Library" tab provides a browser-based interface for the
 same workflow:
@@ -155,12 +155,19 @@ same workflow:
 4. Click **Find servers** to run an SSDP sweep.
 5. Click **Add** next to a server to register it on the speaker.
 6. Open the server to browse folders and tracks.
-7. Click a track to play it on the speaker.
+7. Click a track to play it, or the star on its row to save it to a preset.
 
-> **BETA notice:** DLNA behavior varies across server implementations. Some
-> servers expose non-standard browse trees or restrict access by IP. If a
-> server appears in discovery but does not load in the library browser, check
-> that the media server allows UPnP browsing from the speaker's IP address.
+**Refresh** asks the speaker to re-read its own account list and reports what
+it has. Use it when a server you registered is no longer listed on one speaker
+while other speakers still see it.
+
+A folder larger than one page lists its first page and offers **Load more**,
+with the count so far shown beside it.
+
+> DLNA behaviour varies across server implementations. Some servers expose
+> non-standard browse trees or restrict access by IP. If a server appears in
+> discovery but does not load in the library browser, check that the media
+> server allows UPnP browsing from the speaker's IP address.
 
 ---
 

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -3558,3 +3558,89 @@ render(h(Fixture), document.getElementById('fixture'));
 		}
 	}
 }
+
+// TestLibraryRefreshReportsWhatTheSpeakerNowHas covers the issue 580 gesture.
+// A registered media server sometimes vanishes from one speaker's source list
+// while other speakers still see it, and the only recovery was a reboot. The
+// Refresh button asks the speaker to re-read its accounts and then shows what
+// it has, and says which of the three things happened, because a refresh that
+// changes nothing otherwise looks identical to one that never ran.
+func TestLibraryRefreshReportsWhatTheSpeakerNowHas(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { Library } from '/app/static/js/components/Library.js';
+function Fixture() {
+  const [devices] = useState({ speaker: { info: { device_id: 'DEVICE1', name: 'Speaker' }, status: { revision: 1 } } });
+  return h('section', { id: 'library' }, h(Library, { devices, onPlaybackRequest: () => true }));
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	refreshes := 0
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		// The speaker starts out having lost its media server, which is the
+		// state the issue describes.
+		r.Get("/api/control/devices/speaker/library/servers", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: []any{}})
+		})
+		r.Post("/api/control/devices/speaker/library/servers/refresh", func(w http.ResponseWriter, _ *http.Request) {
+			mu.Lock()
+			refreshes++
+			found := refreshes > 1
+			mu.Unlock()
+
+			servers := []any{}
+			if found {
+				servers = append(servers, map[string]any{
+					"udn": "uuid:library", "name": "Media server", "ready": true, "registered": true,
+				})
+			}
+
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"servers": servers, "refreshed": true,
+			}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var emptyNote string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`#library .tunein-toolbar`, chromedp.ByQuery),
+		// First refresh: still nothing, and the UI says where to go next.
+		chromedp.Evaluate(`[...document.querySelectorAll('#library .tunein-toolbar button')].find(b => b.textContent.trim() === 'Refresh').click()`, nil),
+		chromedp.WaitVisible(`#library .library-refresh-note`, chromedp.ByQuery),
+		chromedp.Text(`#library .library-refresh-note`, &emptyNote, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("refresh with nothing registered: %v", err)
+	}
+
+	if !strings.Contains(emptyNote, "no media server") {
+		t.Errorf("note after an empty refresh = %q, want it to say the speaker reports no media server", emptyNote)
+	}
+
+	var foundNote string
+	var serverRows int
+	if err := chromedp.Run(ctx,
+		// Second refresh: the speaker has it again, so it is listed.
+		chromedp.Evaluate(`[...document.querySelectorAll('#library .tunein-toolbar button')].find(b => b.textContent.trim() === 'Refresh').click()`, nil),
+		chromedp.Poll(`document.querySelectorAll('#library .tunein-item').length === 1`, nil),
+		chromedp.Evaluate(`document.querySelectorAll('#library .tunein-item').length`, &serverRows),
+		chromedp.Text(`#library .library-refresh-note`, &foundNote, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("refresh that finds the server: %v", err)
+	}
+
+	if serverRows != 1 || !strings.Contains(foundNote, "Found 1 server") {
+		t.Errorf("after the second refresh: %d rows, note %q; want 1 row and a found note", serverRows, foundNote)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if refreshes != 2 {
+		t.Errorf("refresh calls = %d, want 2", refreshes)
+	}
+}

--- a/pkg/service/soundtouchweb/browser_compatibility_test.go
+++ b/pkg/service/soundtouchweb/browser_compatibility_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -3434,5 +3435,126 @@ render(h(NowPlaying, { nowPlaying, deviceId: 'speaker', presets }), document.get
 	defer mu.Unlock()
 	if len(slots) != 1 || slots[0] != "5" {
 		t.Errorf("storepreset calls = %v, want one for slot 5", slots)
+	}
+}
+
+// TestLibraryPagesThroughALargeFolder covers issue 583: a folder with more
+// entries than one page carries showed only the first page, with nothing to
+// say there was more. The speaker does page correctly (measured on a
+// SoundTouch 10: a 484-entry folder answers start=201 with the next slice and
+// reports totalItems=484 on every page), so the truncation was ours.
+//
+// The fixture returns 3 entries per request regardless of the requested count,
+// which is what a media server is free to do, and reports a total of 7.
+func TestLibraryPagesThroughALargeFolder(t *testing.T) {
+	const fixture = `
+import { h, render } from 'preact';
+import { useState } from 'preact/hooks';
+import { Library } from '/app/static/js/components/Library.js';
+function Fixture() {
+  const [devices] = useState({ speaker: { info: { device_id: 'DEVICE1', name: 'Speaker' }, status: { revision: 1 } } });
+  return h('section', { id: 'library' }, h(Library, { devices, onPlaybackRequest: () => true }));
+}
+render(h(Fixture), document.getElementById('fixture'));
+`
+
+	var mu sync.Mutex
+	var starts []string
+	server := newPlayerFixtureServer(t, fixture, func(r chi.Router) {
+		r.Get("/api/control/devices/speaker/library/servers", func(w http.ResponseWriter, _ *http.Request) {
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: []any{
+				map[string]any{"udn": "uuid:library", "name": "Media server", "ready": true},
+			}})
+		})
+		r.Get("/api/control/devices/speaker/library/browse", func(w http.ResponseWriter, req *http.Request) {
+			start := req.URL.Query().Get("start")
+			if start == "" {
+				start = "1"
+			}
+
+			mu.Lock()
+			starts = append(starts, start)
+			mu.Unlock()
+
+			offset, _ := strconv.Atoi(start)
+
+			entries := []any{}
+			for i := offset; i < offset+3 && i <= 7; i++ {
+				// Directories, so the last step can browse into one and
+				// check that a new listing starts empty.
+				entries = append(entries, map[string]any{
+					"name": fmt.Sprintf("Folder %02d", i), "location": fmt.Sprintf("/t/%d", i),
+					"type": "dir", "isDir": true,
+				})
+			}
+
+			_ = json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: map[string]any{
+				"entries": entries, "totalItems": 7,
+			}})
+		})
+	})
+
+	ctx := newHeadlessChromeContext(t)
+	var firstCount int
+	var firstLabel string
+	if err := chromedp.Run(ctx,
+		chromedp.Navigate(server.URL+"/fixture"),
+		chromedp.WaitVisible(`#library .tunein-item`, chromedp.ByQuery),
+		chromedp.Click(`#library .tunein-item`, chromedp.ByQuery),
+		chromedp.WaitVisible(`#library .library-more`, chromedp.ByQuery),
+		chromedp.Evaluate(`document.querySelectorAll('#library .tunein-list .tunein-item').length`, &firstCount),
+		chromedp.Text(`#library .library-more .tunein-item-desc`, &firstLabel, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("browse the first page: %v", err)
+	}
+
+	if firstCount != 3 || firstLabel != "3 of 7" {
+		t.Errorf("first page: %d rows labelled %q, want 3 rows labelled \"3 of 7\"", firstCount, firstLabel)
+	}
+
+	var total int
+	var moreGone bool
+	if err := chromedp.Run(ctx,
+		chromedp.Click(`#library .library-more button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelectorAll('#library .tunein-list .tunein-item').length === 6`, nil),
+		chromedp.Click(`#library .library-more button`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelectorAll('#library .tunein-list .tunein-item').length === 7`, nil),
+		chromedp.Evaluate(`document.querySelectorAll('#library .tunein-list .tunein-item').length`, &total),
+		// Everything is listed, so the row that offers more is gone.
+		chromedp.Evaluate(`document.querySelector('#library .library-more') === null`, &moreGone),
+	); err != nil {
+		t.Fatalf("page through the folder: %v", err)
+	}
+
+	if total != 7 || !moreGone {
+		t.Errorf("after paging: %d rows, load-more gone = %v; want 7 and true", total, moreGone)
+	}
+
+	// Browsing into a row must start a fresh listing rather than appending to
+	// the folder we were in.
+	var afterDescend int
+	if err := chromedp.Run(ctx,
+		chromedp.Click(`#library .tunein-list .tunein-item`, chromedp.ByQuery),
+		chromedp.Poll(`document.querySelectorAll('#library .tunein-list .tunein-item').length === 3`, nil),
+		chromedp.Evaluate(`document.querySelectorAll('#library .tunein-list .tunein-item').length`, &afterDescend),
+	); err != nil {
+		t.Fatalf("browse into a row after paging: %v", err)
+	}
+
+	if afterDescend != 3 {
+		t.Errorf("a new listing shows %d rows, want 3 (the accumulated pages must not carry over)", afterDescend)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	if want := []string{"1", "4", "7", "1"}; len(starts) != len(want) {
+		t.Fatalf("browse starts = %v, want %v", starts, want)
+	} else {
+		for i := range want {
+			if starts[i] != want[i] {
+				t.Errorf("browse start %d = %q, want %q (%v)", i, starts[i], want[i], starts)
+			}
+		}
 	}
 }

--- a/pkg/service/soundtouchweb/handler_library.go
+++ b/pkg/service/soundtouchweb/handler_library.go
@@ -2,6 +2,7 @@ package soundtouchweb
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -29,6 +30,12 @@ import (
 // the browser handles a long list, so this is a likely candidate for a setting
 // later.
 const defaultLibraryPageSize = 500
+
+// sourcesUpdatedSettleDelay is how long a refresh waits between telling a
+// speaker its sources changed and asking what it now has. Measured informally:
+// a speaker acts on the notification within a second. Too short and the
+// re-read returns the list we already had; too long and the UI feels stuck.
+const sourcesUpdatedSettleDelay = 1500 * time.Millisecond
 
 // libraryServer is the JSON DTO for a DLNA media server. The registered and
 // ready fields reflect state on the specific speaker that was queried;
@@ -244,6 +251,101 @@ func (app *WebApp) HandleDeviceLibraryServers(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	out := storedMusicServers(sources)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if encErr := json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: out}); encErr != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// HandleRefreshLibraryServers re-reads a speaker's STORED_MUSIC sources after
+// asking it to re-read its own account list first.
+//
+// A media server sometimes disappears from one speaker's source list while
+// other speakers still see it (issue 580). Rebooting that speaker brings it
+// back, which says the registration itself survived and only the speaker's
+// live view of it was lost. The same sourcesUpdated nudge that makes a newly
+// registered server appear without a power cycle (see HandleAddLibraryServer)
+// is the cheapest thing that can rebuild that view, so this handler offers it
+// as an explicit gesture rather than making the user reboot.
+//
+// The nudge is best effort and its outcome is reported as "refreshed": the
+// re-read happens either way, so a speaker that ignores the notification still
+// answers with its current list rather than an error. Whether this actually
+// restores a lost library is not confirmed; the reporter of issue 580 has the
+// intermittent case we cannot reproduce here.
+func (app *WebApp) HandleRefreshLibraryServers(w http.ResponseWriter, r *http.Request) {
+	deviceID := chi.URLParam(r, "id")
+
+	device, exists := app.GetDevice(deviceID)
+	if !exists {
+		app.sendError(w, "Device not found", http.StatusNotFound)
+		return
+	}
+
+	if device.Client == nil {
+		app.sendError(w, "Device client not available", http.StatusInternalServerError)
+		return
+	}
+
+	refreshed := false
+
+	if boseDeviceID := app.boseDeviceID(device); boseDeviceID != "" {
+		if err := device.Client.NotifySourcesUpdated(boseDeviceID); err == nil {
+			refreshed = true
+		} else {
+			slog.Debug("library refresh: sourcesUpdated failed", "err", sanitizeLog(err.Error()))
+		}
+	}
+
+	// Give the speaker a moment to act on the notification before asking what
+	// it now has. Without this the re-read races the speaker's own work and
+	// reports the list we were already showing.
+	if refreshed {
+		select {
+		case <-time.After(sourcesUpdatedSettleDelay):
+		case <-r.Context().Done():
+			return
+		}
+	}
+
+	sources, err := device.Client.GetSources()
+	if err != nil {
+		app.sendError(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	out := storedMusicServers(sources)
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if encErr := json.NewEncoder(w).Encode(webtypes.APIResponse{
+		Success: true,
+		Data:    map[string]interface{}{"servers": out, "refreshed": refreshed},
+	}); encErr != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+	}
+}
+
+// boseDeviceID resolves the speaker's own device ID for notifications,
+// preferring the cached DeviceInfo over a live /info round-trip.
+func (app *WebApp) boseDeviceID(device *webtypes.DeviceConnection) string {
+	if device.DeviceInfo != nil && device.DeviceInfo.DeviceID != "" {
+		return device.DeviceInfo.DeviceID
+	}
+
+	if info, err := device.Client.GetDeviceInfo(); err == nil && info != nil {
+		return info.DeviceID
+	}
+
+	return ""
+}
+
+// storedMusicServers maps a speaker's /sources response to the media servers
+// registered on it.
+func storedMusicServers(sources *models.Sources) []libraryServer {
 	out := make([]libraryServer, 0)
 
 	for _, si := range sources.SourceItem {
@@ -260,11 +362,7 @@ func (app *WebApp) HandleDeviceLibraryServers(w http.ResponseWriter, r *http.Req
 		})
 	}
 
-	w.Header().Set("Content-Type", "application/json")
-
-	if encErr := json.NewEncoder(w).Encode(webtypes.APIResponse{Success: true, Data: out}); encErr != nil {
-		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
+	return out
 }
 
 // HandleAddLibraryServer registers a DLNA media server on a specific speaker

--- a/pkg/service/soundtouchweb/handler_library.go
+++ b/pkg/service/soundtouchweb/handler_library.go
@@ -16,6 +16,20 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
+// defaultLibraryPageSize is how many items one browse asks the speaker for
+// when the caller does not say.
+//
+// The speaker honours numItems well past this (measured on a SoundTouch 10
+// against a 484-entry folder: 200, 400 and 1000 all came back correctly, the
+// last one with every entry), so a larger page costs response size rather than
+// correctness. 500 covers most real folders in one request while leaving the
+// paging path in use for the libraries that need it (issue 583).
+//
+// A named constant because the right value depends on the library and on how
+// the browser handles a long list, so this is a likely candidate for a setting
+// later.
+const defaultLibraryPageSize = 500
+
 // libraryServer is the JSON DTO for a DLNA media server. The registered and
 // ready fields reflect state on the specific speaker that was queried;
 // HandleDiscoverLibraryServers leaves them false because it performs a
@@ -387,7 +401,8 @@ func (app *WebApp) HandleRemoveLibraryServer(w http.ResponseWriter, r *http.Requ
 //   - location (optional) location token from a previous browse; empty means root
 //   - type     (optional) type hint for the container item, defaults to "dir"
 //   - start    (optional) 1-based start index, defaults to 1
-//   - count    (optional) number of items to return, defaults to 200
+//   - count    (optional) number of items to return, defaults to
+//     defaultLibraryPageSize
 func (app *WebApp) HandleLibraryBrowse(w http.ResponseWriter, r *http.Request) {
 	deviceID := chi.URLParam(r, "id")
 
@@ -419,7 +434,7 @@ func (app *WebApp) HandleLibraryBrowse(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	count := 200
+	count := defaultLibraryPageSize
 
 	if raw := r.URL.Query().Get("count"); raw != "" {
 		if v, err := strconv.Atoi(raw); err == nil && v >= 1 {

--- a/pkg/service/soundtouchweb/handler_library_test.go
+++ b/pkg/service/soundtouchweb/handler_library_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -958,5 +959,151 @@ func TestHandleLibraryBrowse_ReportsTotalItems(t *testing.T) {
 	if !resp.Success || resp.Data.TotalItems != 2 || len(resp.Data.Entries) != 2 {
 		t.Errorf("got success=%v totalItems=%d entries=%d, want true/2/2",
 			resp.Success, resp.Data.TotalItems, len(resp.Data.Entries))
+	}
+}
+
+// cannedSourcesWithoutLibrary is the same speaker answering with no
+// STORED_MUSIC source at all, which is what issue 580 reports: the media
+// server disappears from one speaker while others still see it.
+const cannedSourcesWithoutLibrary = `<?xml version="1.0" encoding="UTF-8" ?>
+<sources deviceID="AABBCCDDEEFF">
+  <sourceItem source="BLUETOOTH" sourceAccount="" status="READY" isLocal="true" multiroomallowed="false">Bluetooth</sourceItem>
+</sources>`
+
+// TestHandleRefreshLibraryServers_NudgesThenReads verifies the order the
+// refresh depends on: the speaker is told its sources changed, and only then
+// asked what it has. Reading first would report the stale list the user is
+// already looking at.
+func TestHandleRefreshLibraryServers_NudgesThenReads(t *testing.T) {
+	var mu sync.Mutex
+	var calls []string
+
+	speaker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		calls = append(calls, r.URL.Path)
+		mu.Unlock()
+
+		if r.URL.Path == "/sources" {
+			w.Header().Set("Content-Type", "application/xml")
+			_, _ = w.Write([]byte(cannedSourcesResponse))
+
+			return
+		}
+
+		// /notification answers with the posted status echoed back.
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8" ?><status>/notification</status>`))
+	}))
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/library/servers/refresh", nil)
+	req = withChiParams(req, map[string]string{"id": "lib-device"})
+	w := httptest.NewRecorder()
+
+	app.HandleRefreshLibraryServers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Refreshed bool `json:"refreshed"`
+			Servers   []struct {
+				UDN   string `json:"udn"`
+				Name  string `json:"name"`
+				Ready bool   `json:"ready"`
+			} `json:"servers"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !resp.Success || !resp.Data.Refreshed {
+		t.Errorf("got success=%v refreshed=%v, want both true", resp.Success, resp.Data.Refreshed)
+	}
+
+	if len(resp.Data.Servers) != 1 || resp.Data.Servers[0].UDN != "uuid:nas-udn" || !resp.Data.Servers[0].Ready {
+		t.Errorf("servers = %+v, want the one READY STORED_MUSIC source", resp.Data.Servers)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	notifyAt, sourcesAt := -1, -1
+
+	for i, p := range calls {
+		if p == "/notification" && notifyAt < 0 {
+			notifyAt = i
+		}
+
+		if p == "/sources" && sourcesAt < 0 {
+			sourcesAt = i
+		}
+	}
+
+	if notifyAt < 0 || sourcesAt < 0 || notifyAt > sourcesAt {
+		t.Errorf("calls = %v, want /notification before /sources", calls)
+	}
+}
+
+// TestHandleRefreshLibraryServers_ReportsAnEmptyList covers the case the
+// reporter of issue 580 sees: the speaker genuinely has no media server left.
+// The refresh must answer with an empty list rather than an error, so the UI
+// can say so and point at "Find servers".
+func TestHandleRefreshLibraryServers_ReportsAnEmptyList(t *testing.T) {
+	speaker, _ := setupSpeakerMock(t, map[string]string{"/sources": cannedSourcesWithoutLibrary})
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/lib-device/library/servers/refresh", nil)
+	req = withChiParams(req, map[string]string{"id": "lib-device"})
+	w := httptest.NewRecorder()
+
+	app.HandleRefreshLibraryServers(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			Servers []any `json:"servers"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !resp.Success || len(resp.Data.Servers) != 0 {
+		t.Errorf("got success=%v servers=%v, want true and an empty list", resp.Success, resp.Data.Servers)
+	}
+}
+
+// TestHandleRefreshLibraryServers_UnknownDevice keeps the 404 distinct from an
+// empty list: "no such speaker" and "this speaker has no media server" are
+// different answers.
+func TestHandleRefreshLibraryServers_UnknownDevice(t *testing.T) {
+	speaker, _ := setupSpeakerMock(t, nil)
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	req := httptest.NewRequest("POST", "/api/control/devices/nope/library/servers/refresh", nil)
+	req = withChiParams(req, map[string]string{"id": "nope"})
+	w := httptest.NewRecorder()
+
+	app.HandleRefreshLibraryServers(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d: %s", w.Code, w.Body.String())
 	}
 }

--- a/pkg/service/soundtouchweb/handler_library_test.go
+++ b/pkg/service/soundtouchweb/handler_library_test.go
@@ -884,3 +884,79 @@ func TestDiscoverDeviceMediaServers_UnreachableSpeakerSkippedSilently(t *testing
 		t.Errorf("expected the reachable speaker's server, got %+v", got[0])
 	}
 }
+
+// TestHandleLibraryBrowse_PageSize checks the two halves of the paging
+// contract (issue 583): the default page size the handler asks the speaker
+// for, and that an explicit start and count are passed through so the player
+// can fetch the next slice.
+func TestHandleLibraryBrowse_PageSize(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		wantStart string
+		wantNum   string
+	}{
+		{"defaults", "account=uuid:test-udn/0", "<startItem>1</startItem>", "<numItems>500</numItems>"},
+		{"explicit page", "account=uuid:test-udn/0&start=501&count=250", "<startItem>501</startItem>", "<numItems>250</numItems>"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			speaker, captured := setupSpeakerMock(t, map[string]string{"/navigate": cannedNavigateResponse})
+			defer speaker.Close()
+
+			app := newLibraryTestApp(speaker.URL)
+
+			req := httptest.NewRequest("GET", "/api/control/devices/lib-device/library/browse?"+tt.query, nil)
+			req = withChiParams(req, map[string]string{"id": "lib-device"})
+			w := httptest.NewRecorder()
+
+			app.HandleLibraryBrowse(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			navigateXML := captured["/navigate"]
+			for _, want := range []string{tt.wantStart, tt.wantNum} {
+				if !strings.Contains(navigateXML, want) {
+					t.Errorf("navigate XML should contain %q, got:\n%s", want, navigateXML)
+				}
+			}
+		})
+	}
+}
+
+// TestHandleLibraryBrowse_ReportsTotalItems pins the field the player pages
+// against: without it there is no way to know a page is partial.
+func TestHandleLibraryBrowse_ReportsTotalItems(t *testing.T) {
+	speaker, _ := setupSpeakerMock(t, map[string]string{"/navigate": cannedNavigateResponse})
+	defer speaker.Close()
+
+	app := newLibraryTestApp(speaker.URL)
+
+	req := httptest.NewRequest("GET", "/api/control/devices/lib-device/library/browse?account=uuid:test-udn/0", nil)
+	req = withChiParams(req, map[string]string{"id": "lib-device"})
+	w := httptest.NewRecorder()
+
+	app.HandleLibraryBrowse(w, req)
+
+	var resp struct {
+		Success bool `json:"success"`
+		Data    struct {
+			TotalItems int `json:"totalItems"`
+			Entries    []struct {
+				Name string `json:"name"`
+			} `json:"entries"`
+		} `json:"data"`
+	}
+
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if !resp.Success || resp.Data.TotalItems != 2 || len(resp.Data.Entries) != 2 {
+		t.Errorf("got success=%v totalItems=%d entries=%d, want true/2/2",
+			resp.Success, resp.Data.TotalItems, len(resp.Data.Entries))
+	}
+}

--- a/pkg/service/soundtouchweb/mount.go
+++ b/pkg/service/soundtouchweb/mount.go
@@ -88,6 +88,9 @@ func (app *WebApp) MountWeb(r chi.Router, discoveryService *discovery.UnifiedDis
 				r.Route("/library", func(r chi.Router) {
 					r.Get("/servers", app.HandleDeviceLibraryServers)
 					r.Post("/servers", app.HandleAddLibraryServer)
+					// Ask the speaker to re-read its own account list, then
+					// report what it has (issue 580).
+					r.Post("/servers/refresh", app.HandleRefreshLibraryServers)
 					r.Delete("/servers/{account}", app.HandleRemoveLibraryServer)
 					r.Get("/browse", app.HandleLibraryBrowse)
 					r.Post("/play", app.HandlePlayLibrary)

--- a/pkg/service/soundtouchweb/mount_test.go
+++ b/pkg/service/soundtouchweb/mount_test.go
@@ -75,6 +75,8 @@ func TestMountWebControlAPIShape(t *testing.T) {
 		"/api/control/devices/{id}/stereo-pair/",
 		// The named-content preset store (issue 700), sibling of /play.
 		"/api/control/devices/{id}/preset/{slot}",
+		// Re-read a speaker's media servers (issue 580).
+		"/api/control/devices/{id}/library/servers/refresh",
 	}
 	for _, want := range mustExist {
 		if !registered[want] {

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -678,6 +678,12 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 .preset-picker-slot.saved  { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
 .preset-picker-slot.error  { border-color: var(--danger); color: var(--danger); }
 
+/* The "Load more" row under a partially listed folder (issue 583). */
+.library-more {
+    display: flex; align-items: center; gap: .75rem;
+    padding: .75rem 0;
+}
+
 /* Library rows reuse the picker overlay above. The star sits beside the row's
    play button, so it is sized like that button, wears the gold --fav colour
    the other save gestures use, and its popover hangs off the right edge

--- a/pkg/service/soundtouchweb/static/css/app.css
+++ b/pkg/service/soundtouchweb/static/css/app.css
@@ -678,6 +678,9 @@ img.now-playing-source-icon { width: 28px; height: 28px; object-fit: contain; fi
 .preset-picker-slot.saved  { border-color: var(--accent); background: var(--accent); color: var(--accent-fg); }
 .preset-picker-slot.error  { border-color: var(--danger); color: var(--danger); }
 
+/* Feedback line beside the Library refresh button (issue 580). */
+.library-refresh-note { font-size: .8rem; }
+
 /* The "Load more" row under a partially listed folder (issue 583). */
 .library-more {
     display: flex; align-items: center; gap: .75rem;

--- a/pkg/service/soundtouchweb/static/js/api.js
+++ b/pkg/service/soundtouchweb/static/js/api.js
@@ -158,6 +158,9 @@ export const api = {
     libraryDiscover: (timeout) => req(`/api/control/providers/library/servers${timeout ? `?timeout=${timeout}` : ''}`),
     libraryServers: (id) => req(`/api/control/devices/${id}/library/servers`),
     libraryAddServer: (id, body) => req(`/api/control/devices/${id}/library/servers`, { method: 'POST', headers: JSON_HEADERS, body: JSON.stringify(body) }),
+    // Nudges the speaker to re-read its sources, then returns what it has
+    // (issue 580: a media server can vanish from one speaker's list).
+    libraryRefreshServers: (id) => req(`/api/control/devices/${id}/library/servers/refresh`, { method: 'POST' }),
     libraryRemoveServer: (id, account) => req(`/api/control/devices/${id}/library/servers/${encodeURIComponent(account)}`, { method: 'DELETE' }),
     libraryBrowse: (id, { account, location, type, start, count }) => {
         const qs = [

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -316,9 +316,6 @@ export function Library({
                     ${refreshNote ? html`
                         <span class="library-refresh-note tunein-item-desc">${refreshNote}</span>
                     ` : null}
-                    <span style="font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-dim);padding:.2rem .4rem;border:1px solid var(--border);border-radius:4px">
-                        BETA
-                    </span>
                 </div>
             `}
 

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -32,6 +32,8 @@ export function Library({
     const browseGeneration = useRef(0);
     const [loading, setLoading] = useState(false);
     const [finding, setFinding] = useState(false);
+    const [refreshing, setRefreshing] = useState(false);
+    const [refreshNote, setRefreshNote] = useState('');
 
     // Sync deviceId when devices prop first arrives or changes enough to
     // invalidate the current selection.
@@ -73,6 +75,41 @@ export function Library({
         const resp = await api.libraryServers(id);
         setLoading(false);
         if (resp.success) setServers(resp.data || []);
+    }
+
+    // A registered media server sometimes disappears from one speaker's source
+    // list while other speakers still see it, and a reboot brings it back
+    // (issue 580). This asks the speaker to re-read its accounts and then
+    // reports what it has, which is the same nudge that makes a newly added
+    // server appear without a power cycle.
+    async function refreshServers() {
+        if (!deviceId || refreshing) return;
+
+        setRefreshing(true);
+        setRefreshNote('');
+
+        const before = servers.length;
+        const resp = await api.libraryRefreshServers(deviceId);
+
+        setRefreshing(false);
+
+        if (!resp?.success) {
+            setRefreshNote(resp?.error || 'Refresh failed');
+            return;
+        }
+
+        const found = resp.data?.servers || [];
+        setServers(found);
+
+        // Say what happened either way: a refresh that changes nothing looks
+        // identical to one that did not run.
+        if (found.length > before) {
+            setRefreshNote(`Found ${found.length} server${found.length === 1 ? '' : 's'}`);
+        } else if (found.length === 0) {
+            setRefreshNote('The speaker reports no media server. Use "Find servers" to add one again.');
+        } else {
+            setRefreshNote('No change');
+        }
     }
 
     async function discover() {
@@ -268,6 +305,17 @@ export function Library({
                     >
                         ${finding ? 'Hide' : 'Find servers'}
                     </button>
+                    <button
+                        class="btn-secondary"
+                        onClick=${refreshServers}
+                        disabled=${refreshing}
+                        title="Ask the speaker to re-read its media servers"
+                    >
+                        ${refreshing ? 'Refreshing…' : 'Refresh'}
+                    </button>
+                    ${refreshNote ? html`
+                        <span class="library-refresh-note tunein-item-desc">${refreshNote}</span>
+                    ` : null}
                     <span style="font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em;color:var(--text-dim);padding:.2rem .4rem;border:1px solid var(--border);border-radius:4px">
                         BETA
                     </span>

--- a/pkg/service/soundtouchweb/static/js/components/Library.js
+++ b/pkg/service/soundtouchweb/static/js/components/Library.js
@@ -1,5 +1,5 @@
 import { h } from 'preact';
-import { useState, useEffect } from 'preact/hooks';
+import { useState, useEffect, useRef } from 'preact/hooks';
 import htm from 'htm';
 import { api } from '../api.js';
 import { PresetPicker } from './PresetPicker.js';
@@ -21,6 +21,15 @@ export function Library({
     const [server, setServer] = useState(null);       // { udn, name, account }
     const [navStack, setNavStack] = useState([]);     // [{ label, location, type }]
     const [entries, setEntries] = useState([]);
+    // What the speaker says the open container holds, which is how we know a
+    // page is partial. It answers /navigate with totalItems regardless of how
+    // many items the page carries (measured: a 484-entry folder reports 484
+    // whether 200, 400 or all 484 come back).
+    const [totalItems, setTotalItems] = useState(0);
+    const [loadingMore, setLoadingMore] = useState(false);
+    // Fences a page against a browse that started after it: navigating away
+    // while a page is in flight must not append that page to the new folder.
+    const browseGeneration = useRef(0);
     const [loading, setLoading] = useState(false);
     const [finding, setFinding] = useState(false);
 
@@ -98,10 +107,52 @@ export function Library({
     }
 
     async function browseLevel(account, location, type) {
+        const generation = ++browseGeneration.current;
+
         setLoading(true);
+        setEntries([]);
+        setTotalItems(0);
+
         const resp = await api.libraryBrowse(deviceId, { account, location, type });
+
+        if (generation !== browseGeneration.current) return;
+
         setLoading(false);
-        if (resp.success) setEntries(resp.data?.entries || []);
+        if (!resp.success) return;
+
+        setEntries(resp.data?.entries || []);
+        setTotalItems(resp.data?.totalItems || 0);
+    }
+
+    // The speaker pages: a large folder comes back in slices, and the rest is
+    // only fetched when asked for. Before this, the first page was all anyone
+    // ever saw, so a 393-entry folder looked like it held 200 (issue 583).
+    async function loadMore() {
+        const generation = browseGeneration.current;
+        const frame = navStack[navStack.length - 1];
+
+        if (!server || !frame || loadingMore) return;
+
+        setLoadingMore(true);
+
+        const resp = await api.libraryBrowse(deviceId, {
+            account: server.account,
+            location: frame.location,
+            type: frame.type,
+            start: entries.length + 1,
+        });
+
+        if (generation !== browseGeneration.current) return;
+
+        setLoadingMore(false);
+        if (!resp.success) return;
+
+        const page = resp.data?.entries || [];
+
+        // A page that comes back empty would otherwise leave the button
+        // offering a next page forever, so trust the page over the count.
+        setTotalItems(page.length === 0 ? entries.length : (resp.data?.totalItems || 0));
+        setEntries(current => [...current, ...page]);
     }
 
     async function browseEntry(entry) {
@@ -285,6 +336,7 @@ export function Library({
                             </li>
                         `)}
                     </ul>
+
                 </div>
             ` : null}
 
@@ -338,6 +390,19 @@ export function Library({
                             </li>
                         `)}
                     </ul>
+
+                    ${entries.length > 0 && entries.length < totalItems ? html`
+                        <div class="library-more">
+                            <button
+                                class="btn-secondary"
+                                onClick=${loadMore}
+                                disabled=${loadingMore}
+                            >${loadingMore ? 'Loading…' : 'Load more'}</button>
+                            <span class="tunein-item-desc">
+                                ${entries.length} of ${totalItems}
+                            </span>
+                        </div>
+                    ` : null}
                 </div>
             ` : null}
 


### PR DESCRIPTION
Two library fixes, one branch, one commit each.

## Paging, [issue 583](https://github.com/gesellix/Bose-SoundTouch/issues/583)

A folder with more entries than one page carries showed only the first page, with nothing on screen to say there was more: 393 entries looked like 200.

The speaker was never the limit. Measured on a SoundTouch 10 against a 484-entry folder:

| request | totalItems | returned |
| --- | --- | --- |
| `start=1 num=200` | 484 | 200 |
| `start=1 num=400` | 484 | 400 |
| `start=1 num=1000` | 484 | 484 |
| `start=201 num=200` | 484 | 200 |
| `start=401 num=200` | 484 | 84 |

So `/navigate` pages correctly and reports the true total on every page. The truncation was ours: the browse handler defaulted to 200 items, and the Library view asked for one page and never asked for another, even though the handler already returned `totalItems` and the API helper already took `start` and `count`.

Now the view accumulates pages behind a "Load more" row that also shows progress ("3 of 7"), and the default page size is a named constant at 500, a likely candidate for a setting later.

Two failure modes are handled rather than assumed away: a browse that starts while a page is in flight fences that page out, so navigating away never appends the previous folder's items, and a page that comes back empty ends the listing instead of leaving the button offering more forever.

## Refresh, [issue 580](https://github.com/gesellix/Bose-SoundTouch/issues/580)

A registered media server sometimes disappears from one speaker's source list while other speakers still see it, and the only way back is a reboot. That it survives a reboot says the account is still there and only the speaker's live view was lost.

Registering a server already sends a `sourcesUpdated` notification, which is what makes a new server appear without a power cycle, but nothing ever sent it again. "Find servers" is discovery for adding something new, so there was no gesture meaning "re-check what I already have".

The Library toolbar gains **Refresh**, backed by `POST /api/control/devices/{id}/library/servers/refresh`: send the notification, wait for the speaker to act on it, then report what it now has. The outcome is stated (found, unchanged, or none at all with a pointer to "Find servers"), because a refresh that changes nothing otherwise looks identical to one that never ran.

**This one is a candidate fix, not a confirmed one.** The case is intermittent and does not reproduce on the hardware here. It is the same mechanism registration already relies on, it only reads plus the notification, and it gives the reporter something to try that is not a reboot. It also separates the two possible causes, which is the diagnostic the issue currently lacks: either the server reappears (the account was intact, the view was stale) or the speaker reports none (the account itself is gone).

## Tests

- Handler: the default and explicit page size reaching the speaker as `startItem`/`numItems`, `totalItems` reaching the client, refresh ordering (notify before read, since reading first returns the stale list), the empty-list case, and 404 for an unknown device.
- Browser: paging 3 → 6 → 7 of 7 with the button disappearing, then descending into a row to prove pages do not carry over, asserting the requested offsets were 1, 4, 7, 1; and the refresh button driven twice, empty then found.
- Route snapshots updated for the new endpoint.

`make check`, `make lint`, the node tests and the full browser suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)