### PR TITLE
docs: send the home page's Get Started button to the getting-started guide

### DIFF
--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -41,7 +41,7 @@ layout: hextra-home
   >}}
   {{< hextra/feature-card
     title="Stereo Pairing"
-    subtitle="SoundTouch 10 stereo pairing via soundtouch-cli, no Bose cloud required."
+    subtitle="SoundTouch 10 stereo pairing via soundtouch-player and soundtouch-cli, no Bose cloud required."
     icon="adjustments"
   >}}
   {{< hextra/feature-card

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -22,7 +22,7 @@ layout: hextra-home
 </div>
 
 <div class="hx-mb-6">
-{{< hextra/hero-button text="Get Started" link="docs/guides/MIGRATION-GUIDE" >}}
+{{< hextra/hero-button text="Get Started" link="docs/guides/GETTING-STARTED" >}}
 {{< hextra/hero-button text="Survival Guide" link="docs/guides/SURVIVAL-GUIDE" style="outline" >}}
 </div>
 
@@ -32,6 +32,7 @@ layout: hextra-home
     title="Presets Restored"
     subtitle="Preset buttons, long-press assignment, and recently-played sync — fully working."
     icon="star"
+    link="docs/guides/PRESETS"
   >}}
   {{< hextra/feature-card
     title="Music Browsing"

--- a/docs/content/docs/guides/SURVIVAL-GUIDE.md
+++ b/docs/content/docs/guides/SURVIVAL-GUIDE.md
@@ -19,7 +19,7 @@ What **continues to work** regardless:
 
 - **Presets** — full preset management including long-press assignment and recently-played sync; music service presets (Spotify, TuneIn, etc.) work once the service is linked (see [Connecting Music Services](MUSIC-SERVICES.md))
 - **Music browsing and playback** — TuneIn, Internet Radio, and RadioBrowser via `soundtouch-player`; direct station/URL playback via `soundtouch-cli`; Spotify via Spotify Connect (speaker-native) or AfterTouch's OAuth integration; Amazon Music OAuth infrastructure is in place but streaming is not yet verified
-- **Stereo pairing** — via `soundtouch-cli`
+- **Stereo pairing** — via `soundtouch-player` (a speaker's detail page) or `soundtouch-cli`
 
 Alexa voice commands are not currently supported.
 


### PR DESCRIPTION
Two small corrections on the docs home page, found while reading it after [PR #723](https://github.com/gesellix/Bose-SoundTouch/pull/723).

**The Get Started button pointed one step too far in.** It linked the migration guide, which assumes the service is already running somewhere: that is step 2 of 4. It predates the rewritten getting-started page, which is now the owner-facing route (run the service, migrate, check it, presets) and links onward to the migration guide from its own step 2.

**The Presets Restored card had no link.** It was the only card in the grid promising something with no way to act on it, and presets are the most common reason people arrive, so it now goes to the preset guide.

**Stereo pairing is not CLI-only.** The home page card and the survival guide both said pairing happens via `soundtouch-cli`. The player has had the stereo-pair lifecycle on a speaker's detail page since v0.130.0. Both now name the player first and the CLI as the scriptable route, each in the phrasing its own neighbours already use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)